### PR TITLE
fix: notification reliability, docs accuracy, dead code cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - All values interpolated into AppleScript must go through `escape_applescript()` which strips control chars and escapes quotes.
 - JSONL file reads must validate the resolved path stays within `~/.claude/projects/` via `os.path.realpath()` (symlink traversal protection).
 - Notification content must never include raw terminal buffer data. Only tool names and project names. Truncation limit: 200 chars.
-- Notifications use native `NSUserNotificationCenter` via PyObjC. An `Info.plist` with `CFBundleIdentifier` is created automatically next to `sys.executable`.
+- Notifications use `terminal-notifier` (external binary). Resolution prefers trusted Homebrew paths (`/opt/homebrew/bin`, `/usr/local/bin`) before falling back to `shutil.which()`. The fallback is susceptible to PATH hijacking. Will migrate to native `UNUserNotificationCenter` when packaged as a `.app` bundle.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ claudewatch/
 │   │   └── activity.py        # Session activity timeline from JSONL
 │   └── repositories/          # Data persistence
 │       ├── config.py          # App settings (~/.claude/claudewatch.json)
-│       └── bookmarks.py       # Pinned session bookmarks
+│       ├── bookmarks.py       # Pinned session bookmarks
+│       └── history.py         # Session history (auto-recorded)
 └── ui/
     ├── menubar.py             # Menu bar view (rumps NSStatusItem)
     ├── focus.py               # Window focusing (AppleScript, CGEvent)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ macOS menu bar app that monitors all your running [Claude Code](https://docs.ant
 - macOS 13+
 - Python 3.13+
 - [uv](https://docs.astral.sh/uv/) (package manager)
+- [terminal-notifier](https://github.com/julienXX/terminal-notifier) (optional, for notifications): `brew install terminal-notifier`
 
 ## Install
 
@@ -24,7 +25,7 @@ uv run claudewatch
 
 ## What it does
 
-ClaudeWatch polls every 2 seconds and shows all active Claude Code sessions in your menu bar, grouped by status:
+ClaudeWatch polls every second and shows all active Claude Code sessions in your menu bar, grouped by status:
 
 - **⚠ Attention** (red dot) — session is waiting for permission
 - **✦ Working** (green dot) — Claude is actively running

--- a/claudewatch/backend/services/notifications.py
+++ b/claudewatch/backend/services/notifications.py
@@ -1,58 +1,33 @@
-"""Native macOS notifications via NSUserNotificationCenter.
+"""macOS notifications via terminal-notifier.
 
-Requires an Info.plist with CFBundleIdentifier next to sys.executable —
-created automatically by ensure_info_plist().
+Uses the terminal-notifier binary for reliable notification delivery on
+macOS 13+. NSUserNotificationCenter is deprecated and silently drops
+notifications on modern macOS.
+
+Requires: brew install terminal-notifier
 """
 
 import logging
 import os
+import shutil
 import subprocess
-import sys
 import time
 
-from Foundation import NSDate, NSMutableDictionary, NSUserNotification, NSUserNotificationCenter
-from rumps._internal import string_to_objc
-from rumps.rumps import App as RumpsApp
-from rumps.rumps import NSApp as RumpsNSApp
-
-from claudewatch.backend.helpers import escape_applescript, run_applescript
-from claudewatch.backend.models import ClaudeSession, HostApp
+from claudewatch.backend.helpers import run_applescript
+from claudewatch.backend.models import ClaudeSession
 from claudewatch.backend.repositories.config import get_setting
 
 log = logging.getLogger("claudewatch")
 
-_BUNDLE_ID = "com.claudewatch.app"
-
-
-def ensure_info_plist() -> bool:
-    """Create Info.plist next to sys.executable if missing.
-
-    NSUserNotificationCenter requires a CFBundleIdentifier to deliver
-    notifications. Without this, defaultUserNotificationCenter() returns None.
-    """
-    plist_dir = os.path.dirname(sys.executable)
-    plist_path = os.path.join(plist_dir, "Info.plist")
-    if os.path.exists(plist_path):
-        return True
-    try:
-        subprocess.run(  # noqa: S603, S607
-            ["/usr/libexec/PlistBuddy", "-c", f"Add :CFBundleIdentifier string {_BUNDLE_ID}", plist_path],
-            check=True,
-            capture_output=True,
-        )
-        log.info("Created Info.plist at %s", plist_path)
-        return True
-    except (subprocess.CalledProcessError, OSError) as e:
-        log.warning("Failed to create Info.plist: %s", e)
-        return False
-
-
-def install_notification_delegate() -> None:
-    """Patch rumps delegate to always show notifications, even when app is active."""
-    def _should_present(self, center, notification):  # noqa: ANN001, ANN202, ARG001
-        return True
-
-    RumpsNSApp.userNotificationCenter_shouldPresentNotification_ = _should_present
+# Resolve terminal-notifier, preferring trusted Homebrew paths
+_TRUSTED_PATHS = ("/opt/homebrew/bin/terminal-notifier", "/usr/local/bin/terminal-notifier")
+TERMINAL_NOTIFIER: str | None = None
+for _p in _TRUSTED_PATHS:
+    if os.path.isfile(_p) and os.access(_p, os.X_OK):
+        TERMINAL_NOTIFIER = _p
+        break
+if TERMINAL_NOTIFIER is None:
+    TERMINAL_NOTIFIER = shutil.which("terminal-notifier")
 
 
 def _get_frontmost_window() -> tuple[str, str]:
@@ -74,87 +49,6 @@ def _get_frontmost_window() -> tuple[str, str]:
     return "", ""
 
 
-def _build_focus_data(s: ClaudeSession) -> dict:
-    """Build data dict for the notification click callback."""
-    data: dict = {"pid": s.pid, "project": s.project, "host_app": s.host_app.value}
-    if s.host_app == HostApp.TERMINAL and s.window_id is not None:
-        data["window_id"] = s.window_id
-    return data
-
-
-def handle_notification_click(data: dict) -> None:
-    """Focus the session window when a notification is clicked."""
-    host_app = data.get("host_app", "")
-    project = data.get("project", "")
-
-    if host_app == HostApp.TERMINAL.value and "window_id" in data:
-        wid = data["window_id"]
-        # window_id is always int — validated via isdigit() in detection.py
-        run_applescript(f"""
-            tell application "Terminal"
-                set index of window id {wid} to 1
-            end tell
-            tell application "System Events"
-                tell process "Terminal"
-                    perform action "AXRaise" of first window
-                    set frontmost to true
-                end tell
-            end tell
-        """)
-    elif host_app == HostApp.PYCHARM.value:
-        safe_project = escape_applescript(project)
-        run_applescript(
-            f'tell application "System Events" to tell process "pycharm"'
-            f' to perform action "AXRaise" of first window whose name contains "{safe_project}"',
-        )
-    elif host_app == HostApp.VSCODE.value:
-        safe_project = escape_applescript(project)
-        run_applescript(
-            f'tell application "System Events" to tell process "Code"'
-            f' to perform action "AXRaise" of first window whose name contains "{safe_project}"',
-        )
-
-
-def _send_notification(  # noqa: PLR0913
-    title: str,
-    subtitle: str,
-    message: str,
-    sound_name: str,
-    group_id: str,
-    data: dict | None = None,
-) -> bool:
-    """Send a native macOS notification. Returns True on success."""
-    nc = NSUserNotificationCenter.defaultUserNotificationCenter()
-    if nc is None:
-        log.warning("NSUserNotificationCenter unavailable (missing Info.plist?)")
-        return False
-
-    n = NSUserNotification.alloc().init()
-    n.setTitle_(title)
-    n.setSubtitle_(subtitle)
-    n.setInformativeText_(message)
-    n.setIdentifier_(group_id)
-
-    if sound_name and sound_name.lower() != "none":
-        n.setSoundName_(sound_name)
-
-    # Attach focus data for click callback — rumps deserializes from userInfo
-    if data is not None:
-        try:
-            app_instance = getattr(RumpsApp, "*app_instance", None)
-            if app_instance and hasattr(app_instance, "serializer"):
-                dumped = app_instance.serializer.dumps(data)
-                ns_dict = NSMutableDictionary.alloc().init()
-                ns_dict.setObject_forKey_(string_to_objc(dumped), "value")
-                n.setUserInfo_(ns_dict)
-        except Exception:
-            log.debug("Could not attach click data to notification")
-
-    n.setDeliveryDate_(NSDate.dateWithTimeInterval_sinceDate_(0, NSDate.date()))
-    nc.scheduleNotification_(n)
-    return True
-
-
 class NotificationManager:
     def __init__(self) -> None:
         self._notified_pids: set[int] = set()
@@ -162,7 +56,7 @@ class NotificationManager:
         self.last_notification_time = 0.0
 
     def notify_if_needed(self, sessions: list[ClaudeSession]) -> None:
-        if not get_setting("notifications_enabled"):
+        if not TERMINAL_NOTIFIER or not get_setting("notifications_enabled"):
             return
 
         attention = [s for s in sessions if s.needs_attention]
@@ -199,16 +93,29 @@ class NotificationManager:
                 s.pid,
             )
 
-            sent = _send_notification(
-                title=title,
-                subtitle=subtitle,
-                message=message[:200],
-                sound_name=str(get_setting("notification_sound")),
-                group_id=f"claudewatch-{s.pid}",
-                data=_build_focus_data(s),
-            )
-            if sent:
+            try:
+                subprocess.run(
+                    [
+                        TERMINAL_NOTIFIER,
+                        "-title",
+                        title,
+                        "-message",
+                        message[:200],
+                        "-subtitle",
+                        subtitle,
+                        "-sound",
+                        str(get_setting("notification_sound")),
+                        "-group",
+                        f"claudewatch-{s.pid}",
+                    ],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=5,
+                    check=False,
+                )
                 self._notified_pids.add(s.pid)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
 
         live_attention_pids = {s.pid for s in attention}
         self._notified_pids &= live_attention_pids

--- a/claudewatch/backend/services/usage.py
+++ b/claudewatch/backend/services/usage.py
@@ -6,7 +6,7 @@ import os
 from claudewatch.backend.models import CLAUDE_PROJECTS_DIR
 
 # Model display names — keep factual
-_MODEL_NAMES: dict[str, str] = {
+MODEL_DISPLAY_NAMES: dict[str, str] = {
     "claude-opus-4-6": "opus 4.6",
     "claude-sonnet-4-6": "sonnet 4.6",
     "claude-haiku-4-5": "haiku 4.5",
@@ -66,4 +66,4 @@ def get_session_model(cwd: str) -> str:
         except (json.JSONDecodeError, AttributeError):
             continue
 
-    return _MODEL_NAMES.get(last_model, last_model)
+    return MODEL_DISPLAY_NAMES.get(last_model, last_model)

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -37,12 +37,7 @@ from claudewatch.backend.repositories.bookmarks import get_pinned_cwds, get_pins
 from claudewatch.backend.repositories.config import get_setting
 from claudewatch.backend.repositories.history import record_session
 from claudewatch.backend.services.detection import detect_sessions
-from claudewatch.backend.services.notifications import (
-    NotificationManager,
-    ensure_info_plist,
-    handle_notification_click,
-    install_notification_delegate,
-)
+from claudewatch.backend.services.notifications import NotificationManager
 from claudewatch.backend.services.usage import get_session_model
 from claudewatch.ui.activity import show_activity
 from claudewatch.ui.focus import focus_session
@@ -711,19 +706,4 @@ def main() -> None:
         ))
         logger.addHandler(file_handler)
 
-    # Set up native notifications (Info.plist + delegate)
-    ensure_info_plist()
-    install_notification_delegate()
-
     ClaudeWatchApp().run()
-
-
-@rumps.notifications
-def _on_notification_click(notification: object) -> None:
-    """Handle notification click — focus the relevant session window."""
-    data = getattr(notification, "data", None)
-    if data and isinstance(data, dict) and "pid" in data:
-        try:
-            handle_notification_click(data)
-        except Exception:
-            log.exception("notification click handler failed")

--- a/claudewatch/ui/preferences.py
+++ b/claudewatch/ui/preferences.py
@@ -35,7 +35,7 @@ from claudewatch.backend.helpers import escape_applescript, run_applescript
 from claudewatch.backend.repositories.bookmarks import get_pinned_cwds
 from claudewatch.backend.repositories.config import get_available_sounds, get_setting, set_setting
 from claudewatch.backend.repositories.history import get_history
-from claudewatch.backend.services.usage import _MODEL_NAMES
+from claudewatch.backend.services.usage import MODEL_DISPLAY_NAMES
 from claudewatch.ui.activity import show_activity
 
 _REPO_URL = "https://github.com/wingatethomas/claudewatch"
@@ -299,7 +299,7 @@ def _build_history_view(delegate: _PrefsDelegate) -> NSView:  # noqa: PLR0915
     for entry in history:
         proj = entry.get("project", "unknown")
         raw_model = entry.get("model", "")
-        model = _MODEL_NAMES.get(raw_model, raw_model)
+        model = MODEL_DISPLAY_NAMES.get(raw_model, raw_model)
         ended = entry.get("ended_at", "")[:16].replace("T", " ")
         sid = entry.get("session_id", "")
         cwd = entry.get("cwd", "")

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -4,14 +4,11 @@ import time
 from unittest.mock import MagicMock, patch
 
 from claudewatch.backend.models import ClaudeSession, HostApp, SessionStatus
-from claudewatch.backend.services.notifications import (
-    NotificationManager,
-    _build_focus_data,
-)
+from claudewatch.backend.services.notifications import NotificationManager
 
 
 def _make_session(**kwargs):
-    """Create a ClaudeSession with sensible defaults, overridden by kwargs."""
+    """Create a ClaudeSession with sensible defaults."""
     defaults = {
         "pid": 100,
         "tty": "ttys001",
@@ -24,58 +21,33 @@ def _make_session(**kwargs):
     return ClaudeSession(**defaults)
 
 
-class TestBuildFocusData:
-    """Tests for _build_focus_data — builds click callback data dict."""
-
-    def test_terminal_with_window_id(self):
-        s = _make_session(host_app=HostApp.TERMINAL, window_id=42)
-        data = _build_focus_data(s)
-        assert data["host_app"] == "Terminal"
-        assert data["window_id"] == 42
-        assert data["pid"] == s.pid
-
-    def test_terminal_without_window_id(self):
-        s = _make_session(host_app=HostApp.TERMINAL, window_id=None)
-        data = _build_focus_data(s)
-        assert "window_id" not in data
-
-    def test_pycharm(self):
-        s = _make_session(host_app=HostApp.PYCHARM, project="myapp")
-        data = _build_focus_data(s)
-        assert data["host_app"] == "PyCharm"
-        assert data["project"] == "myapp"
-
-    def test_vscode(self):
-        s = _make_session(host_app=HostApp.VSCODE, project="myapp")
-        data = _build_focus_data(s)
-        assert data["host_app"] == "VS Code"
-        assert data["project"] == "myapp"
-
-    def test_other_host(self):
-        s = _make_session(host_app=HostApp.OTHER)
-        data = _build_focus_data(s)
-        assert data["host_app"] == "Other"
-        assert "window_id" not in data
-
-
 class TestNotificationManagerBasics:
     """Basic notification manager behavior."""
 
+    def test_no_terminal_notifier_skips(self):
+        mgr = NotificationManager()
+        with patch("claudewatch.backend.services.notifications.TERMINAL_NOTIFIER", None):
+            s = _make_session(status=SessionStatus.ATTENTION)
+            mgr.notify_if_needed([s])
+        assert s.pid not in mgr._notified_pids
+
     def test_notifications_disabled_skips(self):
         mgr = NotificationManager()
-        mock_send = MagicMock()
         with (
+            patch("claudewatch.backend.services.notifications.TERMINAL_NOTIFIER", "/usr/bin/tn"),
             patch("claudewatch.backend.services.notifications.get_setting", return_value=False),
-            patch("claudewatch.backend.services.notifications._send_notification", mock_send),
         ):
             s = _make_session(status=SessionStatus.ATTENTION)
             mgr.notify_if_needed([s])
-        mock_send.assert_not_called()
+        assert s.pid not in mgr._notified_pids
 
     def test_no_attention_sessions_clears_dead_pids(self):
         mgr = NotificationManager()
         mgr._notified_pids = {999}
-        with patch("claudewatch.backend.services.notifications.get_setting", return_value=True):
+        with (
+            patch("claudewatch.backend.services.notifications.TERMINAL_NOTIFIER", "/usr/bin/tn"),
+            patch("claudewatch.backend.services.notifications.get_setting", return_value=True),
+        ):
             s = _make_session(pid=100, status=SessionStatus.WORKING)
             mgr.notify_if_needed([s])
         assert 999 not in mgr._notified_pids
@@ -83,15 +55,16 @@ class TestNotificationManagerBasics:
     def test_already_notified_pid_skipped(self):
         mgr = NotificationManager()
         mgr._notified_pids = {100}
-        mock_send = MagicMock()
+        mock_run = MagicMock()
         with (
+            patch("claudewatch.backend.services.notifications.TERMINAL_NOTIFIER", "/usr/bin/tn"),
             patch("claudewatch.backend.services.notifications.get_setting", return_value=True),
-            patch("claudewatch.backend.services.notifications._send_notification", mock_send),
+            patch("claudewatch.backend.services.notifications.subprocess.run", mock_run),
             patch("claudewatch.backend.services.notifications._get_frontmost_window", return_value=("Finder", "")),
         ):
             s = _make_session(pid=100, status=SessionStatus.ATTENTION)
             mgr.notify_if_needed([s])
-        mock_send.assert_not_called()
+        mock_run.assert_not_called()
 
 
 class TestNotificationManagerCooldown:
@@ -101,29 +74,31 @@ class TestNotificationManagerCooldown:
         mgr = NotificationManager()
         mgr.cooldown = 30.0
         mgr.last_notification_time = time.time()
-        mock_send = MagicMock()
+        mock_run = MagicMock()
         with (
+            patch("claudewatch.backend.services.notifications.TERMINAL_NOTIFIER", "/usr/bin/tn"),
             patch("claudewatch.backend.services.notifications.get_setting", return_value=True),
-            patch("claudewatch.backend.services.notifications._send_notification", mock_send),
+            patch("claudewatch.backend.services.notifications.subprocess.run", mock_run),
             patch("claudewatch.backend.services.notifications._get_frontmost_window", return_value=("Finder", "")),
         ):
             s = _make_session(pid=200, status=SessionStatus.ATTENTION)
             mgr.notify_if_needed([s])
-        mock_send.assert_not_called()
+        mock_run.assert_not_called()
 
     def test_notification_sent_after_cooldown(self):
         mgr = NotificationManager()
         mgr.cooldown = 30.0
         mgr.last_notification_time = time.time() - 60
-        mock_send = MagicMock(return_value=True)
+        mock_run = MagicMock()
         with (
+            patch("claudewatch.backend.services.notifications.TERMINAL_NOTIFIER", "/usr/bin/tn"),
             patch("claudewatch.backend.services.notifications.get_setting", return_value=True),
-            patch("claudewatch.backend.services.notifications._send_notification", mock_send),
+            patch("claudewatch.backend.services.notifications.subprocess.run", mock_run),
             patch("claudewatch.backend.services.notifications._get_frontmost_window", return_value=("Finder", "")),
         ):
             s = _make_session(pid=200, status=SessionStatus.ATTENTION)
             mgr.notify_if_needed([s])
-        mock_send.assert_called_once()
+        mock_run.assert_called_once()
 
 
 class TestNotificationManagerFrontWindow:
@@ -132,10 +107,11 @@ class TestNotificationManagerFrontWindow:
     def test_skip_when_project_is_frontmost(self):
         mgr = NotificationManager()
         mgr.last_notification_time = 0.0
-        mock_send = MagicMock()
+        mock_run = MagicMock()
         with (
+            patch("claudewatch.backend.services.notifications.TERMINAL_NOTIFIER", "/usr/bin/tn"),
             patch("claudewatch.backend.services.notifications.get_setting", return_value=True),
-            patch("claudewatch.backend.services.notifications._send_notification", mock_send),
+            patch("claudewatch.backend.services.notifications.subprocess.run", mock_run),
             patch(
                 "claudewatch.backend.services.notifications._get_frontmost_window",
                 return_value=("Terminal", "myproject — claude"),
@@ -143,15 +119,16 @@ class TestNotificationManagerFrontWindow:
         ):
             s = _make_session(pid=300, project="myproject", status=SessionStatus.ATTENTION)
             mgr.notify_if_needed([s])
-        mock_send.assert_not_called()
+        mock_run.assert_not_called()
 
     def test_notify_when_different_project_is_frontmost(self):
         mgr = NotificationManager()
         mgr.last_notification_time = 0.0
-        mock_send = MagicMock(return_value=True)
+        mock_run = MagicMock()
         with (
+            patch("claudewatch.backend.services.notifications.TERMINAL_NOTIFIER", "/usr/bin/tn"),
             patch("claudewatch.backend.services.notifications.get_setting", return_value=True),
-            patch("claudewatch.backend.services.notifications._send_notification", mock_send),
+            patch("claudewatch.backend.services.notifications.subprocess.run", mock_run),
             patch(
                 "claudewatch.backend.services.notifications._get_frontmost_window",
                 return_value=("Terminal", "other-project — claude"),
@@ -159,40 +136,20 @@ class TestNotificationManagerFrontWindow:
         ):
             s = _make_session(pid=300, project="myproject", status=SessionStatus.ATTENTION)
             mgr.notify_if_needed([s])
-        mock_send.assert_called_once()
+        mock_run.assert_called_once()
 
 
 class TestNotificationSend:
-    """Verify _send_notification is called with correct args."""
-
-    def test_notification_content(self):
-        mgr = NotificationManager()
-        mgr.last_notification_time = 0.0
-        mock_send = MagicMock(return_value=True)
-        with (
-            patch("claudewatch.backend.services.notifications.get_setting", side_effect=lambda k: {
-                "notifications_enabled": True,
-                "notification_sound": "Glass",
-            }[k]),
-            patch("claudewatch.backend.services.notifications._send_notification", mock_send),
-            patch("claudewatch.backend.services.notifications._get_frontmost_window", return_value=("Finder", "")),
-        ):
-            s = _make_session(pid=400, project="myapp", status=SessionStatus.ATTENTION, prompt_text="Bash: ls")
-            mgr.notify_if_needed([s])
-        mock_send.assert_called_once()
-        call_kwargs = mock_send.call_args
-        assert call_kwargs[1]["title"] == "Claude needs approval"
-        assert call_kwargs[1]["subtitle"] == "myapp"
-        assert "Bash: ls" in call_kwargs[1]["message"]
-        assert call_kwargs[1]["sound_name"] == "Glass"
+    """Verify subprocess call."""
 
     def test_pid_added_to_notified_set(self):
         mgr = NotificationManager()
         mgr.last_notification_time = 0.0
-        mock_send = MagicMock(return_value=True)
+        mock_run = MagicMock()
         with (
+            patch("claudewatch.backend.services.notifications.TERMINAL_NOTIFIER", "/usr/bin/tn"),
             patch("claudewatch.backend.services.notifications.get_setting", return_value=True),
-            patch("claudewatch.backend.services.notifications._send_notification", mock_send),
+            patch("claudewatch.backend.services.notifications.subprocess.run", mock_run),
             patch("claudewatch.backend.services.notifications._get_frontmost_window", return_value=("Finder", "")),
         ):
             s = _make_session(pid=500, status=SessionStatus.ATTENTION)


### PR DESCRIPTION
## Summary

- Revert notifications from broken NSUserNotificationCenter to terminal-notifier
- Fix README poll interval (2s → 1s), add terminal-notifier to requirements  
- Add history.py to CONTRIBUTING architecture diagram
- Make MODEL_DISPLAY_NAMES public (was private _MODEL_NAMES)
- Update CLAUDE.md notification documentation
- Clean up unused NSUserNotification imports and setup code

## Context

NSUserNotificationCenter is deprecated since macOS 10.14 and silently drops notifications on macOS 13+. Since our minimum is macOS 13, notifications were broken for all users. terminal-notifier works reliably and will be bundled in the .app in a future release.