### PR TITLE
fix: CI pipeline — lint on ubuntu, release signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - run: uv sync --only-group dev
-      - run: uv run ruff check .
-      - run: uv run ruff format --check .
+      - run: uv pip install ruff --system
+      - run: ruff check .
+      - run: ruff format --check .
 
   test:
-    runs-on: macos-14  # ARM64 — matches target platform, has PyObjC support
+    runs-on: macos-14  # ARM64 — PyObjC requires macOS
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,14 @@ jobs:
 
       - name: Build .app bundle
         run: |
-          uv run briefcase create macOS || true
-          uv run briefcase build macOS
-          uv run briefcase package macOS --no-sign
+          uv run briefcase create macOS --no-input || true
+          uv run briefcase build macOS --no-input
+          uv run briefcase package macOS --adhoc-sign --no-input
 
       - name: Zip the app
         run: |
-          cd macOS/ClaudeWatch
-          zip -r ../../ClaudeWatch-${{ github.ref_name }}-arm64.zip ClaudeWatch.app
+          cd build/claudewatch/macos/app
+          zip -r ../../../../ClaudeWatch-${{ github.ref_name }}-arm64.zip ClaudeWatch.app
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- Lint job installs ruff directly via `uv pip install ruff --system` — avoids PyObjC build failure on Linux
- Release workflow adds `--no-input` and `--adhoc-sign` flags for non-interactive Briefcase in CI
- Fixed Briefcase output path (`build/` not `macOS/`)

## Context

CI was failing because:
1. Lint job on ubuntu tried to install PyObjC (macOS-only) via `uv sync --only-group dev`
2. Briefcase `package` command prompted for signing identity interactively