### PR TITLE
fix: menu shows Preferences/Help/Quit with no active sessions

### DIFF
--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -226,7 +226,7 @@ class ClaudeWatchApp(rumps.App):
     def __init__(self) -> None:
         super().__init__("ClaudeWatch", quit_button=None)
         self.sessions: list[ClaudeSession] = []
-        self._last_menu_key = ""
+        self._last_menu_key = "__uninitialized__"
         self._consecutive_errors = 0
         self.icon = None
         self.notifications = NotificationManager()


### PR DESCRIPTION
Menu footer items (Preferences, Help, Quit) were inaccessible when no Claude sessions were running. The menu key sentinel now ensures the first render always builds the complete menu.