### PR TITLE
fix: detect VS Code extension and PyCharm plugin sessions

### DIFF
--- a/claudewatch/backend/services/detection.py
+++ b/claudewatch/backend/services/detection.py
@@ -454,15 +454,17 @@ def detect_sessions() -> list[ClaudeSession]:  # noqa: PLR0912, PLR0915
                     tty = parent["tty"]
                     break
                 walk_pid = parent["ppid"]
-        if not tty or tty == "??":
-            continue
-
         cwd = cwds.get(pid, "")
         project = os.path.basename(cwd) if cwd else ""
         if not project:
             continue
 
         host_app = _detect_host_app(pid, all_ps)
+
+        # Allow TTY-less sessions for IDE host apps (VS Code extension, PyCharm plugin).
+        # These spawn Claude as a direct subprocess without a terminal emulator.
+        if (not tty or tty == "??") and host_app not in (HostApp.VSCODE, HostApp.PYCHARM):
+            continue
         window_title = host_app.value
         window_id = None
 


### PR DESCRIPTION
## Summary

IDE extensions spawn Claude as a direct subprocess without a terminal emulator. The entire PPID chain has no TTY (`??`). Previously skipped by the TTY filter.

**Fix:** Detect host app before the TTY check. Allow TTY-less sessions when host app is VS Code or PyCharm.

## Root Cause

```
Terminal Claude:  claude (ttys001) → zsh → login → Terminal.app  ✓
VS Code ext:     claude (??) → Code Helper (Plugin) (??) → Code (??)  ✗ was skipped
```

Everything else works for these sessions — pgrep finds them, CWD works, host detection works, JSONL attention detection works. Only the TTY filter blocked them.