### PR TITLE
fix: richer pin summaries and larger text field

### DIFF
--- a/claudewatch/backend/services/summarize.py
+++ b/claudewatch/backend/services/summarize.py
@@ -12,10 +12,13 @@ log = logging.getLogger("claudewatch")
 _MAX_CONTEXT_CHARS = 8000
 _TIMEOUT_SECONDS = 15
 _PROMPT = (
-    "Summarize this Claude Code conversation in 1-2 concise sentences. "
-    "Focus on what the user was trying to accomplish and the current state. "
+    "Summarize this Claude Code conversation in 3-4 sentences. "
+    "Cover: what the user was trying to accomplish, what was done, key files or areas touched, "
+    "and the current state (e.g. merged, in progress, blocked). "
     "Do not use markdown. Do not start with 'The user' or 'This conversation'. "
-    "Example: 'Debugging auth middleware — fixed session token storage, added tests, PR ready for review.'\n\n"
+    "Example: 'Debugging auth middleware after session tokens were stored incorrectly. "
+    "Fixed token validation in auth.py, added integration tests, updated the migration. "
+    "PR #42 is merged to main.'\n\n"
 )
 
 

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -567,9 +567,11 @@ class ClaudeWatchApp(rumps.App):
                 alert.setInformativeText_(f"Add a note for {project}:")
                 alert.addButtonWithTitle_("Pin")
                 alert.addButtonWithTitle_("Cancel")
-                text_field = NSTextField.alloc().initWithFrame_(((0, 0), (300, 24)))
+                text_field = NSTextField.alloc().initWithFrame_(((0, 0), (350, 60)))
                 text_field.setStringValue_("")
                 text_field.setPlaceholderString_("Generating summary…")
+                text_field.setLineBreakMode_(0)  # NSLineBreakByWordWrapping
+                text_field.setUsesSingleLineMode_(False)
                 alert.setAccessoryView_(text_field)
                 alert.window().setInitialFirstResponder_(text_field)
 


### PR DESCRIPTION
## Summary
- Prompt asks for 3-4 sentences (was 1-2) covering goal, work done, key files, current state
- Pin dialog text field: 350x60 multi-line (was 300x24 single-line)