### PR TITLE
chore: housekeeping — version bump, rules update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,11 @@
 - **helpers.py** — shared AppleScript runner, escaping, shell utilities.
 - **models.py** — data structures, enums, and path mapping (`cwd_to_proj_key()` / `proj_key_to_cwd()`).
 - **jsonl.py** — all JSONL discovery, symlink validation, and reading. Never do inline JSONL file discovery — use `find_most_recent_jsonl()`, `read_jsonl_tail()`, `is_safe_jsonl_path()`.
-- **summarize.py** — conversation summaries via `claude -p`. Subprocess calls must use list args, never `shell=True`.
+- **summarize.py** — conversation summaries via `claude -p`. Subprocess calls must use `Popen` with PID tracking (never `shell=True`). Summaries persist to `~/.claude/claudewatch-summaries.json`. Background thread refreshes every 60s. Max 1 concurrent `claude -p`. Own PIDs tracked in `_our_pids` set and filtered from detection.
+- **onboarding.py** — feature discovery tips via terminal-notifier. Tracks shown tips and session count in config. One tip per poll cycle.
 - `detect_sessions()` runs on a background thread. Results are collected on the main thread via `Future.result()`. All `self.sessions` access happens on the main thread.
 - Set `_modal_active = True` during any modal dialog to pause polling. Reset in `finally`.
+- Never generate summaries or do I/O during menu build — only read from caches. Background threads handle generation.
 
 ## Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claudewatch"
-version = "0.3.0"
+version = "0.4.0"
 description = "macOS menu bar app for monitoring Claude Code sessions"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -36,7 +36,7 @@ packages = ["claudewatch"]
 [tool.briefcase]
 project_name = "ClaudeWatch"
 bundle = "com.claudewatch"
-version = "0.3.0"
+version = "0.4.0"
 url = "https://github.com/wingatethomas/claudewatch"
 license.file = "LICENSE"
 author = "ClaudeWatch Contributors"


### PR DESCRIPTION
Version 0.4.0, CLAUDE.md updated with onboarding/summarize rules, closed stale issue #6, pruned 17 branches.