### PR TITLE
feat: usage stats in menu bar from Claude's stats-cache

### DIFF
--- a/claudewatch/backend/services/usage_stats.py
+++ b/claudewatch/backend/services/usage_stats.py
@@ -1,0 +1,71 @@
+"""Read Claude Code usage statistics from ~/.claude/stats-cache.json."""
+
+import json
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+
+log = logging.getLogger("claudewatch")
+
+_STATS_PATH = os.path.expanduser("~/.claude/stats-cache.json")
+
+
+def _load_daily_activity() -> list[dict]:
+    """Load daily activity entries from the stats cache."""
+    try:
+        with open(_STATS_PATH) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    activity = data.get("dailyActivity", [])
+    return activity if isinstance(activity, list) else []
+
+
+def _sum_range(days: list[dict], start: str, end: str) -> dict[str, int]:
+    """Sum messageCount, sessionCount, toolCallCount for dates in [start, end]."""
+    messages = 0
+    sessions = 0
+    tools = 0
+    for day in days:
+        date = day.get("date", "")
+        if start <= date <= end:
+            messages += day.get("messageCount", 0)
+            sessions += day.get("sessionCount", 0)
+            tools += day.get("toolCallCount", 0)
+    return {"messages": messages, "sessions": sessions, "tools": tools}
+
+
+def get_today_stats() -> dict[str, int]:
+    """Get today's usage stats."""
+    today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    return _sum_range(_load_daily_activity(), today, today)
+
+
+def get_week_stats() -> dict[str, int]:
+    """Get this week's usage stats (last 7 days)."""
+    now = datetime.now(tz=UTC)
+    start = (now - timedelta(days=6)).strftime("%Y-%m-%d")
+    end = now.strftime("%Y-%m-%d")
+    return _sum_range(_load_daily_activity(), start, end)
+
+
+def get_month_stats() -> dict[str, int]:
+    """Get this month's usage stats (last 30 days)."""
+    now = datetime.now(tz=UTC)
+    start = (now - timedelta(days=29)).strftime("%Y-%m-%d")
+    end = now.strftime("%Y-%m-%d")
+    return _sum_range(_load_daily_activity(), start, end)
+
+
+def format_stats_line(stats: dict[str, int]) -> str:
+    """Format stats as a compact one-line string."""
+    parts = []
+    if stats["messages"]:
+        parts.append(f"{stats['messages']:,} msgs")
+    if stats["sessions"]:
+        parts.append(f"{stats['sessions']} sessions")
+    if stats["tools"]:
+        parts.append(f"{stats['tools']:,} tools")
+    return " · ".join(parts) if parts else "No activity"

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -56,6 +56,7 @@ from claudewatch.backend.services.summarize import (
     track_session,
 )
 from claudewatch.backend.services.usage import MODEL_DISPLAY_NAMES, get_session_model
+from claudewatch.backend.services.usage_stats import format_stats_line, get_month_stats, get_today_stats, get_week_stats
 from claudewatch.ui.activity import show_activity
 from claudewatch.ui.focus import focus_session
 from claudewatch.ui.preferences import show_preferences
@@ -431,9 +432,15 @@ class ClaudeWatchApp(rumps.App):
 
         self.menu.clear()
 
-        # App title
+        # App title + today's usage
         app_title = rumps.MenuItem("ClaudeWatch", callback=None)
         self.menu.add(app_title)
+        today = get_today_stats()
+        today_line = format_stats_line(today)
+        if today["messages"]:
+            today_item = rumps.MenuItem(f"  Today: {today_line}")
+            today_item.set_callback(None)
+            self.menu.add(today_item)
         self.menu.add(rumps.separator)
 
         # Show accessibility warning if needed
@@ -601,6 +608,22 @@ class ClaudeWatchApp(rumps.App):
                 recent_menu.add(item)
                 track_session(cwd)  # background thread will generate summary
             self.menu.add(recent_menu)
+
+        # Usage stats submenu
+        week = get_week_stats()
+        month = get_month_stats()
+        if week["messages"] or month["messages"]:
+            self.menu.add(rumps.separator)
+            usage_menu = rumps.MenuItem("📊 Usage")
+            for label, stats in (("This week", week), ("Last 30 days", month)):
+                line = format_stats_line(stats)
+                header = rumps.MenuItem(f"  {label}")
+                header.set_callback(None)
+                usage_menu.add(header)
+                detail = rumps.MenuItem(f"    {line}")
+                detail.set_callback(None)
+                usage_menu.add(detail)
+            self.menu.add(usage_menu)
 
         self.menu.add(rumps.separator)
         self.menu.add(rumps.MenuItem("Preferences...", callback=self._open_preferences))

--- a/tests/test_usage_stats.py
+++ b/tests/test_usage_stats.py
@@ -1,0 +1,102 @@
+"""Tests for claudewatch.backend.services.usage_stats."""
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from claudewatch.backend.services.usage_stats import (
+    _sum_range,
+    format_stats_line,
+    get_month_stats,
+    get_today_stats,
+    get_week_stats,
+)
+
+
+class TestSumRange:
+    def test_sums_matching_dates(self):
+        days = [
+            {"date": "2026-03-20", "messageCount": 10, "sessionCount": 1, "toolCallCount": 5},
+            {"date": "2026-03-21", "messageCount": 20, "sessionCount": 2, "toolCallCount": 10},
+            {"date": "2026-03-22", "messageCount": 30, "sessionCount": 3, "toolCallCount": 15},
+        ]
+        result = _sum_range(days, "2026-03-20", "2026-03-21")
+        assert result == {"messages": 30, "sessions": 3, "tools": 15}
+
+    def test_empty_range(self):
+        result = _sum_range([], "2026-01-01", "2026-12-31")
+        assert result == {"messages": 0, "sessions": 0, "tools": 0}
+
+    def test_no_matching_dates(self):
+        days = [{"date": "2025-01-01", "messageCount": 10, "sessionCount": 1, "toolCallCount": 5}]
+        result = _sum_range(days, "2026-01-01", "2026-12-31")
+        assert result == {"messages": 0, "sessions": 0, "tools": 0}
+
+
+class TestFormatStatsLine:
+    def test_all_nonzero(self):
+        result = format_stats_line({"messages": 100, "sessions": 5, "tools": 42})
+        assert "100 msgs" in result
+        assert "5 sessions" in result
+        assert "42 tools" in result
+
+    def test_no_activity(self):
+        assert format_stats_line({"messages": 0, "sessions": 0, "tools": 0}) == "No activity"
+
+    def test_partial(self):
+        result = format_stats_line({"messages": 50, "sessions": 0, "tools": 10})
+        assert "50 msgs" in result
+        assert "sessions" not in result
+        assert "10 tools" in result
+
+    def test_comma_formatting(self):
+        result = format_stats_line({"messages": 1234, "sessions": 1, "tools": 5678})
+        assert "1,234" in result
+        assert "5,678" in result
+
+
+class TestGetStats:
+    def test_today_reads_from_file(self, tmp_path):
+        stats_file = tmp_path / "stats-cache.json"
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        data = {
+            "version": 2,
+            "dailyActivity": [
+                {"date": today, "messageCount": 42, "sessionCount": 2, "toolCallCount": 10},
+            ],
+        }
+        stats_file.write_text(json.dumps(data))
+        with patch("claudewatch.backend.services.usage_stats._STATS_PATH", str(stats_file)):
+            result = get_today_stats()
+        assert result["messages"] == 42
+
+    def test_missing_file_returns_zeros(self, tmp_path):
+        with patch("claudewatch.backend.services.usage_stats._STATS_PATH", str(tmp_path / "nope.json")):
+            result = get_today_stats()
+        assert result == {"messages": 0, "sessions": 0, "tools": 0}
+
+    def test_week_sums_7_days(self, tmp_path):
+        stats_file = tmp_path / "stats-cache.json"
+        now = datetime.now(tz=UTC)
+        days = []
+        for i in range(10):
+            d = (now - timedelta(days=i)).strftime("%Y-%m-%d")
+            days.append({"date": d, "messageCount": 10, "sessionCount": 1, "toolCallCount": 5})
+        data = {"version": 2, "dailyActivity": days}
+        stats_file.write_text(json.dumps(data))
+        with patch("claudewatch.backend.services.usage_stats._STATS_PATH", str(stats_file)):
+            result = get_week_stats()
+        assert result["messages"] == 70  # 7 days * 10
+
+    def test_month_sums_30_days(self, tmp_path):
+        stats_file = tmp_path / "stats-cache.json"
+        now = datetime.now(tz=UTC)
+        days = []
+        for i in range(35):
+            d = (now - timedelta(days=i)).strftime("%Y-%m-%d")
+            days.append({"date": d, "messageCount": 1, "sessionCount": 1, "toolCallCount": 1})
+        data = {"version": 2, "dailyActivity": days}
+        stats_file.write_text(json.dumps(data))
+        with patch("claudewatch.backend.services.usage_stats._STATS_PATH", str(stats_file)):
+            result = get_month_stats()
+        assert result["messages"] == 30  # 30 days


### PR DESCRIPTION
## Summary
- Today's stats shown under ClaudeWatch header (e.g. "Today: 42 msgs · 12 tools")
- 📊 Usage submenu: this week + last 30 days breakdowns
- Reads directly from ~/.claude/stats-cache.json
- 11 new tests (228 total)