### PR TITLE
feat: per-session token usage, fix summary hover

### DIFF
--- a/claudewatch/backend/services/usage.py
+++ b/claudewatch/backend/services/usage.py
@@ -1,8 +1,12 @@
 """Parse session metadata from Claude Code JSONL session logs."""
 
 import json
+import os
 
-from claudewatch.backend.services.jsonl import find_most_recent_jsonl, read_jsonl_tail
+from claudewatch.backend.services.jsonl import find_most_recent_jsonl, read_jsonl_full, read_jsonl_tail
+
+# CWD → (tokens_dict, jsonl_mtime)
+_token_cache: dict[str, tuple[dict[str, int], float]] = {}
 
 # Model display names — keep factual
 MODEL_DISPLAY_NAMES: dict[str, str] = {
@@ -41,3 +45,65 @@ def get_session_model(cwd: str) -> str:
             continue
 
     return MODEL_DISPLAY_NAMES.get(last_model, last_model)
+
+
+def get_session_tokens(cwd: str) -> dict[str, int]:
+    """Get total token usage for the most recent session at a CWD.
+
+    Returns {"input": N, "output": N} summed across all messages.
+    Cached by JSONL mtime — only re-reads when the file changes.
+    """
+    path = find_most_recent_jsonl(cwd)
+    if not path:
+        return {"input": 0, "output": 0}
+
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        return {"input": 0, "output": 0}
+
+    cached = _token_cache.get(cwd)
+    if cached and cached[1] >= mtime:
+        return cached[0]
+
+    lines = read_jsonl_full(path)
+    total_in = 0
+    total_out = 0
+    for line in lines:
+        try:
+            d = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        msg = d.get("message", {})
+        if not isinstance(msg, dict):
+            continue
+        usage = msg.get("usage", {})
+        if not isinstance(usage, dict):
+            continue
+        total_in += usage.get("input_tokens", 0)
+        total_in += usage.get("cache_creation_input_tokens", 0)
+        total_in += usage.get("cache_read_input_tokens", 0)
+        total_out += usage.get("output_tokens", 0)
+
+    result = {"input": total_in, "output": total_out}
+    _token_cache[cwd] = (result, mtime)
+    return result
+
+
+def format_tokens(tokens: dict[str, int]) -> str:
+    """Format token counts as a compact string like '12K in · 3K out'."""
+    total = tokens["input"] + tokens["output"]
+    if total == 0:
+        return ""
+
+    _m = 1_000_000
+    _k = 1000
+
+    def _fmt(n: int) -> str:
+        if n >= _m:
+            return f"{n / _m:.1f}M"
+        if n >= _k:
+            return f"{n / _k:.0f}K"
+        return str(n)
+
+    return f"{_fmt(tokens['input'])} in · {_fmt(tokens['output'])} out"

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -55,8 +55,7 @@ from claudewatch.backend.services.summarize import (
     is_generating,
     track_session,
 )
-from claudewatch.backend.services.usage import MODEL_DISPLAY_NAMES, get_session_model
-from claudewatch.backend.services.usage_stats import format_stats_line, get_month_stats, get_today_stats, get_week_stats
+from claudewatch.backend.services.usage import MODEL_DISPLAY_NAMES, format_tokens, get_session_model, get_session_tokens
 from claudewatch.ui.activity import show_activity
 from claudewatch.ui.focus import focus_session
 from claudewatch.ui.preferences import show_preferences
@@ -245,20 +244,22 @@ def _noop(_: rumps.MenuItem) -> None:
 
 
 def _add_summary_lines(menu_item: rumps.MenuItem, text: str) -> None:
-    """Split a summary into wrapped menu items with readable styling."""
+    """Split a summary into wrapped menu items — non-interactive, readable text."""
     _wrap = 55
     words = text.split()
     line = ""
     for word in words:
         if line and len(line) + 1 + len(word) > _wrap:
-            item = rumps.MenuItem(f"  {line}", callback=_noop)
+            item = rumps.MenuItem(f"  {line}")
+            item.set_callback(None)
             _style_summary_item(item)
             menu_item.add(item)
             line = word
         else:
             line = f"{line} {word}" if line else word
     if line:
-        item = rumps.MenuItem(f"  {line}", callback=_noop)
+        item = rumps.MenuItem(f"  {line}")
+        item.set_callback(None)
         _style_summary_item(item)
         menu_item.add(item)
 
@@ -432,15 +433,9 @@ class ClaudeWatchApp(rumps.App):
 
         self.menu.clear()
 
-        # App title + today's usage
+        # App title
         app_title = rumps.MenuItem("ClaudeWatch", callback=None)
         self.menu.add(app_title)
-        today = get_today_stats()
-        today_line = format_stats_line(today)
-        if today["messages"]:
-            today_item = rumps.MenuItem(f"  Today: {today_line}")
-            today_item.set_callback(None)
-            self.menu.add(today_item)
         self.menu.add(rumps.separator)
 
         # Show accessibility warning if needed
@@ -609,22 +604,6 @@ class ClaudeWatchApp(rumps.App):
                 track_session(cwd)  # background thread will generate summary
             self.menu.add(recent_menu)
 
-        # Usage stats submenu
-        week = get_week_stats()
-        month = get_month_stats()
-        if week["messages"] or month["messages"]:
-            self.menu.add(rumps.separator)
-            usage_menu = rumps.MenuItem("📊 Usage")
-            for label, stats in (("This week", week), ("Last 30 days", month)):
-                line = format_stats_line(stats)
-                header = rumps.MenuItem(f"  {label}")
-                header.set_callback(None)
-                usage_menu.add(header)
-                detail = rumps.MenuItem(f"    {line}")
-                detail.set_callback(None)
-                usage_menu.add(detail)
-            self.menu.add(usage_menu)
-
         self.menu.add(rumps.separator)
         self.menu.add(rumps.MenuItem("Preferences...", callback=self._open_preferences))
 
@@ -702,10 +681,11 @@ class ClaudeWatchApp(rumps.App):
                 item.add(rumps.MenuItem("Pin session...", callback=self._make_pin_handler(s)))
             item.add(rumps.MenuItem("Quit session", callback=self._make_quit_handler(s)))
         self.menu.add(item)
-        # Detail line: status + model
+        # Detail line: status + model + tokens
         detail = s.detail_line
         model = get_session_model(s.cwd)
-        detail_parts = [p for p in [detail, model] if p]
+        tokens = format_tokens(get_session_tokens(s.cwd))
+        detail_parts = [p for p in [detail, model, tokens] if p]
         if detail_parts:
             detail_item = rumps.MenuItem(f"      {' · '.join(detail_parts)}")
             detail_item.set_callback(None)


### PR DESCRIPTION
## Summary
- Token counts in detail line: '42K in · 3K out' per session
- Cached by JSONL mtime
- Summary lines no longer hoverable/selectable
- Removed stale usage stats (quota % not available locally)