### PR TITLE
fix: notifications broken — use host app bundle ID as sender

### DIFF
--- a/claudewatch/backend/services/notifications.py
+++ b/claudewatch/backend/services/notifications.py
@@ -112,7 +112,7 @@ class NotificationManager:
                 "-group",
                 f"claudewatch-{s.pid}",
                 "-sender",
-                "com.claudewatch",  # prevent terminal-notifier from activating host app on click
+                _BUNDLE_IDS.get(s.host_app, "com.apple.Terminal"),
             ]
 
             if s.host_app == HostApp.TERMINAL and s.window_id is not None:

--- a/claudewatch/backend/services/onboarding.py
+++ b/claudewatch/backend/services/onboarding.py
@@ -82,7 +82,7 @@ def show_tip(tip_id: str) -> bool:
         "-group",
         f"claudewatch-onboarding-{tip_id}",
         "-sender",
-        "com.claudewatch",
+        "com.apple.Terminal",
     ]
     try:
         subprocess.run(  # noqa: S603


### PR DESCRIPTION
macOS drops notifications from unknown bundle IDs. Now uses Terminal/VS Code/PyCharm bundle ID.