### PR TITLE
docs: update project rules for current architecture

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,10 +1,15 @@
 - **Layered structure:** `backend/services/` (business logic), `backend/repositories/` (persistence), `ui/` (views).
 - **backend/** has no UI imports. Never import from `ui/` in backend code.
+- **paths.py** — centralized app data directory (`~/Library/Application Support/ClaudeWatch/`). All file paths for settings, pins, history, summaries, and logs are defined here. Auto-migrates legacy files from `~/.claude/claudewatch-*` on first run. Import paths from here, never hardcode.
 - **helpers.py** — shared AppleScript runner, escaping, shell utilities.
-- **models.py** — data structures, enums, and path mapping (`cwd_to_proj_key()` / `proj_key_to_cwd()`).
+- **models.py** — data structures, enums, and path mapping (`cwd_to_proj_key()` / `proj_key_to_cwd()`). Path resolution uses longest-match for hyphenated directory names.
 - **jsonl.py** — all JSONL discovery, symlink validation, and reading. Never do inline JSONL file discovery — use `find_most_recent_jsonl()`, `read_jsonl_tail()`, `is_safe_jsonl_path()`.
-- **summarize.py** — conversation summaries via `claude -p`. Subprocess calls must use `Popen` with PID tracking (never `shell=True`). Summaries persist to `~/.claude/claudewatch-summaries.json`. Background thread refreshes every 60s. Max 1 concurrent `claude -p`. Own PIDs tracked in `_our_pids` set and filtered from detection.
+- **summarize.py** — conversation summaries via `claude -p`. Subprocess calls must use `Popen` with PID tracking (never `shell=True`). Background thread refreshes every 60s. Max 1 concurrent `claude -p`. Own PIDs tracked in `_our_pids` set and filtered from detection. Failures tracked per CWD — gives up after 3 consecutive failures.
+- **updates.py** — checks GitHub Releases for newer versions every 6 hours. Uses `gh` CLI with curl fallback. Thread-safe cache with lock.
 - **onboarding.py** — feature discovery tips via terminal-notifier. Tracks shown tips and session count in config. One tip per poll cycle.
+- **menubar.py** — menu bar app using direct AppKit (`NSStatusBar`, `NSMenu`, `NSMenuItem`, `NSTimer`). `_AppDelegate` bridges NSMenuItem actions to Python callbacks via integer tags.
+- **welcome.py** — first-launch window explaining permissions and data access. Shown once, tracked via `welcome_shown` setting.
+- **preferences.py** — preferences window with settings and session history table.
 - `detect_sessions()` runs on a background thread. Results are collected on the main thread via `Future.result()`. All `self.sessions` access happens on the main thread.
 - Set `_modal_active = True` during any modal dialog to pause polling. Reset in `finally`.
 - Never generate summaries or do I/O during menu build — only read from caches. Background threads handle generation.

--- a/.claude/rules/macos.md
+++ b/.claude/rules/macos.md
@@ -1,3 +1,9 @@
+- **Menu bar app uses direct AppKit** — `NSStatusBar`, `NSMenu`, `NSMenuItem`, `NSTimer`, `AppHelper.runEventLoop()`.
+- **Callback dispatch:** `_AppDelegate` maps `NSMenuItem` tags (integers) to Python callables. Use `_make_menu_item(title, callback, delegate)` to create items. Always clear `_callbacks` dict and reset `_next_tag` when rebuilding the menu to prevent leaks.
+- **NSObject subclasses must use `objc.super()`** — never use Python's `super()` in PyObjC classes. Pattern: `self = objc.super(ClassName, self).init()`.
+- **Quit uses `AppHelper.stopEventLoop()`** — not `NSApplication.terminate_()`, which doesn't work with `AppHelper.runEventLoop()`. Ctrl+C also uses `stopEventLoop` via a SIGINT handler.
+- **Restart uses `os.execv(sys.executable, [sys.executable] + sys.argv)`** — replaces the process in-place.
+- **`NSApplicationActivationPolicyAccessory`** — set in `run()` for menu-bar-only mode (no dock icon).
 - Terminal.app AppleScript must be guarded with `if application "Terminal" is running`.
 - **Window focus must only raise the target window, never all windows of the app.** For Terminal.app, use `set index of window id X to 1` + `activateWithOptions_(1 << 1)` (without `NSApplicationActivateAllWindows`). Never use `-activate` with terminal-notifier for Terminal.app — use `-execute` with targeted AppleScript instead.
 - Always `NSImage.copy()` before calling `setSize_` on images from `NSWorkspace`.

--- a/.claude/rules/packaging.md
+++ b/.claude/rules/packaging.md
@@ -1,0 +1,14 @@
+- **Briefcase** builds the `.app` bundle. Config is in `pyproject.toml` under `[tool.briefcase]`.
+- **Icon:** `icons/claudewatch.svg` — Briefcase generates all required sizes. Referenced via `icon = "icons/claudewatch"` (no extension) in pyproject.toml.
+- **Build commands:**
+  ```
+  PIP_INDEX_URL=https://pypi.org/simple/ uv run briefcase create macOS --no-input
+  uv run briefcase build macOS --no-input
+  uv run briefcase package macOS --adhoc-sign --no-input
+  ```
+- **`PIP_INDEX_URL` override** is needed if the system pip config points to a private index. Briefcase's embedded pip inherits it.
+- **`LSUIElement = true`** in Info.plist — menu-bar-only app, no dock icon.
+- **Entitlements:** `com.apple.security.cs.allow-unsigned-executable-memory` and `com.apple.security.cs.disable-library-validation` are required for PyObjC. These are set by the Briefcase template.
+- **TCC folder prompts** (Photos, Music, Downloads, etc.) are triggered by the Python framework startup, not our code. Users can safely deny them. This is a known BeeWare limitation.
+- **Release workflow** (`.github/workflows/release.yml`): push a `v*` tag to build and attach `ClaudeWatch-vX.Y.Z-arm64.zip` to a GitHub Release.
+- Always bump `version` in both `[project]` and `[tool.briefcase]` sections of pyproject.toml when tagging a release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,10 @@
 
 Project rules are in `.claude/rules/`:
 
-- `architecture.md` — layered structure, module responsibilities, threading model
+- `architecture.md` — layered structure, module responsibilities, threading model, data flow
 - `security.md` — input validation, AppleScript escaping, JSONL symlink protection, CI pinning
 - `code-style.md` — linting, commits, branching, attribution
 - `testing.md` — coverage, mocking, fixtures
-- `macos.md` — AppKit threading, window focus, NSImage safety
+- `macos.md` — AppKit patterns, PyObjC delegate callbacks, window focus, NSImage safety
+- `packaging.md` — Briefcase builds, icon, entitlements, release workflow
 - `license.md` — GPL-3.0-or-later


### PR DESCRIPTION
## Summary
- Update `architecture.md` with new modules (paths.py, updates.py, welcome.py, summarize failure tracking)
- Update `macos.md` with AppKit patterns (tag dispatch, objc.super, AppHelper lifecycle, restart)
- Add `packaging.md` — Briefcase builds, icon, entitlements, TCC prompts, release workflow
- Update `CLAUDE.md` index