### PR TITLE
feat: in-app self-update via GitHub Releases

### DIFF
--- a/claudewatch/backend/services/updates.py
+++ b/claudewatch/backend/services/updates.py
@@ -2,9 +2,13 @@
 
 import json
 import logging
+import os
 import subprocess
+import sys
+import tempfile
 import threading
 import time
+from collections.abc import Callable
 
 from claudewatch import __version__
 
@@ -95,3 +99,113 @@ def get_cached_update() -> dict[str, str] | None:
     """Return the cached update info without hitting the network."""
     with _cache_lock:
         return _cached_update
+
+
+_REPO = "wingatethomas/claudewatch"
+
+
+def _get_download_url(tag: str) -> str:
+    """Build the release asset URL for a given tag."""
+    return f"https://github.com/{_REPO}/releases/download/{tag}/ClaudeWatch-{tag}-arm64.zip"
+
+
+def _find_app_bundle() -> str | None:
+    """Find the running .app bundle path, if running from one."""
+    # When running as a .app, sys.executable is inside the bundle:
+    # ClaudeWatch.app/Contents/MacOS/ClaudeWatch
+    exe = os.path.realpath(sys.executable)
+    parts = exe.split("/")
+    for i, part in enumerate(parts):
+        if part.endswith(".app"):
+            return "/".join(parts[: i + 1])
+    return None
+
+
+def download_and_apply_update(tag: str, on_ready: Callable[[], None] | None = None) -> bool:
+    """Download a release and prepare the swap. Returns True if swap is staged.
+
+    Call on_ready() (which should quit the app) after staging succeeds.
+    The swap script runs after the app exits.
+    """
+    app_path = _find_app_bundle()
+    if not app_path:
+        log.warning("update: not running from a .app bundle, cannot self-update")
+        return False
+
+    url = _get_download_url(tag)
+    tmp_dir = tempfile.mkdtemp(prefix="claudewatch-update-")
+    zip_path = os.path.join(tmp_dir, "update.zip")
+
+    log.info("update: downloading %s", url)
+    try:
+        result = subprocess.run(  # noqa: S603, S607
+            ["curl", "-fSL", "--max-time", "60", "-o", zip_path, url],
+            capture_output=True,
+            text=True,
+            timeout=90,
+            check=False,
+        )
+        if result.returncode != 0:
+            log.warning("update: download failed: %s", result.stderr.strip())
+            return False
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        log.warning("update: download failed: %s", e)
+        return False
+
+    # Unzip
+    extract_dir = os.path.join(tmp_dir, "extracted")
+    os.makedirs(extract_dir)
+    try:
+        subprocess.run(  # noqa: S603, S607
+            ["unzip", "-q", zip_path, "-d", extract_dir],
+            capture_output=True,
+            timeout=30,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        log.warning("update: unzip failed: %s", e)
+        return False
+
+    # Find the .app inside the extracted directory
+    new_app = None
+    for name in os.listdir(extract_dir):
+        if name.endswith(".app"):
+            new_app = os.path.join(extract_dir, name)
+            break
+    if not new_app:
+        log.warning("update: no .app found in zip")
+        return False
+
+    # Stage the swap script — runs after our process exits
+    pid = os.getpid()
+    script = f"""#!/bin/bash
+# Wait for ClaudeWatch to exit (max 30s)
+for i in $(seq 1 60); do
+    kill -0 {pid} 2>/dev/null || break
+    sleep 0.5
+done
+# Swap the app bundle
+rm -rf "{app_path}"
+mv "{new_app}" "{app_path}"
+# Relaunch
+open "{app_path}"
+# Cleanup
+rm -rf "{tmp_dir}"
+"""
+    script_path = os.path.join(tmp_dir, "swap.sh")
+    with open(script_path, "w") as f:
+        f.write(script)
+    os.chmod(script_path, 0o755)  # noqa: S103
+
+    # Launch the swap script detached from our process
+    subprocess.Popen(  # noqa: S603
+        [script_path],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    log.info("update: swap script staged, quitting for update to %s", tag)
+
+    if on_ready:
+        on_ready()
+    return True

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -62,7 +62,7 @@ from claudewatch.backend.services.summarize import (
     is_generating,
     track_session,
 )
-from claudewatch.backend.services.updates import check_for_update, get_cached_update
+from claudewatch.backend.services.updates import check_for_update, download_and_apply_update, get_cached_update
 from claudewatch.backend.services.usage import (
     MODEL_DISPLAY_NAMES,
     format_tokens_breakdown,
@@ -553,7 +553,7 @@ class ClaudeWatchApp:
         if update_info:
             self._menu.addItem_(
                 _make_menu_item(
-                    f"Update available ({update_info['tag']})",
+                    f"Update to {update_info['tag']}",
                     self._make_open_update_handler(),
                     d,
                 )
@@ -1043,7 +1043,29 @@ class ClaudeWatchApp:
 
     def _make_open_update_handler(self) -> _MenuCallback:
         def handler(_: NSMenuItem) -> None:
-            webbrowser.open("https://github.com/wingatethomas/claudewatch/releases/latest")
+            update_info = get_cached_update()
+            if not update_info:
+                return
+            tag = update_info["tag"]
+
+            app = NSApplication.sharedApplication()
+            app.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
+            app.activateIgnoringOtherApps_(True)
+            alert = NSAlert.alloc().init()
+            alert.setMessageText_(f"Update to {tag}?")
+            alert.setInformativeText_("ClaudeWatch will download the update, quit, and relaunch automatically.")
+            alert.addButtonWithTitle_("Update")
+            alert.addButtonWithTitle_("Cancel")
+            if alert.runModal() != NSAlertFirstButtonReturn:
+                return
+
+            def quit_app() -> None:
+                AppHelper.stopEventLoop()
+
+            success = download_and_apply_update(tag, on_ready=quit_app)
+            if not success:
+                # Fallback: open browser
+                webbrowser.open("https://github.com/wingatethomas/claudewatch/releases/latest")
 
         return handler
 


### PR DESCRIPTION
## Summary
- Click "Update to vX.Y.Z" in menu → confirmation alert → download → quit → swap → relaunch
- Downloads release zip via curl, unzips, spawns a detached swap script that waits for PID exit
- Falls back to opening browser if not running from a .app bundle (e.g. `uv run claudewatch`)
- No external frameworks, uses only curl/unzip/bash