### PR TITLE
fix: consolidate CI to one macos-14 job, add caching and path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,33 +3,45 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.claude/**'
+      - 'icons/**'
+      - '.superpowers/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.claude/**'
+      - 'icons/**'
+      - '.superpowers/**'
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
-      - run: uvx ruff check .
-      - run: uvx ruff format --check .
-
   test:
     runs-on: macos-14  # ARM64 — PyObjC requires macOS
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
       - run: uv sync
+      - name: Lint
+        run: |
+          uvx ruff check .
+          uvx ruff format --check .
       - name: Run tests with coverage
         run: uv run pytest -v --cov=claudewatch --cov-report=term-missing --cov-fail-under=75
 
   security:
-    runs-on: macos-14  # PyObjC requires macOS to resolve
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
       - name: Audit dependencies for known vulnerabilities
         run: |
-          uv export --no-hashes > requirements.txt
+          uv export --no-hashes | grep -v '^pyobjc' > requirements.txt
           uvx pip-audit -r requirements.txt


### PR DESCRIPTION
## Summary
- Merge lint into test job (1 macos-14 runner instead of 2)
- Move pip-audit to ubuntu-latest (filter pyobjc, no macOS needed)
- Add path-ignore for docs, markdown, icons
- Enable uv dependency caching