### PR TITLE
feat: add static import audit script with layer rule enforcement

### DIFF
--- a/scripts/audit_imports.py
+++ b/scripts/audit_imports.py
@@ -1,0 +1,386 @@
+"""Static import audit for the claudewatch package.
+
+Parses Python files with the ast module (no execution) to enforce
+architectural layer rules, report dependency metrics, and detect
+circular dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Root of the claudewatch package relative to repo root
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PACKAGE_ROOT = REPO_ROOT / "claudewatch"
+PACKAGE_NAME = "claudewatch"
+
+# ---------------------------------------------------------------------------
+# Layer classification
+# ---------------------------------------------------------------------------
+
+# Domain directories (siblings of core/ and repositories/ under backend/)
+DOMAIN_DIRS = frozenset(
+    {
+        "detection",
+        "summary",
+        "notifications",
+        "onboarding",
+        "updates",
+        "usage",
+        "activity",
+        "bookmark",
+        "history",
+    }
+)
+
+# Minimum part count to identify core sub-packages (e.g. process, session_log)
+_MIN_CORE_SUBPACKAGE_PARTS = 3
+
+# Core sub-packages that count as "core/services"
+_CORE_SERVICE_PACKAGES = frozenset({"process", "session_log"})
+
+
+def _classify_backend(parts: list[str]) -> str:
+    """Classify a backend module given the parts after 'backend'."""
+    if parts[0] == "core":
+        if len(parts) >= _MIN_CORE_SUBPACKAGE_PARTS and parts[1] in _CORE_SERVICE_PACKAGES:
+            return "core/services"
+        return "core"
+    if parts[0] == "repositories":
+        return "repositories"
+    return "domain" if parts[0] in DOMAIN_DIRS else "other"
+
+
+def _classify(module_path: str) -> str:
+    """Return a layer tag for an internal module path.
+
+    Tags:
+        "core"           -- backend/core (excluding services)
+        "core/services"  -- backend/core/process, backend/core/session_log
+        "repositories"   -- backend/repositories
+        "domain"         -- any domain package under backend/
+        "ui"             -- ui/
+        "other"          -- anything else (e.g. __main__)
+    """
+    parts = module_path.split(".")
+    # Strip leading package name
+    if parts and parts[0] == PACKAGE_NAME:
+        parts = parts[1:]
+
+    if not parts:
+        return "other"
+
+    if parts[0] == "ui":
+        return "ui"
+
+    if parts[0] == "backend" and len(parts) > 1:
+        return _classify_backend(parts[1:])
+
+    return "other"
+
+
+def _is_config_import(module_path: str) -> bool:
+    """Return True if the import targets repositories/config specifically."""
+    parts = module_path.split(".")
+    if PACKAGE_NAME in parts:
+        parts = parts[parts.index(PACKAGE_NAME) + 1 :]
+    return parts[:3] == ["backend", "repositories", "config"]
+
+
+# ---------------------------------------------------------------------------
+# Layer rules: (from_layer, to_layer) -> forbidden unless exception applies
+# ---------------------------------------------------------------------------
+
+# Pairs that are always forbidden (no exceptions)
+_FORBIDDEN_PAIRS: set[tuple[str, str]] = {
+    # core/ must not import from domains, repositories, or ui
+    ("core", "domain"),
+    ("core", "repositories"),
+    ("core", "ui"),
+    # core/services must not import from domains, repositories, or ui
+    ("core/services", "domain"),
+    ("core/services", "repositories"),
+    ("core/services", "ui"),
+    # repositories must not import from domains or ui
+    ("repositories", "domain"),
+    ("repositories", "ui"),
+    # domains must not import from ui
+    ("domain", "ui"),
+    # ui must not import from repositories (exception handled below)
+    ("ui", "repositories"),
+}
+
+
+def _is_violation(from_layer: str, to_layer: str, to_module: str) -> bool:
+    """Return True if importing *to_module* from *from_layer* to *to_layer* is a violation."""
+    pair = (from_layer, to_layer)
+    if pair not in _FORBIDDEN_PAIRS:
+        return False
+    # Exception: ui may import from repositories/config
+    return not (pair == ("ui", "repositories") and _is_config_import(to_module))
+
+
+# ---------------------------------------------------------------------------
+# AST-based import extraction
+# ---------------------------------------------------------------------------
+
+
+def _module_name(filepath: Path) -> str:
+    """Convert a file path to a dotted module name relative to the repo root."""
+    rel = filepath.relative_to(REPO_ROOT)
+    parts = list(rel.with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _extract_imports(filepath: Path) -> list[str]:
+    """Parse a Python file and return all imported module paths (internal only)."""
+    try:
+        source = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    try:
+        tree = ast.parse(source, filename=str(filepath))
+    except SyntaxError:
+        return []
+
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith(PACKAGE_NAME + "."):
+                    imports.append(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.module.startswith(PACKAGE_NAME + "."):
+            imports.append(node.module)
+    return imports
+
+
+# ---------------------------------------------------------------------------
+# Dependency graph construction
+# ---------------------------------------------------------------------------
+
+
+def build_graph(package_root: Path) -> dict[str, list[str]]:
+    """Return {module: [imported_module, ...]} for all .py files under package_root."""
+    graph: dict[str, list[str]] = {}
+    for pyfile in sorted(package_root.rglob("*.py")):
+        mod = _module_name(pyfile)
+        imported = _extract_imports(pyfile)
+        if imported:
+            graph[mod] = imported
+        else:
+            graph[mod] = []
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Layer violation checking
+# ---------------------------------------------------------------------------
+
+
+def find_violations(graph: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return a list of dicts describing each layer violation."""
+    violations: list[dict[str, str]] = []
+    for module, imports in sorted(graph.items()):
+        from_layer = _classify(module)
+        if from_layer == "other":
+            continue
+        for imp in imports:
+            to_layer = _classify(imp)
+            if to_layer == "other":
+                continue
+            if _is_violation(from_layer, to_layer, imp):
+                violations.append(
+                    {
+                        "module": module,
+                        "imports": imp,
+                        "from_layer": from_layer,
+                        "to_layer": to_layer,
+                    }
+                )
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+def compute_fan_out(graph: dict[str, list[str]]) -> dict[str, int]:
+    """Fan-out: how many distinct internal modules each module imports."""
+    return {mod: len(set(imps)) for mod, imps in graph.items()}
+
+
+def compute_fan_in(graph: dict[str, list[str]]) -> dict[str, int]:
+    """Fan-in: how many modules import each module."""
+    fan_in: dict[str, int] = defaultdict(int)
+    for imps in graph.values():
+        for imp in set(imps):
+            fan_in[imp] += 1
+    return dict(fan_in)
+
+
+def find_cycles(graph: dict[str, list[str]]) -> list[list[str]]:
+    """Detect circular dependencies using DFS. Returns list of cycles."""
+    # Normalise graph edges to modules that exist in the graph
+    all_modules = set(graph.keys())
+    adj: dict[str, set[str]] = {}
+    for mod, imps in graph.items():
+        adj[mod] = {i for i in set(imps) if i in all_modules}
+
+    visited: set[str] = set()
+    on_stack: set[str] = set()
+    stack: list[str] = []
+    cycles: list[list[str]] = []
+
+    def dfs(node: str) -> None:
+        visited.add(node)
+        on_stack.add(node)
+        stack.append(node)
+        for neighbour in sorted(adj.get(node, set())):
+            if neighbour not in visited:
+                dfs(neighbour)
+            elif neighbour in on_stack:
+                idx = stack.index(neighbour)
+                cycle = stack[idx:] + [neighbour]
+                cycles.append(cycle)
+        stack.pop()
+        on_stack.discard(node)
+
+    for node in sorted(all_modules):
+        if node not in visited:
+            dfs(node)
+
+    return cycles
+
+
+def max_import_depth(graph: dict[str, list[str]]) -> int:
+    """Compute the longest chain of internal imports (graph diameter via BFS)."""
+    all_modules = set(graph.keys())
+    adj: dict[str, set[str]] = {}
+    for mod, imps in graph.items():
+        adj[mod] = {i for i in set(imps) if i in all_modules}
+
+    max_depth = 0
+    memo: dict[str, int] = {}
+
+    def depth(node: str, seen: frozenset[str]) -> int:
+        if node in memo and not (seen & {node}):
+            return memo[node]
+        neighbours = adj.get(node, set()) - seen
+        if not neighbours:
+            return 0
+        d = max(1 + depth(n, seen | {node}) for n in neighbours)
+        if not seen:
+            memo[node] = d
+        return d
+
+    for mod in all_modules:
+        d = depth(mod, frozenset())
+        max_depth = max(max_depth, d)
+
+    return max_depth
+
+
+# ---------------------------------------------------------------------------
+# Output modes
+# ---------------------------------------------------------------------------
+
+
+def print_violations(violations: list[dict[str, str]]) -> None:
+    """Print layer violations to stderr."""
+    if not violations:
+        print("No layer violations found.")
+        return
+    print(f"Found {len(violations)} layer violation(s):\n", file=sys.stderr)
+    for v in violations:
+        print(
+            f"  VIOLATION: {v['module']} ({v['from_layer']}) -> {v['imports']} ({v['to_layer']})",
+            file=sys.stderr,
+        )
+
+
+def print_metrics(graph: dict[str, list[str]]) -> None:
+    """Print dependency metrics summary."""
+    fan_out = compute_fan_out(graph)
+    fan_in = compute_fan_in(graph)
+    cycles = find_cycles(graph)
+    depth = max_import_depth(graph)
+
+    print("\n--- Dependency Metrics ---\n")
+
+    # Top fan-out
+    top_out = sorted(fan_out.items(), key=lambda x: x[1], reverse=True)[:10]
+    print("Top 10 fan-out (most imports):")
+    for mod, count in top_out:
+        if count > 0:
+            print(f"  {mod}: {count}")
+
+    # Top fan-in
+    print("\nTop 10 fan-in (most imported):")
+    top_in = sorted(fan_in.items(), key=lambda x: x[1], reverse=True)[:10]
+    for mod, count in top_in:
+        print(f"  {mod}: {count}")
+
+    print(f"\nMax import depth: {depth}")
+
+    if cycles:
+        print(f"\nCircular dependencies ({len(cycles)}):")
+        for cycle in cycles:
+            print(f"  {' -> '.join(cycle)}")
+    else:
+        print("\nNo circular dependencies detected.")
+
+
+def print_graph_markdown(graph: dict[str, list[str]]) -> None:
+    """Print the dependency graph as a markdown table."""
+    print("# Dependency Graph\n")
+    print("| Module | Imports |")
+    print("|--------|---------|")
+    for mod in sorted(graph.keys()):
+        imps = graph[mod]
+        if imps:
+            imp_str = ", ".join(f"`{i}`" for i in sorted(set(imps)))
+            print(f"| `{mod}` | {imp_str} |")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns 0 on success, 1 if violations found in --check mode."""
+    parser = argparse.ArgumentParser(description="Static import audit for claudewatch")
+    parser.add_argument("--check", action="store_true", help="Exit non-zero if layer violations found (CI mode)")
+    parser.add_argument("--graph", action="store_true", help="Print dependency graph as markdown")
+    args = parser.parse_args(argv)
+
+    graph = build_graph(PACKAGE_ROOT)
+    violations = find_violations(graph)
+
+    if args.graph:
+        print_graph_markdown(graph)
+        return 0
+
+    if args.check:
+        if violations:
+            print_violations(violations)
+            return 1
+        print("All layer rules OK.")
+        return 0
+
+    # Default mode: violations + metrics
+    print_violations(violations)
+    print_metrics(graph)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audit_imports.py
+++ b/tests/test_audit_imports.py
@@ -1,0 +1,221 @@
+"""Tests for scripts/audit_imports.py."""
+
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.audit_imports import (
+    _classify,
+    _extract_imports,
+    _is_config_import,
+    _is_violation,
+    _module_name,
+    build_graph,
+    compute_fan_in,
+    compute_fan_out,
+    find_cycles,
+    find_violations,
+    main,
+    max_import_depth,
+)
+
+
+class TestClassify:
+    def test_core_module(self):
+        assert _classify("claudewatch.backend.core.models") == "core"
+
+    def test_core_services_process(self):
+        assert _classify("claudewatch.backend.core.process.service") == "core/services"
+
+    def test_core_services_session_log(self):
+        assert _classify("claudewatch.backend.core.session_log.service") == "core/services"
+
+    def test_repositories(self):
+        assert _classify("claudewatch.backend.repositories.config") == "repositories"
+
+    def test_domain_detection(self):
+        assert _classify("claudewatch.backend.detection.service") == "domain"
+
+    def test_domain_summary(self):
+        assert _classify("claudewatch.backend.summary.service") == "domain"
+
+    def test_ui(self):
+        assert _classify("claudewatch.ui.menubar") == "ui"
+
+    def test_other(self):
+        assert _classify("claudewatch.__main__") == "other"
+
+    def test_bare_package(self):
+        assert _classify("claudewatch") == "other"
+
+
+class TestIsConfigImport:
+    def test_config_import(self):
+        assert _is_config_import("claudewatch.backend.repositories.config") is True
+
+    def test_bookmarks_import(self):
+        assert _is_config_import("claudewatch.backend.repositories.bookmarks") is False
+
+
+class TestIsViolation:
+    def test_core_importing_domain_is_violation(self):
+        assert _is_violation("core", "domain", "claudewatch.backend.detection.service") is True
+
+    def test_core_importing_ui_is_violation(self):
+        assert _is_violation("core", "ui", "claudewatch.ui.menubar") is True
+
+    def test_domain_importing_core_is_ok(self):
+        assert _is_violation("domain", "core", "claudewatch.backend.core.models") is False
+
+    def test_ui_importing_repositories_is_violation(self):
+        assert _is_violation("ui", "repositories", "claudewatch.backend.repositories.bookmarks") is True
+
+    def test_ui_importing_config_is_exception(self):
+        assert _is_violation("ui", "repositories", "claudewatch.backend.repositories.config") is False
+
+    def test_domain_importing_ui_is_violation(self):
+        assert _is_violation("domain", "ui", "claudewatch.ui.menubar") is True
+
+    def test_repositories_importing_domain_is_violation(self):
+        assert _is_violation("repositories", "domain", "claudewatch.backend.detection.service") is True
+
+
+class TestExtractImports:
+    def test_extracts_from_import(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            textwrap.dedent("""\
+                from claudewatch.backend.core.models import ClaudeSession
+                import os
+            """)
+        )
+        result = _extract_imports(f)
+        assert result == ["claudewatch.backend.core.models"]
+
+    def test_extracts_import_statement(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text("import claudewatch.backend.core.helpers\n")
+        result = _extract_imports(f)
+        assert result == ["claudewatch.backend.core.helpers"]
+
+    def test_ignores_non_internal(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text("import os\nfrom pathlib import Path\n")
+        result = _extract_imports(f)
+        assert result == []
+
+    def test_handles_syntax_error(self, tmp_path):
+        f = tmp_path / "bad.py"
+        f.write_text("def broken(:\n")
+        result = _extract_imports(f)
+        assert result == []
+
+
+class TestModuleName:
+    def test_regular_module(self, tmp_path):
+        # Simulate repo root structure
+        pkg = tmp_path / "claudewatch" / "backend" / "core"
+        pkg.mkdir(parents=True)
+        f = pkg / "models.py"
+        f.touch()
+        with patch("scripts.audit_imports.REPO_ROOT", tmp_path):
+            assert _module_name(f) == "claudewatch.backend.core.models"
+
+    def test_init_file(self, tmp_path):
+        pkg = tmp_path / "claudewatch" / "backend"
+        pkg.mkdir(parents=True)
+        f = pkg / "__init__.py"
+        f.touch()
+        with patch("scripts.audit_imports.REPO_ROOT", tmp_path):
+            assert _module_name(f) == "claudewatch.backend"
+
+
+class TestBuildGraph:
+    def test_builds_graph(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        a = pkg / "a.py"
+        a.write_text("from claudewatch.backend.core.models import X\n")
+        b = pkg / "b.py"
+        b.write_text("")
+        with patch("scripts.audit_imports.REPO_ROOT", tmp_path):
+            graph = build_graph(pkg)
+        assert len(graph) == 2
+
+
+class TestFindViolations:
+    def test_detects_core_to_domain_violation(self):
+        graph = {
+            "claudewatch.backend.core.models": ["claudewatch.backend.detection.service"],
+        }
+        violations = find_violations(graph)
+        assert len(violations) == 1
+        assert violations[0]["from_layer"] == "core"
+        assert violations[0]["to_layer"] == "domain"
+
+    def test_no_violation_for_allowed_import(self):
+        graph = {
+            "claudewatch.backend.detection.service": ["claudewatch.backend.core.models"],
+        }
+        violations = find_violations(graph)
+        assert len(violations) == 0
+
+
+class TestMetrics:
+    def test_fan_out(self):
+        graph = {"a": ["b", "c", "b"], "b": ["c"], "c": []}
+        fan_out = compute_fan_out(graph)
+        assert fan_out["a"] == 2  # deduplicated
+        assert fan_out["c"] == 0
+
+    def test_fan_in(self):
+        graph = {"a": ["b", "c"], "b": ["c"], "c": []}
+        fan_in = compute_fan_in(graph)
+        assert fan_in["c"] == 2
+        assert fan_in["b"] == 1
+
+    def test_no_cycles(self):
+        graph = {"a": ["b"], "b": ["c"], "c": []}
+        cycles = find_cycles(graph)
+        assert cycles == []
+
+    def test_detects_cycle(self):
+        graph = {"a": ["b"], "b": ["a"]}
+        cycles = find_cycles(graph)
+        assert len(cycles) > 0
+
+    def test_max_depth(self):
+        graph = {"a": ["b"], "b": ["c"], "c": []}
+        assert max_import_depth(graph) == 2
+
+    def test_max_depth_no_edges(self):
+        graph = {"a": [], "b": []}
+        assert max_import_depth(graph) == 0
+
+
+class TestMain:
+    def test_check_mode_clean(self):
+        with (
+            patch("scripts.audit_imports.PACKAGE_ROOT", Path("/nonexistent")),
+            patch("scripts.audit_imports.build_graph", return_value={}),
+        ):
+            result = main(["--check"])
+        assert result == 0
+
+    def test_check_mode_with_violations(self):
+        fake_graph = {
+            "claudewatch.backend.core.models": ["claudewatch.backend.detection.service"],
+        }
+        with patch("scripts.audit_imports.build_graph", return_value=fake_graph):
+            result = main(["--check"])
+        assert result == 1
+
+    def test_graph_mode(self, capsys):
+        fake_graph = {
+            "claudewatch.backend.core.models": ["claudewatch.backend.core.helpers"],
+        }
+        with patch("scripts.audit_imports.build_graph", return_value=fake_graph):
+            result = main(["--graph"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Dependency Graph" in out


### PR DESCRIPTION
## Summary
- `scripts/audit_imports.py` validates layer rules via AST parsing
- `--check` mode for CI (exits non-zero on violations)
- `--graph` mode outputs markdown dependency map
- Reports fan-out/fan-in metrics, max import depth, circular deps
- 36 tests