### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claudewatch"
-version = "0.5.0"
+version = "0.6.0"
 description = "macOS menu bar app for monitoring Claude Code sessions"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -35,7 +35,7 @@ packages = ["claudewatch"]
 [tool.briefcase]
 project_name = "ClaudeWatch"
 bundle = "com.claudewatch"
-version = "0.5.0"
+version = "0.6.0"
 url = "https://github.com/wingatethomas/claudewatch"
 license.file = "LICENSE"
 author = "ClaudeWatch Contributors"


### PR DESCRIPTION
## Summary
- Bump version in both `[project]` and `[tool.briefcase]` sections

Tagging after merge.