### PR TITLE
fix: pre-release hardening — checksum, shell removal, CI audit, docs

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,7 +1,7 @@
 - All pure functions in `backend/` should have tests.
-- CI enforces ≥60% backend coverage (`ui/` excluded — requires running macOS app).
+- CI enforces ≥75% backend coverage (`ui/` and `dependencies.py` files excluded).
 - CI runs pip-audit for dependency vulnerability scanning.
 - Tests must never call real system commands. Use `unittest.mock.patch` to mock external calls.
 - Use `tmp_path` fixture for tests that need filesystem state.
-- When mocking `CLAUDE_PROJECTS_DIR`, patch at `claudewatch.backend.services.jsonl.CLAUDE_PROJECTS_DIR` (the module that reads it). If a function also imports it directly, patch both.
+- When mocking `CLAUDE_PROJECTS_DIR`, patch at `claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR` (the module that reads it). If a function also imports it directly, patch both.
 - Reset module-level state between tests (e.g. `_host_app_cache.clear()` in `setup_method`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           uvx ruff check .
           uvx ruff format --check .
+      - name: Check layer rules
+        run: uv run python scripts/audit_imports.py --check
       - name: Run tests with coverage
         run: uv run pytest -v --cov=claudewatch --cov-report=term-missing --cov-fail-under=75
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,12 @@ jobs:
           uv run briefcase build macOS --no-input
           uv run briefcase package macOS --adhoc-sign --no-input
 
-      - name: Zip the app
+      - name: Zip the app and generate checksums
         run: |
           cd build/claudewatch/macos/app
           zip -r "../../../../ClaudeWatch-${TAG}-arm64.zip" ClaudeWatch.app
+          cd ../../../..
+          shasum -a 256 "ClaudeWatch-${TAG}-arm64.zip" > checksums.txt
         env:
           TAG: ${{ github.ref_name }}
 
@@ -42,6 +44,7 @@ jobs:
           fi
           gh release create "$TAG" \
             "ClaudeWatch-${TAG}-arm64.zip" \
+            checksums.txt \
             --generate-notes \
             $PRERELEASE
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,28 +35,42 @@ Pre-commit hooks run ruff automatically on each commit.
 ```
 claudewatch/
 ├── backend/
-│   ├── core/                  # Shared infrastructure (no service/repo/UI imports)
-│   │   ├── models.py          # Data models, enums, constants
-│   │   ├── dto.py             # BaseDTO + all shared DTOs (*DTO suffix)
-│   │   ├── helpers.py         # AppleScript runner, escaping
-│   │   ├── paths.py           # Centralized file paths
-│   │   ├── base_service.py    # BaseService with import constraint enforcement
-│   │   └── services/          # Core services (process, session log)
-│   ├── dependencies.py        # Service factory functions (get_*_service())
-│   ├── services/              # Domain services (extend BaseService)
-│   └── repositories/          # Data persistence
-│       ├── config.py          # App settings (infrastructure)
-│       ├── bookmarks.py       # Pinned session bookmarks
-│       └── history.py         # Session history
+│   ├── core/                      # Shared infrastructure — no domain/repo/UI imports
+│   │   ├── models.py              # Data models, enums, constants
+│   │   ├── dto.py                 # BaseDTO + shared DTOs (*DTO suffix)
+│   │   ├── helpers.py             # AppleScript runner, escaping
+│   │   ├── paths.py               # Centralized file paths
+│   │   ├── base_service.py        # BaseService with import constraint enforcement
+│   │   ├── process/               # ProcessService — PID lookup + child PID registry
+│   │   │   ├── service.py
+│   │   │   ├── dependencies.py
+│   │   │   └── procinfo.py
+│   │   └── session_log/           # SessionLogService — JSONL discovery/reading
+│   │       ├── service.py
+│   │       ├── dependencies.py
+│   │       └── jsonl.py
+│   ├── repositories/              # Data persistence — can import from core/
+│   │   ├── config.py
+│   │   ├── bookmarks.py
+│   │   └── history.py
+│   ├── detection/                 # Each domain: service.py + dependencies.py
+│   ├── summary/
+│   ├── notifications/
+│   ├── onboarding/
+│   ├── updates/
+│   ├── usage/
+│   ├── activity/
+│   ├── bookmark/
+│   └── history/
 └── ui/
-    ├── menubar.py             # Menu bar view (AppKit NSStatusBar)
-    ├── focus.py               # Window focusing (AppleScript, CGEvent)
-    ├── preferences.py         # Preferences window (PyObjC NSWindow)
-    ├── welcome.py             # First-launch permissions guide
-    └── activity.py            # Activity feed window
+    ├── menubar.py                 # Menu bar (AppKit NSStatusBar)
+    ├── focus.py                   # Window focusing
+    ├── preferences.py             # Preferences window
+    ├── welcome.py                 # First-launch permissions guide
+    └── activity.py                # Activity feed window
 ```
 
-**Layer rules:** `core/` has no imports from `services/`, `repositories/`, or `ui/`. `services/` can import from `core/` and `repositories/`. `ui/` imports from `services/` and `core/` (DTOs/models only), never `repositories/` (except config, which is infrastructure).
+Each domain is a package with `service.py` (class extending `BaseService`) and `dependencies.py` (`@lru_cache` factory). **Layer rules:** `core/` has no imports from domains, repos, or UI. Domains can import from `core/` and `repositories/`. UI imports from domains (via `dependencies.py`) and `core/` (DTOs/models only), never `repositories/` directly (except config).
 
 ## PR Guidelines
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ macOS menu bar app that monitors all your running [Claude Code](https://docs.ant
 
 ### Download the App (recommended)
 
-Download `ClaudeWatch-v0.6.0-arm64.zip` from the [latest release](https://github.com/wingatethomas/claudewatch/releases/latest), unzip, and drag to `/Applications`.
+Download the latest `.zip` from the [releases page](https://github.com/wingatethomas/claudewatch/releases/latest), unzip, and drag to `/Applications`.
+
+To verify the download, check the SHA-256 checksum against `checksums.txt` from the same release:
+
+```bash
+shasum -a 256 ClaudeWatch-*.zip
+# Compare with the hash in checksums.txt
+```
 
 On first launch, a welcome window explains what permissions are needed.
 

--- a/claudewatch/backend/core/helpers.py
+++ b/claudewatch/backend/core/helpers.py
@@ -1,19 +1,8 @@
 import logging
-import subprocess
 
 from Foundation import NSAppleScript
 
 log = logging.getLogger("claudewatch")
-
-
-def _shell(cmd: str) -> str:
-    """Run a shell command and return stdout. Internal use only — callers must ensure
-    all interpolated values are validated (e.g. integer PIDs from isdigit() checks)."""
-    try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=5, check=False)  # noqa: S602
-        return r.stdout.strip()
-    except (subprocess.TimeoutExpired, OSError):
-        return ""
 
 
 def run_applescript(source: str) -> str:

--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -1,10 +1,11 @@
 import json
 import logging
 import os
+import subprocess
 import time
 
 from claudewatch.backend.core.base_service import BaseService
-from claudewatch.backend.core.helpers import _shell, run_applescript
+from claudewatch.backend.core.helpers import run_applescript
 from claudewatch.backend.core.models import (
     HOST_PROCESS_NAMES,
     IDLE_INDICATOR,
@@ -25,9 +26,6 @@ _JSONL_MAX_AGE = 300  # 5 min — Claude can wait for approval a long time
 _JSONL_MIN_AGE = 1
 _WIN_SPLIT_FIELDS = 3
 _TERMINAL_CACHE_TTL = 3  # seconds between AppleScript refreshes
-
-# Module-level cache — kept because tests import and clear it directly.
-_host_app_cache: dict[int, HostApp] = {}
 
 
 class DetectionService(BaseService):
@@ -286,7 +284,13 @@ class DetectionService(BaseService):
 
     def detect(self) -> list[ClaudeSession]:  # noqa: PLR0912, PLR0915
         """Detect all running Claude Code sessions."""
-        pids_out = _shell("pgrep -x claude")
+        try:
+            r = subprocess.run(  # noqa: S603, S607
+                ["pgrep", "-x", "claude"], capture_output=True, text=True, timeout=5, check=False,
+            )
+            pids_out = r.stdout.strip()
+        except (subprocess.TimeoutExpired, OSError):
+            pids_out = ""
         raw_pids = [int(p) for p in pids_out.splitlines() if p.strip().isdigit()]
         child_pids = self._process_service.get_child_pids()
         pids = [p for p in raw_pids if p not in child_pids][:_MAX_SESSIONS]

--- a/claudewatch/backend/updates/service.py
+++ b/claudewatch/backend/updates/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -78,6 +79,32 @@ def _get_download_url(tag: str) -> str:
     return f"https://github.com/{_REPO}/releases/download/{tag}/ClaudeWatch-{tag}-arm64.zip"
 
 
+def _sha256_file(path: str) -> str:
+    """Compute SHA-256 hex digest of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _fetch_expected_checksum(tag: str) -> str | None:
+    """Fetch SHA-256 checksum from the release's checksums.txt asset."""
+    url = f"https://github.com/{_REPO}/releases/download/{tag}/checksums.txt"
+    try:
+        result = subprocess.run(  # noqa: S603, S607
+            ["curl", "-sfL", "--max-time", "10", url],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            for line in result.stdout.strip().splitlines():
+                if "arm64.zip" in line:
+                    return line.split()[0]
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
 def _find_app_bundle() -> str | None:
     """Find the running .app bundle path, if running from one."""
     # When running as a .app, sys.executable is inside the bundle:
@@ -138,7 +165,7 @@ class UpdateService(BaseService):
         with self._cache_lock:
             return self._cached_update
 
-    def download_and_apply(self, tag: str, on_ready: Callable[[], None] | None = None) -> bool:
+    def download_and_apply(self, tag: str, on_ready: Callable[[], None] | None = None) -> bool:  # noqa: PLR0911
         """Download a release and prepare the swap. Returns True if swap is staged.
 
         Call on_ready() (which should quit the app) after staging succeeds.
@@ -168,6 +195,15 @@ class UpdateService(BaseService):
         except (FileNotFoundError, subprocess.TimeoutExpired) as e:
             log.warning("update: download failed: %s", e)
             return False
+
+        # Verify checksum if available
+        expected = _fetch_expected_checksum(tag)
+        if expected:
+            actual = _sha256_file(zip_path)
+            if actual != expected:
+                log.warning("update: checksum mismatch — expected %s, got %s", expected[:12], actual[:12])
+                return False
+            log.info("update: checksum verified")
 
         # Unzip
         extract_dir = os.path.join(tmp_dir, "extracted")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,24 +1,8 @@
-"""Tests for claudewatch.backend.core.helpers — _shell and escape_applescript."""
+"""Tests for claudewatch.backend.core.helpers — escape_applescript and run_applescript."""
 
-import subprocess
 from unittest.mock import MagicMock, patch
 
-from claudewatch.backend.core.helpers import _shell, escape_applescript, run_applescript
-
-
-class TestShell:
-    def test_returns_stdout(self):
-        with patch("claudewatch.backend.core.helpers.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(stdout="  hello world  ")
-            assert _shell("echo hello") == "hello world"
-
-    def test_returns_empty_on_timeout(self):
-        with patch("claudewatch.backend.core.helpers.subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 5)):
-            assert _shell("sleep 100") == ""
-
-    def test_returns_empty_on_oserror(self):
-        with patch("claudewatch.backend.core.helpers.subprocess.run", side_effect=OSError("nope")):
-            assert _shell("bad") == ""
+from claudewatch.backend.core.helpers import escape_applescript, run_applescript
 
 
 class TestRunApplescript:


### PR DESCRIPTION
## Summary
- Self-update verifies SHA-256 checksum from `checksums.txt` release asset
- Release workflow generates `checksums.txt` alongside zip
- Remove `_shell()` function (`shell=True`) — replaced with `subprocess.run` list args
- Remove dead module-level `_host_app_cache` from detection
- Wire `scripts/audit_imports.py --check` into CI pipeline
- Fix README version link (use releases/latest, not hardcoded version)
- Update CONTRIBUTING.md architecture tree for domain packages
- Fix testing rule (75% not 60%, correct patch path)
- Add SHA verification instructions in README