### PR TITLE
fix: align Recent icon, add TCC folder descriptions

### DIFF
--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -714,7 +714,8 @@ class ClaudeWatchApp:
 
         if recent_entries:
             self._menu.addItem_(NSMenuItem.separatorItem())
-            recent_menu_item = _make_menu_item(f"⏱ Recent ({len(recent_entries)})", None, d)
+            recent_menu_item = _make_menu_item(f"Recent ({len(recent_entries)})", None, d)
+            recent_menu_item.setImage_(_sf_icon("clock.arrow.circlepath"))
             recent_submenu = NSMenu.alloc().init()
             for entry in recent_entries:
                 model = MODEL_DISPLAY_NAMES.get(entry.model, entry.model)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ system_requires = []
 [tool.briefcase.app.claudewatch.macOS.info]
 LSUIElement = true
 NSAppleEventsUsageDescription = "ClaudeWatch needs automation access to read terminal windows and focus sessions."
+NSDesktopFolderUsageDescription = "ClaudeWatch does not need access to your Desktop."
+NSDocumentsFolderUsageDescription = "ClaudeWatch does not need access to your Documents."
+NSDownloadsFolderUsageDescription = "ClaudeWatch does not need access to your Downloads."
 
 [tool.coverage.run]
 source = ["claudewatch"]


### PR DESCRIPTION
## Summary
- Replace emoji on Recent with SF Symbol for consistent icon alignment
- Add folder usage descriptions to Info.plist so macOS remembers access denials