### PR TITLE
feat: compact model names (o4.6, s4.6, h4.5)

### DIFF
--- a/claudewatch/backend/usage/service.py
+++ b/claudewatch/backend/usage/service.py
@@ -10,11 +10,11 @@ from claudewatch.backend.core.session_log.service import SessionLogService
 
 # Model display names — keep factual
 MODEL_DISPLAY_NAMES: dict[str, str] = {
-    "claude-opus-4-6": "opus 4.6",
-    "claude-sonnet-4-6": "sonnet 4.6",
-    "claude-haiku-4-5": "haiku 4.5",
-    "claude-sonnet-4-5-20250514": "sonnet 4.5",
-    "claude-opus-4-20250512": "opus 4",
+    "claude-opus-4-6": "o4.6",
+    "claude-sonnet-4-6": "s4.6",
+    "claude-haiku-4-5": "h4.5",
+    "claude-sonnet-4-5-20250514": "s4.5",
+    "claude-opus-4-20250512": "o4",
 }
 
 _EMPTY_TOKENS: dict[str, int] = {

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -13,14 +13,14 @@ class TestRecordSession:
     def test_records_new_session(self, tmp_path):
         fake_path = str(tmp_path / "history.json")
         with patch.object(history, "_PATH", fake_path):
-            history.record_session("sess-1", "myproject", "/tmp/myproject", "opus 4.6", "Terminal")
+            history.record_session("sess-1", "myproject", "/tmp/myproject", "o4.6", "Terminal")
             entries = history._load()
 
         assert len(entries) == 1
         assert entries[0]["session_id"] == "sess-1"
         assert entries[0]["project"] == "myproject"
         assert entries[0]["cwd"] == "/tmp/myproject"
-        assert entries[0]["model"] == "opus 4.6"
+        assert entries[0]["model"] == "o4.6"
         assert entries[0]["host_app"] == "Terminal"
         assert "ended_at" in entries[0]
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -23,9 +23,9 @@ class TestModelDisplayNames:
     """MODEL_DISPLAY_NAMES mapping tests."""
 
     def test_known_models_have_display_names(self):
-        assert MODEL_DISPLAY_NAMES["claude-opus-4-6"] == "opus 4.6"
-        assert MODEL_DISPLAY_NAMES["claude-sonnet-4-6"] == "sonnet 4.6"
-        assert MODEL_DISPLAY_NAMES["claude-haiku-4-5"] == "haiku 4.5"
+        assert MODEL_DISPLAY_NAMES["claude-opus-4-6"] == "o4.6"
+        assert MODEL_DISPLAY_NAMES["claude-sonnet-4-6"] == "s4.6"
+        assert MODEL_DISPLAY_NAMES["claude-haiku-4-5"] == "h4.5"
 
 
 class TestUsageServiceGetModel:
@@ -42,7 +42,7 @@ class TestUsageServiceGetModel:
     def test_returns_display_name_for_known_model(self):
         tail = json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}}) + "\n"
         svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
-        assert svc.get_model("/Users/dev/myapp") == "opus 4.6"
+        assert svc.get_model("/Users/dev/myapp") == "o4.6"
 
     def test_returns_raw_model_for_unknown(self):
         tail = json.dumps({"type": "assistant", "message": {"model": "claude-future-99"}}) + "\n"
@@ -55,7 +55,7 @@ class TestUsageServiceGetModel:
             + json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}}) + "\n"
         )
         svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
-        assert svc.get_model("/Users/dev/myapp") == "opus 4.6"
+        assert svc.get_model("/Users/dev/myapp") == "o4.6"
 
     def test_handles_invalid_json_lines(self):
         tail = (
@@ -63,7 +63,7 @@ class TestUsageServiceGetModel:
             + json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}}) + "\n"
         )
         svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
-        assert svc.get_model("/Users/dev/myapp") == "opus 4.6"
+        assert svc.get_model("/Users/dev/myapp") == "o4.6"
 
     def test_handles_non_dict_message(self):
         tail = json.dumps({"type": "assistant", "message": "string"}) + "\n"


### PR DESCRIPTION
## Summary
- Shorten model display names: opus 4.6 → o4.6, sonnet 4.6 → s4.6, haiku 4.5 → h4.5
- Frees up space in the detail line for longer summary one-liners