### PR TITLE
Fix Pin→Bookmark UI text, welcome notification spam

### DIFF
--- a/claudewatch/backend/onboarding/service.py
+++ b/claudewatch/backend/onboarding/service.py
@@ -29,8 +29,8 @@ TIPS: dict[str, dict[str, str]] = {
         "message": "Click a session to focus its window.",
     },
     "pin": {
-        "title": "Tip: Pinned sessions",
-        "message": "Pinned sessions can be resumed later from \u2605 Pinned.",
+        "title": "Tip: Bookmarked sessions",
+        "message": "Bookmarked sessions can be resumed later from the Bookmarks menu.",
     },
     "hover": {
         "title": "Tip: Session actions",
@@ -45,6 +45,7 @@ class OnboardingService(BaseService):
     def __init__(self, notification_service: NotificationService) -> None:
         super().__init__()
         self._notification_service = notification_service
+        self._shown_this_session: set[str] = set()  # in-memory fallback
 
     def _shown_tips(self) -> list[str]:
         """Return the list of already-shown tip IDs."""
@@ -55,6 +56,7 @@ class OnboardingService(BaseService):
 
     def _mark_shown(self, tip_id: str) -> None:
         """Persist *tip_id* as shown so it is never delivered again."""
+        self._shown_this_session.add(tip_id)
         shown = self._shown_tips()
         if tip_id not in shown:
             shown.append(tip_id)
@@ -62,7 +64,7 @@ class OnboardingService(BaseService):
 
     def is_tip_shown(self, tip_id: str) -> bool:
         """Check whether *tip_id* has already been delivered."""
-        return tip_id in self._shown_tips()
+        return tip_id in self._shown_this_session or tip_id in self._shown_tips()
 
     def show_tip(self, tip_id: str) -> bool:
         """Deliver an onboarding tip if not already shown.

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -304,9 +304,9 @@ class ClaudeWatchApp:
                 app.activateIgnoringOtherApps_(True)
 
                 alert = NSAlert.alloc().init()
-                alert.setMessageText_("Pin Session")
+                alert.setMessageText_("Bookmark Session")
                 alert.setInformativeText_(f"Add a note for {project}:")
-                alert.addButtonWithTitle_("Pin")
+                alert.addButtonWithTitle_("Bookmark")
                 alert.addButtonWithTitle_("Generate Summary")
                 alert.addButtonWithTitle_("Cancel")
                 text_field = NSTextField.alloc().initWithFrame_(((0, 0), (350, 60)))

--- a/claudewatch/ui/preferences.py
+++ b/claudewatch/ui/preferences.py
@@ -72,7 +72,7 @@ _history_data: list[dict] = []
 
 # Sub-descriptions for feature toggles
 _FEATURE_DETAILS: dict[str, str] = {
-    "bookmarks": "Pin sessions to resume later from the menu bar.",
+    "bookmarks": "Save sessions to resume later from the menu bar.",
     "notifications": "Get alerts when Claude needs your attention.",
     "background_summaries": "Periodically regenerate session summaries in the background.",
     "auto_updates": "Check GitHub for new releases periodically.",


### PR DESCRIPTION
## Summary

- All remaining "Pin" text in UI → "Bookmark"
- Welcome notification spam fix: in-memory fallback prevents repeat tips even if NSUserDefaults fails to persist in .app bundle