### PR TITLE
refactor: overhaul .claude rules with path scoping

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,54 +1,8 @@
-## Layer Structure
-
-```
-backend/
-├── core/                       # Shared infrastructure — no imports from domains or ui/
-│   ├── models.py               # ClaudeSession, enums, constants
-│   ├── dto.py                  # BaseDTO + shared DTOs (frozen dataclasses, *DTO suffix)
-│   ├── helpers.py              # AppleScript runner, escaping
-│   ├── paths.py                # Centralized file paths
-│   ├── service.py              # BaseService base class
-│   ├── settings.py             # App settings (config — replaces repositories/config.py)
-│   ├── features.py             # Feature flags
-│   ├── process/                # ProcessService — PID lookup + child PID registry
-│   │   ├── service.py
-│   │   ├── dependencies.py     # get_process_service()
-│   │   └── procinfo.py         # libproc ctypes bindings (implementation detail)
-│   └── session_log/            # SessionLogService — JSONL discovery/reading
-│       ├── service.py
-│       ├── dependencies.py     # get_session_log_service()
-│       └── jsonl.py            # JSONL file operations (implementation detail)
-├── detection/                  # DetectionService — find running Claude sessions
-│   ├── service.py
-│   ├── constants.py            # Detection-specific constants
-│   └── dependencies.py         # get_detection_service()
-├── summary/                    # SummaryService — generate/cache session summaries
-│   ├── service.py
-│   └── dependencies.py         # get_summary_service()
-├── notifications/              # NotificationService — macOS notifications
-│   ├── service.py
-│   └── dependencies.py         # get_notification_service()
-├── onboarding/                 # OnboardingService — first-run tips
-│   ├── service.py
-│   └── dependencies.py         # get_onboarding_service()
-├── updates/                    # UpdateService — GitHub release checker + self-update
-│   ├── service.py
-│   └── dependencies.py         # get_update_service()
-├── usage/                      # UsageService — token counts, model names
-│   ├── service.py
-│   └── dependencies.py         # get_usage_service()
-├── activity/                   # ActivityService — session timeline from JSONL
-│   ├── service.py
-│   └── dependencies.py         # get_activity_service()
-├── bookmark/                   # BookmarkService — pinned session bookmarks
-│   ├── service.py
-│   ├── repository.py           # Bookmark persistence
-│   └── dependencies.py         # get_bookmark_service()
-└── history/                    # HistoryService — session history
-    ├── service.py
-    ├── repository.py           # History persistence
-    └── dependencies.py         # get_history_service()
-```
+---
+paths:
+  - "claudewatch/backend/**/*.py"
+  - "claudewatch/ui/**/*.py"
+---
 
 ## Import Rules
 
@@ -59,30 +13,21 @@ backend/
 | **domains** | YES | YES | peers (via deps) | NO |
 | **ui/** | YES (DTOs/models) | NO | YES (via deps) | self |
 
-- `BaseService` enforces import constraints at runtime via `ImportConstraint`.
-- Config is now in `core/settings.py` — accessible to all layers including UI.
+- Enforced statically via `scripts/audit_imports.py` (runs in CI).
 - UI imports services via `get_*_service()` factory functions from each domain's `dependencies.py`.
 
 ## Domain Package Convention
 
-Each domain is a Python package with:
-- `service.py` — service class extending `BaseService`, receives dependencies via constructor
+Each domain is a package with:
+- `service.py` — extends `BaseService`, receives dependencies via constructor
 - `dependencies.py` — `@lru_cache(maxsize=1)` factory function `get_*_service()` that wires dependencies
-
-Dependencies flow through factory functions, not direct construction. Example:
-```python
-# detection/dependencies.py
-@lru_cache(maxsize=1)
-def get_detection_service() -> DetectionService:
-    return DetectionService(get_process_service(), get_session_log_service())
-```
 
 ## DTO Convention
 
-- All DTOs inherit `BaseDTO` (frozen dataclass), suffixed with `DTO` (e.g. `PinDTO`, `HistoryEntryDTO`)
+- All DTOs inherit `BaseDTO` (frozen dataclass), suffixed with `DTO`
 - DTOs flow from services to UI across layer boundaries
-- `ClaudeSession` from `core/models.py` is the shared session model (not a DTO — it's mutable and used internally)
-- Services that wrap repos return DTOs, not raw dicts
+- `ClaudeSession` from `core/models.py` is the shared session model (mutable, internal)
+- Services return DTOs, not raw dicts
 
 ## Threading Rules
 

--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - ".github/**"
+  - "pyproject.toml"
+---
+
+- GitHub Actions must be pinned to commit hashes, not mutable tags. Comment the version for readability (e.g. `actions/checkout@abc123 # v4`).
+- Release workflow pushes a `v*` tag to build and attach `ClaudeWatch-vX.Y.Z-arm64.zip` to a GitHub Release. Tap update creates a PR on `homebrew-claudewatch`.
+- Always bump `version` in both `[project]` and `[tool.briefcase]` sections of pyproject.toml when tagging a release.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,5 +1,0 @@
-- Run `uv run ruff check .` and `uv run pytest` before committing.
-- Type hints on all functions.
-- No AI attribution in commits, PRs, code comments, or docs.
-- Conventional commit messages: `feat:`, `fix:`, `refactor:`, `docs:`, `style:`, `test:`, `chore:`.
-- **One branch per domain.** Each distinct feature or bug gets its own branch. Never combine unrelated changes in one branch/PR.

--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "pyproject.toml"
+  - "uv.lock"
+---
+
+- All dependencies must compile on macOS ARM (Apple Silicon). Verify before adding.
+- Use `uv` for dependency management. Never use `pip` directly.
+- PyObjC packages are excluded from `pip-audit` (they don't publish to the standard vulnerability DB).
+- Pin versions in `pyproject.toml`. Let `uv.lock` handle transitive resolution.
+- Briefcase bundles dependencies into the `.app` — any new dependency increases app size and attack surface. Justify additions.

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "claudewatch/backend/**/*.py"
+  - "claudewatch/ui/**/*.py"
+---
+
+- ClaudeWatch is a long-running menu bar process. Unhandled exceptions in polling loops kill the app silently — always catch and log.
+- Write errors to the audit log (`~/Library/Application Support/ClaudeWatch/claudewatch.log`) via Python `logging`. Never print to stdout.
+- User-facing errors (modal dialogs) are reserved for actions the user initiated (e.g. failed update). Background failures should log and retry on the next poll cycle.
+- Never retry in a tight loop. Polling-based services already have a natural retry interval via `NSTimer`.
+- If a JSONL file is corrupt or unreadable, skip it and log — never crash the app over one bad session file.

--- a/.claude/rules/license.md
+++ b/.claude/rules/license.md
@@ -1,1 +1,0 @@
-This project is MIT licensed. All contributions are subject to the same license.

--- a/.claude/rules/macos.md
+++ b/.claude/rules/macos.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "claudewatch/ui/**/*.py"
+  - "claudewatch/backend/core/helpers.py"
+  - "claudewatch/backend/detection/**/*.py"
+  - "claudewatch/backend/notifications/**/*.py"
+---
+
 - **Menu bar app uses direct AppKit** — `NSStatusBar`, `NSMenu`, `NSMenuItem`, `NSTimer`, `AppHelper.runEventLoop()`.
 - **Callback dispatch:** `_AppDelegate` maps `NSMenuItem` tags (integers) to Python callables. Use `_make_menu_item(title, callback, delegate)` to create items. Always clear `_callbacks` dict and reset `_next_tag` when rebuilding the menu to prevent leaks.
 - **NSObject subclasses must use `objc.super()`** — never use Python's `super()` in PyObjC classes. Pattern: `self = objc.super(ClassName, self).init()`.

--- a/.claude/rules/packaging.md
+++ b/.claude/rules/packaging.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "pyproject.toml"
+  - "icons/**"
+  - ".github/workflows/release.yml"
+---
+
 - **Briefcase** builds the `.app` bundle. Config is in `pyproject.toml` under `[tool.briefcase]`.
 - **Icon:** `icons/claudewatch.svg` — Briefcase generates all required sizes. Referenced via `icon = "icons/claudewatch"` (no extension) in pyproject.toml.
 - **Build commands:**
@@ -10,5 +17,4 @@
 - **`LSUIElement = true`** in Info.plist — menu-bar-only app, no dock icon.
 - **Entitlements:** `com.apple.security.cs.allow-unsigned-executable-memory` and `com.apple.security.cs.disable-library-validation` are required for PyObjC. These are set by the Briefcase template.
 - **TCC folder prompts** (Photos, Music, Downloads, etc.) are triggered by the Python framework startup, not our code. Users can safely deny them. This is a known BeeWare limitation.
-- **Release workflow** (`.github/workflows/release.yml`): push a `v*` tag to build and attach `ClaudeWatch-vX.Y.Z-arm64.zip` to a GitHub Release.
-- Always bump `version` in both `[project]` and `[tool.briefcase]` sections of pyproject.toml when tagging a release.
+- **Homebrew tap:** `wingatethomas/homebrew-claudewatch` — updated automatically via PR from the release workflow.

--- a/.claude/rules/privacy.md
+++ b/.claude/rules/privacy.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "claudewatch/**/*.py"
+---
+
+- ClaudeWatch reads `~/.claude/` session data. Never expose raw JSONL content to the user — only derived metadata (tool names, project names, timestamps, token counts).
+- Audit log (`~/Library/Application Support/ClaudeWatch/claudewatch.log`) must never contain session content, user prompts, or assistant responses.
+- Notifications must only contain tool names and project names. Never raw terminal buffer data. Truncation limit: 200 chars.
+- No network calls except to `api.github.com` for update checks. No telemetry, no analytics, no crash reporting.
+- Never add functionality that sends session data off-machine.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,6 +1,11 @@
+---
+paths:
+  - "claudewatch/backend/**/*.py"
+  - "claudewatch/ui/**/*.py"
+---
+
 - Never pass user-controlled strings (project names, window titles, paths) to shell commands without validation.
 - Session IDs must be validated as UUIDs before use in commands or clipboard content.
 - All values interpolated into AppleScript must go through `escape_applescript()` which strips control chars and escapes quotes. Exception: integer values (e.g. `window_id`) verified via `isdigit()` may be interpolated directly — add a comment noting the safety invariant.
 - JSONL file reads must validate the resolved path stays within `~/.claude/projects/` via `is_safe_jsonl_path()` in `jsonl.py`.
 - Notification content must never include raw terminal buffer data. Only tool names and project names. Truncation limit: 200 chars.
-- GitHub Actions must be pinned to commit hashes, not mutable tags. Comment the version for readability (e.g. `actions/checkout@abc123 # v4`).

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,5 +1,11 @@
+---
+paths:
+  - "tests/**/*.py"
+  - "claudewatch/backend/**/*.py"
+---
+
 - All pure functions in `backend/` should have tests.
-- CI enforces ≥75% backend coverage (`ui/` and `dependencies.py` files excluded).
+- CI enforces ≥70% backend coverage (`ui/` and `dependencies.py` files excluded).
 - CI runs pip-audit for dependency vulnerability scanning.
 - Tests must never call real system commands. Use `unittest.mock.patch` to mock external calls.
 - Use `tmp_path` fixture for tests that need filesystem state.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ logs/
 *.dmg
 .superpowers/
 docs/superpowers/
+homebrew-claudewatch/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,27 @@
 # ClaudeWatch
 
-Project rules are in `.claude/rules/`:
+MIT licensed. All contributions are subject to the same license.
 
-- `architecture.md` — layered structure, module responsibilities, threading model, data flow
-- `security.md` — input validation, AppleScript escaping, JSONL symlink protection, CI pinning
-- `code-style.md` — linting, commits, branching, attribution
-- `testing.md` — coverage, mocking, fixtures
-- `macos.md` — AppKit patterns, PyObjC delegate callbacks, window focus, NSImage safety
-- `packaging.md` — Briefcase builds, icon, entitlements, release workflow
-- `license.md` — MIT
+## Code Style
+
+- Run `uv run ruff check .` and `uv run pytest` before committing.
+- Type hints on all functions.
+- No AI attribution in commits, PRs, code comments, or docs.
+- Conventional commit messages: `feat:`, `fix:`, `refactor:`, `docs:`, `style:`, `test:`, `chore:`.
+- **One branch per domain.** Each distinct feature or bug gets its own branch. Never combine unrelated changes in one branch/PR.
+
+## Rules Index
+
+Path-scoped rules in `.claude/rules/` — only loaded when touching relevant files:
+
+| Rule | Scope | Purpose |
+|------|-------|---------|
+| `privacy.md` | `claudewatch/**` | Data handling, no telemetry, session content boundaries |
+| `security.md` | `backend/**`, `ui/**` | Input validation, AppleScript escaping, JSONL safety |
+| `error-handling.md` | `backend/**`, `ui/**` | Crash resilience, logging, retry strategy |
+| `architecture.md` | `backend/**`, `ui/**` | Import rules, DTOs, threading |
+| `testing.md` | `tests/**`, `backend/**` | Coverage, mocking, fixtures |
+| `macos.md` | `ui/**`, detection, notifications | AppKit patterns, PyObjC, window focus |
+| `packaging.md` | `pyproject.toml`, icons, release workflow | Briefcase builds, Homebrew tap |
+| `dependencies.md` | `pyproject.toml`, `uv.lock` | Dependency policy, ARM compat, `uv` usage |
+| `ci.md` | `.github/**`, `pyproject.toml` | Actions pinning, release process |


### PR DESCRIPTION
## Summary
- All rules now use `paths` frontmatter — only loaded when touching relevant files, saves context
- Added `privacy.md`, `error-handling.md`, `dependencies.md`, `ci.md`
- Folded `code-style.md` and `license.md` into `CLAUDE.md` (universal rules)
- Trimmed `architecture.md` — removed directory tree (Claude can `ls`), kept import rules and conventions
- Split CI/Actions rules out of `security.md` into `ci.md` with proper scoping
- Fixed stale rules: coverage threshold 75%→70%, import enforcement is static not runtime