### PR TITLE
ci: PR trigger with ready-to-merge label gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  pull_request:
+    types: [labeled, synchronize]
   workflow_dispatch:
     inputs:
       pr:
@@ -9,16 +11,23 @@ on:
         type: string
 
 concurrency:
-  group: ci-${{ github.event.inputs.pr || github.sha }}
+  group: ci-${{ github.event.pull_request.number || github.event.inputs.pr || github.sha }}
   cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   lint:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'ready to merge')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.inputs.pr && format('refs/pull/{0}/head', github.event.inputs.pr) || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.inputs.pr && format('refs/pull/{0}/head', github.event.inputs.pr) || github.ref }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
@@ -32,10 +41,12 @@ jobs:
   test:
     runs-on: macos-14
     needs: lint
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.inputs.pr && format('refs/pull/{0}/head', github.event.inputs.pr) || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.inputs.pr && format('refs/pull/{0}/head', github.event.inputs.pr) || github.ref }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
@@ -45,10 +56,15 @@ jobs:
 
   security:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'ready to merge')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.inputs.pr && format('refs/pull/{0}/head', github.event.inputs.pr) || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.inputs.pr && format('refs/pull/{0}/head', github.event.inputs.pr) || github.ref }}
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true


### PR DESCRIPTION
- CI triggers on PRs when `ready to merge` label is added or code is pushed (with label present)
- Top-level `permissions: {}`, each job scoped to `contents: read`
- Keeps `workflow_dispatch` for manual runs
- Concurrency key includes PR number for proper dedup