### PR TITLE
ci: auto-merge tap PRs after checksum validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,11 @@ jobs:
           git add Casks/claudewatch.rb
           git commit -m "bump claudewatch to ${VERSION}"
           git push -u origin "$BRANCH"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --repo wingatethomas/homebrew-claudewatch \
             --title "bump claudewatch to ${VERSION}" \
-            --body "Automated update from [release ${TAG}](https://github.com/wingatethomas/claudewatch/releases/tag/${TAG}). SHA256: \`${SHA256}\`"
+            --body "Automated update from [release ${TAG}](https://github.com/wingatethomas/claudewatch/releases/tag/${TAG}). SHA256: \`${SHA256}\`")
+          gh pr merge "$PR_URL" --auto --squash
         env:
           TAG: ${{ github.ref_name }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
Release workflow now enables auto-merge on tap PRs. Flow: release → create PR → CI validates checksum → auto-squash-merge.