### PR TITLE
chore: rename tap to homebrew-brews, add auto-merge

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -5,5 +5,5 @@ paths:
 ---
 
 - GitHub Actions must be pinned to commit hashes, not mutable tags. Comment the version for readability (e.g. `actions/checkout@abc123 # v4`).
-- Release workflow pushes a `v*` tag to build and attach `ClaudeWatch-vX.Y.Z-arm64.zip` to a GitHub Release. Tap update creates a PR on `homebrew-claudewatch`.
+- Release workflow pushes a `v*` tag to build and attach `ClaudeWatch-vX.Y.Z-arm64.zip` to a GitHub Release. Tap update creates a PR on `homebrew-brews`.
 - Always bump `version` in both `[project]` and `[tool.briefcase]` sections of pyproject.toml when tagging a release.

--- a/.claude/rules/packaging.md
+++ b/.claude/rules/packaging.md
@@ -17,4 +17,4 @@ paths:
 - **`LSUIElement = true`** in Info.plist — menu-bar-only app, no dock icon.
 - **Entitlements:** `com.apple.security.cs.allow-unsigned-executable-memory` and `com.apple.security.cs.disable-library-validation` are required for PyObjC. These are set by the Briefcase template.
 - **TCC folder prompts** (Photos, Music, Downloads, etc.) are triggered by the Python framework startup, not our code. Users can safely deny them. This is a known BeeWare limitation.
-- **Homebrew tap:** `wingatethomas/homebrew-claudewatch` — updated automatically via PR from the release workflow.
+- **Homebrew tap:** `wingatethomas/homebrew-brews` — updated automatically via PR from the release workflow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,9 @@ jobs:
         run: |
           VERSION="${TAG#v}"
           SHA256=$(awk '{print $1}' checksums.txt)
-          git clone https://github.com/wingatethomas/homebrew-claudewatch.git tap
+          git clone https://github.com/wingatethomas/homebrew-brews.git tap
           cd tap
-          git remote set-url origin "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/wingatethomas/homebrew-claudewatch.git"
+          git remote set-url origin "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/wingatethomas/homebrew-brews.git"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           BRANCH="bump-${VERSION}"
@@ -86,10 +86,11 @@ jobs:
           git add Casks/claudewatch.rb
           git commit -m "bump claudewatch to ${VERSION}"
           git push -u origin "$BRANCH"
-          gh pr create \
-            --repo wingatethomas/homebrew-claudewatch \
+          PR_URL=$(gh pr create \
+            --repo wingatethomas/homebrew-brews \
             --title "bump claudewatch to ${VERSION}" \
-            --body "Automated update from [release ${TAG}](https://github.com/wingatethomas/claudewatch/releases/tag/${TAG}). SHA256: \`${SHA256}\`"
+            --body "Automated update from [release ${TAG}](https://github.com/wingatethomas/claudewatch/releases/tag/${TAG}). SHA256: \`${SHA256}\`")
+          gh pr merge "$PR_URL" --auto --squash
         env:
           TAG: ${{ github.ref_name }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ logs/
 *.dmg
 .superpowers/
 docs/superpowers/
-homebrew-claudewatch/
+homebrew-brews/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ macOS menu bar app that monitors all your running [Claude Code](https://docs.ant
 ### Homebrew (recommended)
 
 ```bash
-brew tap wingatethomas/claudewatch
+brew tap wingatethomas/brews
 brew install --cask claudewatch
 ```
 


### PR DESCRIPTION
Updates all references from homebrew-claudewatch to homebrew-brews. Adds auto-merge for tap PRs after CI validation.