### PR TITLE
fix: prioritize active session summaries

### DIFF
--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -274,17 +274,21 @@ class SummaryService(BaseService):
 
     # -- Background refresh -------------------------------------------------
 
-    def track_session(self, cwd: str) -> None:
+    def track_session(self, cwd: str, *, urgent: bool = False) -> None:
         """Register a CWD for periodic background summary refresh.
 
-        If no summary exists yet, queues it for immediate generation.
+        If no summary exists yet, queues it for generation.
+        *urgent* sessions (Attention/Working) are inserted at the front of the queue.
         """
         with self._tracked_lock:
             self._tracked_cwds.add(cwd)
         if self.get_cached(cwd) is None:
             with self._priority_lock:
                 if cwd not in self._priority_queue:
-                    self._priority_queue.append(cwd)
+                    if urgent:
+                        self._priority_queue.insert(0, cwd)
+                    else:
+                        self._priority_queue.append(cwd)
         self._ensure_bg_thread()
 
     def pending_summary_count(self) -> int:

--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -325,7 +325,9 @@ class MenuBuilder:
             summary_sub.addItem_(make_menu_item("Generating…", None, d))
         else:
             summary_sub.addItem_(make_menu_item("Generating…", None, d))
-            self._app._summary_service.track_session(s.cwd)
+            self._app._summary_service.track_session(
+                s.cwd, urgent=s.status in (SessionStatus.ATTENTION, SessionStatus.WORKING)
+            )
         summary_item.setSubmenu_(summary_sub)
         sub.addItem_(summary_item)
         # Usage submenu with token breakdown + Activity link
@@ -342,7 +344,8 @@ class MenuBuilder:
         sub.addItem_(usage_item)
         sub.addItem_(NSMenuItem.separatorItem())
         # Track for background refresh (auto-generates summaries)
-        self._app._summary_service.track_session(s.cwd)
+        is_active = s.status in (SessionStatus.ATTENTION, SessionStatus.WORKING)
+        self._app._summary_service.track_session(s.cwd, urgent=is_active)
         if pinned:
             sub.addItem_(make_menu_item("Remove Bookmark", self._app._make_unbookmark_handler(s.cwd), d))
             sub.addItem_(make_menu_item("Quit session", self._app._make_quit_handler(s), d))


### PR DESCRIPTION
Attention/Working sessions jump to the front of the summary generation queue. Idle sessions generate after.