### PR TITLE
feat: Homebrew-aware update flow

### DIFF
--- a/claudewatch/backend/core/paths.py
+++ b/claudewatch/backend/core/paths.py
@@ -48,6 +48,15 @@ def _migrate_legacy_files() -> None:
                 log.warning("failed to migrate %s", old)
 
 
+_HOMEBREW_CASKROOM = "/opt/homebrew/Caskroom/claudewatch"
+_HOMEBREW_CASKROOM_INTEL = "/usr/local/Caskroom/claudewatch"
+
+
+def is_homebrew_install() -> bool:
+    """Check if ClaudeWatch was installed via Homebrew."""
+    return os.path.isdir(_HOMEBREW_CASKROOM) or os.path.isdir(_HOMEBREW_CASKROOM_INTEL)
+
+
 CLAUDE_PROJECTS_DIR = os.path.expanduser("~/.claude/projects")
 
 

--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -15,6 +15,7 @@ from AppKit import (
 from Foundation import NSRange
 
 from claudewatch.backend.core.models import ClaudeSession, SessionStatus
+from claudewatch.backend.core.paths import is_homebrew_install
 from claudewatch.backend.usage.service import MODEL_DISPLAY_NAMES, format_tokens_breakdown
 from claudewatch.ui.icons import (
     STATUS_COLORS,
@@ -71,13 +72,22 @@ class MenuBuilder:
         # Update available?
         update_info = self._app._update_service.get_cached()
         if update_info:
-            self._menu.addItem_(
-                make_menu_item(
-                    f"Update to {update_info.tag}",
-                    self._app._make_open_update_handler(),
-                    d,
+            if is_homebrew_install():
+                self._menu.addItem_(
+                    make_menu_item(
+                        f"Update to {update_info.tag} (brew)",
+                        self._app._copy_brew_update,
+                        d,
+                    )
                 )
-            )
+            else:
+                self._menu.addItem_(
+                    make_menu_item(
+                        f"Update to {update_info.tag}",
+                        self._app._make_open_update_handler(),
+                        d,
+                    )
+                )
             self._menu.addItem_(NSMenuItem.separatorItem())
 
         # Guide nudge — show until user clicks it or dismisses

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -17,6 +17,8 @@ from AppKit import (
     NSApplicationActivationPolicyAccessory,
     NSMenu,
     NSMenuItem,
+    NSPasteboard,
+    NSPasteboardTypeString,
     NSStatusBar,
     NSTextField,
     NSTimer,
@@ -462,6 +464,23 @@ class ClaudeWatchApp:
                 webbrowser.open("https://github.com/wingatethomas/claudewatch/releases/latest")
 
         return handler
+
+    def _copy_brew_update(self, _: NSMenuItem) -> None:
+        """Copy the brew upgrade command to clipboard."""
+        cmd = "brew upgrade --cask claudewatch"
+        pb = NSPasteboard.generalPasteboard()
+        pb.clearContents()
+        pb.setString_forType_(cmd, NSPasteboardTypeString)
+
+        update_info = self._update_service.get_cached()
+        tag = update_info.tag if update_info else ""
+        app = NSApplication.sharedApplication()
+        app.activateIgnoringOtherApps_(True)
+        alert = NSAlert.alloc().init()
+        alert.setMessageText_(f"Update to {tag}")
+        alert.setInformativeText_(f"Copied to clipboard:\n\n{cmd}\n\nPaste this in your terminal to update.")
+        alert.addButtonWithTitle_("OK")
+        alert.runModal()
 
     def _open_accessibility(self, _: NSMenuItem) -> None:
         """Open System Settings to the Accessibility pane."""


### PR DESCRIPTION
- Detects Homebrew install via Caskroom directory
- Shows "Update to vX.Y.Z (brew)" instead of self-update
- Clicking copies `brew upgrade --cask claudewatch` to clipboard with confirmation dialog
- Non-Homebrew installs keep the existing self-update flow