### PR TITLE
docs: add missing features to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ Click any session to focus its window. Hover for actions: Activity log, Bookmark
 - **Notifications** — native macOS alerts when sessions need attention, with context about what's being asked
 - **Session summaries** — auto-generated titles and bulleted action summaries
 - **Token usage** — per-session and aggregated usage stats with top sessions breakdown
+- **Launch at login** — optional auto-start via Preferences
 - **Self-update** — checks GitHub Releases periodically, one-click update from the menu
-- **Preferences** — sidebar settings with feature toggles, session history with search/sort/filter, usage dashboard, changelog
+- **Changelog** — "What's New" viewer in Preferences, pulled from GitHub Releases
+- **Getting started guide** — onboarding tips for new users, replayable from the menu
+- **Preferences** — sidebar settings with feature toggles, session history with search/sort/filter, usage dashboard
 
 ### Permissions
 


### PR DESCRIPTION
Adds launch at login, changelog viewer, and getting started guide to the features list.