### PR TITLE
refactor: typed models across all backend domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,8 @@ Click any session to focus its window. Hover for actions: Activity log, Bookmark
 - **Notifications** — native macOS alerts when sessions need attention, with context about what's being asked
 - **Session summaries** — auto-generated titles and bulleted action summaries
 - **Token usage** — per-session and aggregated usage stats with top sessions breakdown
-- **Launch at login** — optional auto-start via Preferences
 - **Self-update** — checks GitHub Releases periodically, one-click update from the menu
-- **Changelog** — "What's New" viewer in Preferences, pulled from GitHub Releases
-- **Getting started guide** — onboarding tips for new users, replayable from the menu
-- **Preferences** — sidebar settings with feature toggles, session history with search/sort/filter, usage dashboard
+- **Preferences** — sidebar settings with feature toggles, session history with search/sort/filter, usage dashboard, changelog
 
 ### Permissions
 

--- a/claudewatch/backend/bookmark/repository.py
+++ b/claudewatch/backend/bookmark/repository.py
@@ -4,8 +4,10 @@ import json
 import logging
 import os
 from datetime import UTC, datetime
+from typing import TypedDict
 
 from claudewatch.backend.core import features
+from claudewatch.backend.core.dto import BookmarkDTO
 from claudewatch.backend.core.paths import PINS_PATH
 
 log = logging.getLogger("claudewatch")
@@ -13,7 +15,15 @@ log = logging.getLogger("claudewatch")
 _PATH = PINS_PATH
 
 
-def _load() -> list[dict]:
+class _BookmarkRecord(TypedDict):
+    session_id: str
+    project: str
+    cwd: str
+    note: str
+    timestamp: str
+
+
+def _load() -> list[_BookmarkRecord]:
     try:
         with open(_PATH) as f:
             data = json.load(f)
@@ -44,7 +54,7 @@ def _load() -> list[dict]:
     return alive
 
 
-def _save(pins: list[dict]) -> None:
+def _save(pins: list[_BookmarkRecord]) -> None:
     tmp = _PATH + ".tmp"
     try:
         with open(tmp, "w") as f:
@@ -59,7 +69,7 @@ def add_bookmark(session_id: str, project: str, cwd: str, note: str) -> None:
     bookmarks = _load()
     ts = datetime.now(tz=UTC).isoformat()
     for entry in bookmarks:
-        if isinstance(entry, dict) and entry.get("cwd") == cwd:
+        if entry["cwd"] == cwd:
             entry["session_id"] = session_id
             entry["note"] = note
             entry["timestamp"] = ts
@@ -67,33 +77,42 @@ def add_bookmark(session_id: str, project: str, cwd: str, note: str) -> None:
             log.info("bookmark.updated project=%s", project)
             return
     bookmarks.append(
-        {
-            "session_id": session_id,
-            "project": project,
-            "cwd": cwd,
-            "note": note,
-            "timestamp": ts,
-        }
+        _BookmarkRecord(
+            session_id=session_id,
+            project=project,
+            cwd=cwd,
+            note=note,
+            timestamp=ts,
+        )
     )
     _save(bookmarks)
     log.info("bookmark.created project=%s", project)
 
 
-def get_bookmarks() -> list[dict]:
-    """Return all bookmarked sessions."""
-    return _load()
+def get_bookmarks() -> list[BookmarkDTO]:
+    """Return all bookmarked sessions as DTOs."""
+    return [
+        BookmarkDTO(
+            session_id=p.get("session_id", ""),
+            project=p.get("project", ""),
+            cwd=p.get("cwd", ""),
+            note=p.get("note", ""),
+            timestamp=p.get("timestamp", ""),
+        )
+        for p in _load()
+    ]
 
 
 def get_bookmarked_cwds() -> set[str]:
     """Return the set of CWDs that are bookmarked."""
-    return {p.get("cwd", "") for p in _load() if isinstance(p, dict)}
+    return {p["cwd"] for p in _load()}
 
 
 def remove_bookmark(cwd: str) -> None:
     """Remove a bookmark by CWD."""
     bookmarks = _load()
     before = len(bookmarks)
-    bookmarks = [p for p in bookmarks if not (isinstance(p, dict) and p.get("cwd") == cwd)]
+    bookmarks = [p for p in bookmarks if p["cwd"] != cwd]
     if len(bookmarks) < before:
         log.info("bookmark.removed cwd=%s", cwd)
     _save(bookmarks)

--- a/claudewatch/backend/bookmark/service.py
+++ b/claudewatch/backend/bookmark/service.py
@@ -18,16 +18,7 @@ class BookmarkService(BaseService):
 
     def get_all(self) -> list[BookmarkDTO]:
         """Return all bookmarked sessions as DTOs."""
-        return [
-            BookmarkDTO(
-                session_id=p.get("session_id", ""),
-                project=p.get("project", ""),
-                cwd=p.get("cwd", ""),
-                note=p.get("note", ""),
-                timestamp=p.get("timestamp", ""),
-            )
-            for p in bookmarks_repo.get_bookmarks()
-        ]
+        return bookmarks_repo.get_bookmarks()
 
     def get_bookmarked_cwds(self) -> set[str]:
         """Return the set of CWDs that are currently bookmarked."""

--- a/claudewatch/backend/core/dto.py
+++ b/claudewatch/backend/core/dto.py
@@ -56,3 +56,25 @@ class ActivityEventDTO(BaseDTO):
     summary: str
     detail: str
     timestamp: str
+
+
+@dataclass(frozen=True)
+class TokenUsageDTO(BaseDTO):
+    """Token usage breakdown for a session."""
+
+    input: int
+    output: int
+    cache_create: int
+    cache_read: int
+
+    @property
+    def total(self) -> int:
+        return self.input + self.output + self.cache_create + self.cache_read
+
+
+@dataclass(frozen=True)
+class ChangelogEntryDTO(BaseDTO):
+    """A single release changelog entry."""
+
+    tag: str
+    body: str

--- a/claudewatch/backend/core/process/models.py
+++ b/claudewatch/backend/core/process/models.py
@@ -1,0 +1,24 @@
+"""Typed models for process inspection data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProcessInfo:
+    """Process info from libproc: tty, parent PID, and executable path."""
+
+    tty: str
+    ppid: int
+    comm: str
+
+
+@dataclass(frozen=True)
+class ProcessEntry:
+    """Full process entry including PID, for list_all_processes results."""
+
+    pid: int
+    tty: str
+    ppid: int
+    comm: str

--- a/claudewatch/backend/core/process/procinfo.py
+++ b/claudewatch/backend/core/process/procinfo.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import ctypes
 import ctypes.util
 
+from claudewatch.backend.core.process.models import ProcessEntry, ProcessInfo
+
 # ---------------------------------------------------------------------------
 # libproc bindings
 # ---------------------------------------------------------------------------
@@ -135,16 +137,16 @@ def _dev_to_tty(dev: int) -> str:
 # ---------------------------------------------------------------------------
 
 
-def get_process_info(pids: list[int]) -> dict[int, dict]:
+def get_process_info(pids: list[int]) -> dict[int, ProcessInfo]:
     """Get tty, ppid, and full executable path for a list of PIDs.
 
-    Returns a dict mapping PID -> {"tty": str, "ppid": int, "comm": str}.
+    Returns a dict mapping PID -> ProcessInfo.
     Replacement for ``ps -o pid=,tty=,ppid=,comm= -p <pids>``.
     """
     if not pids:
         return {}
 
-    result: dict[int, dict] = {}
+    result: dict[int, ProcessInfo] = {}
     info_buf = ctypes.create_string_buffer(_TASKALLINFO_SIZE)
 
     for pid in pids:
@@ -165,11 +167,7 @@ def get_process_info(pids: list[int]) -> dict[int, dict]:
         tty = _dev_to_tty(tdev)
         comm = _proc_pidpath(pid)
 
-        result[pid] = {
-            "tty": tty,
-            "ppid": ppid,
-            "comm": comm,
-        }
+        result[pid] = ProcessInfo(tty=tty, ppid=ppid, comm=comm)
 
     return result
 
@@ -228,7 +226,7 @@ def get_ppid(pid: int) -> int:
     return int.from_bytes(raw[_PBSD_PPID_OFFSET : _PBSD_PPID_OFFSET + 4], "little")
 
 
-def get_single_process_info(pid: int) -> dict | None:
+def get_single_process_info(pid: int) -> ProcessInfo | None:
     """Get tty, ppid, and comm for a single PID.
 
     Replacement for ``ps -o ppid=,comm= -p <pid>``. Returns None on failure.
@@ -248,16 +246,16 @@ def get_single_process_info(pid: int) -> dict | None:
     tdev = int.from_bytes(raw[_PBSD_TDEV_OFFSET : _PBSD_TDEV_OFFSET + 4], "little")
     tty = _dev_to_tty(tdev)
     comm = _proc_pidpath(pid)
-    return {"tty": tty, "ppid": ppid, "comm": comm}
+    return ProcessInfo(tty=tty, ppid=ppid, comm=comm)
 
 
-def list_all_processes() -> list[dict]:
+def list_all_processes() -> list[ProcessEntry]:
     """Return pid, ppid, tty, comm for every process on the system.
 
     Replacement for ``ps -eo pid,ppid,tty,comm``.
     """
     all_pids = _list_all_pids()
-    result: list[dict] = []
+    result: list[ProcessEntry] = []
     info_buf = ctypes.create_string_buffer(_TASKALLINFO_SIZE)
 
     for pid in all_pids:
@@ -275,6 +273,6 @@ def list_all_processes() -> list[dict]:
         tdev = int.from_bytes(raw[_PBSD_TDEV_OFFSET : _PBSD_TDEV_OFFSET + 4], "little")
         tty = _dev_to_tty(tdev)
         comm = _proc_pidpath(pid)
-        result.append({"pid": pid, "ppid": ppid, "tty": tty, "comm": comm})
+        result.append(ProcessEntry(pid=pid, tty=tty, ppid=ppid, comm=comm))
 
     return result

--- a/claudewatch/backend/core/process/service.py
+++ b/claudewatch/backend/core/process/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 
 from claudewatch.backend.core.process import procinfo
+from claudewatch.backend.core.process.models import ProcessEntry, ProcessInfo
 from claudewatch.backend.core.service import BaseService
 
 
@@ -25,11 +26,11 @@ class ProcessService(BaseService):
     # Process inspection (delegates to procinfo)
     # ------------------------------------------------------------------
 
-    def list_all(self) -> list[dict]:
+    def list_all(self) -> list[ProcessEntry]:
         """Return pid, ppid, tty, comm for every process on the system."""
         return procinfo.list_all_processes()
 
-    def get_info(self, pids: list[int]) -> dict[int, dict]:
+    def get_info(self, pids: list[int]) -> dict[int, ProcessInfo]:
         """Get tty, ppid, and full executable path for a list of PIDs."""
         return procinfo.get_process_info(pids)
 
@@ -41,7 +42,7 @@ class ProcessService(BaseService):
         """Get the parent PID for a single process. Returns 0 on failure."""
         return procinfo.get_ppid(pid)
 
-    def get_single_info(self, pid: int) -> dict | None:
+    def get_single_info(self, pid: int) -> ProcessInfo | None:
         """Get tty, ppid, and comm for a single PID. Returns None on failure."""
         return procinfo.get_single_process_info(pid)
 

--- a/claudewatch/backend/detection/models.py
+++ b/claudewatch/backend/detection/models.py
@@ -1,0 +1,41 @@
+"""Typed models for detection-internal data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from claudewatch.backend.core.models import HostApp
+
+
+@dataclass(frozen=True)
+class PendingToolResult:
+    """Result of checking JSONL for a pending tool_use."""
+
+    has_pending: bool
+    one_line: str
+    context: str
+
+
+@dataclass(frozen=True)
+class ToolUseInfo:
+    """Formatted tool_use display strings."""
+
+    one_line: str
+    context: str
+
+
+@dataclass(frozen=True)
+class PromptInfo:
+    """Extracted permission prompt context from terminal buffer."""
+
+    one_line: str
+    context: str
+
+
+@dataclass(frozen=True)
+class TerminalMatch:
+    """Result of matching a session to a Terminal.app window."""
+
+    window_title: str
+    window_id: int | None
+    host_app: HostApp

--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -10,10 +10,12 @@ from claudewatch.backend.core.models import (
     HostApp,
     SessionStatus,
 )
+from claudewatch.backend.core.process.models import ProcessInfo
 from claudewatch.backend.core.process.service import ProcessService
 from claudewatch.backend.core.service import BaseService
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.detection.constants import HOST_PROCESS_NAMES, IDLE_INDICATOR, PROMPT_KEYWORDS
+from claudewatch.backend.detection.models import PendingToolResult, PromptInfo, TerminalMatch, ToolUseInfo
 
 log = logging.getLogger("claudewatch")
 
@@ -51,7 +53,7 @@ class DetectionService(BaseService):
 
     # -- Process info helpers -----------------------------------------------
 
-    def _batch_ps_info(self, pids: list[int]) -> dict[int, dict]:
+    def _batch_ps_info(self, pids: list[int]) -> dict[int, ProcessInfo]:
         """Get tty + ppid + comm for all PIDs via native libproc calls."""
         return self._process_service.get_info(pids)
 
@@ -99,7 +101,7 @@ class DetectionService(BaseService):
 
     # -- Host app detection -------------------------------------------------
 
-    def _detect_host_app(self, pid: int, all_ps: dict[int, dict]) -> HostApp:
+    def _detect_host_app(self, pid: int, all_ps: dict[int, ProcessInfo]) -> HostApp:
         """Walk PPID chain to find the host app. Results are cached by PID."""
         if pid in self._host_app_cache:
             return self._host_app_cache[pid]
@@ -107,7 +109,7 @@ class DetectionService(BaseService):
         current = pid
         for _ in range(20):
             info = all_ps.get(current)
-            ppid = info["ppid"] if info else 0
+            ppid = info.ppid if info else 0
 
             if not ppid:
                 ppid = self._process_service.get_ppid(current)
@@ -116,17 +118,17 @@ class DetectionService(BaseService):
                 break
 
             if ppid in all_ps:
-                comm = os.path.basename(all_ps[ppid]["comm"])
+                comm = os.path.basename(all_ps[ppid].comm)
             else:
                 pinfo = self._process_service.get_single_info(ppid)
                 if pinfo:
-                    parent_ppid = pinfo["ppid"]
-                    raw_comm = pinfo["comm"]
+                    parent_ppid = pinfo.ppid
+                    raw_comm = pinfo.comm
                 else:
                     parent_ppid = 0
                     raw_comm = ""
                 comm = os.path.basename(raw_comm)
-                all_ps[ppid] = {"tty": "", "ppid": parent_ppid, "comm": raw_comm}
+                all_ps[ppid] = ProcessInfo(tty="", ppid=parent_ppid, comm=raw_comm)
 
             comm_lower = comm.lower()
             if comm_lower.startswith("tmux"):
@@ -143,7 +145,7 @@ class DetectionService(BaseService):
 
     # -- IDE tab indices ----------------------------------------------------
 
-    def _get_ide_tab_indices(self, sessions: list[ClaudeSession], all_ps: dict[int, dict]) -> None:  # noqa: PLR0912
+    def _get_ide_tab_indices(self, sessions: list[ClaudeSession], all_ps: dict[int, ProcessInfo]) -> None:  # noqa: PLR0912
         """Map IDE terminal sessions to their tab indices using the process tree."""
         ide_sessions = [s for s in sessions if s.host_app in (HostApp.PYCHARM, HostApp.VSCODE)]
         if not ide_sessions:
@@ -154,14 +156,14 @@ class DetectionService(BaseService):
             current = s.pid
             for _ in range(20):
                 info = all_ps.get(current)
-                ppid = info["ppid"] if info else 0
+                ppid = info.ppid if info else 0
                 if ppid <= 1:
                     break
                 if ppid in all_ps:
-                    comm = os.path.basename(all_ps[ppid]["comm"]).lower()
+                    comm = os.path.basename(all_ps[ppid].comm).lower()
                 else:
                     pinfo = self._process_service.get_single_info(ppid)
-                    comm = os.path.basename(pinfo["comm"]).lower() if pinfo else ""
+                    comm = os.path.basename(pinfo.comm).lower() if pinfo else ""
                 if "pycharm" in comm or "idea" in comm or comm == "code" or "electron" in comm:
                     ide_pids.add(ppid)
                     break
@@ -174,11 +176,11 @@ class DetectionService(BaseService):
         shell_names = {"sh", "bash", "zsh", "fish", "dash", "tcsh", "ksh"}
         ide_shells: list[tuple[int, str]] = []
         for proc in all_procs:
-            child_ppid = proc["ppid"]
-            child_tty = proc["tty"]
-            child_comm = os.path.basename(proc["comm"])
+            child_ppid = proc.ppid
+            child_tty = proc.tty
+            child_comm = os.path.basename(proc.comm)
             if child_ppid in ide_pids and child_tty != "??" and child_comm in shell_names:
-                ide_shells.append((proc["pid"], child_tty))
+                ide_shells.append((proc.pid, child_tty))
 
         ide_shells.sort(key=lambda x: x[0])
         tty_to_index = {tty: i for i, (_, tty) in enumerate(ide_shells)}
@@ -225,22 +227,23 @@ class DetectionService(BaseService):
         path = self._session_log_service.find_most_recent(cwd)
         return self._session_log_service.get_session_id(path) if path else ""
 
-    def _check_jsonl_for_pending_tool(self, cwd: str) -> tuple[bool, str, str]:  # noqa: PLR0911, PLR0912
+    def _check_jsonl_for_pending_tool(self, cwd: str) -> PendingToolResult:  # noqa: PLR0911, PLR0912
         """Check if the most recent JSONL for this CWD has a pending tool_use."""
+        _empty = PendingToolResult(has_pending=False, one_line="", context="")
         path = self._session_log_service.find_most_recent(cwd)
         if not path:
-            return False, "", ""
+            return _empty
 
         try:
             age = time.time() - os.path.getmtime(path)
             if age > _JSONL_MAX_AGE or age < _JSONL_MIN_AGE:
-                return False, "", ""
+                return _empty
         except OSError:
-            return False, "", ""
+            return _empty
 
         tail = self._session_log_service.read_tail(path)
         if not tail:
-            return False, "", ""
+            return _empty
 
         lines = tail.strip().splitlines()
         for line in reversed(lines[-20:]):
@@ -252,31 +255,31 @@ class DetectionService(BaseService):
                     continue
 
                 if dtype == "user":
-                    return False, "", ""
+                    return _empty
 
                 if dtype == "assistant":
                     content = d.get("message", {}).get("content", [])
                     tool_uses = [b for b in content if isinstance(b, dict) and b.get("type") == "tool_use"]
                     if tool_uses:
-                        one_line, ctx = _format_tool_use(tool_uses[-1])
-                        return True, one_line, ctx
-                    return False, "", ""
+                        info = _format_tool_use(tool_uses[-1])
+                        return PendingToolResult(has_pending=True, one_line=info.one_line, context=info.context)
+                    return _empty
 
                 if dtype == "progress":
                     msg = d["data"]["message"]
                     if msg.get("type") == "user":
-                        return False, "", ""
+                        return _empty
                     if msg.get("type") == "assistant":
                         content = msg.get("message", {}).get("content", [])
                         tool_uses = [b for b in content if isinstance(b, dict) and b.get("type") == "tool_use"]
                         if tool_uses:
-                            one_line, ctx = _format_tool_use(tool_uses[-1])
-                            return True, one_line, ctx
-                        return False, "", ""
+                            info = _format_tool_use(tool_uses[-1])
+                            return PendingToolResult(has_pending=True, one_line=info.one_line, context=info.context)
+                        return _empty
 
             except (json.JSONDecodeError, KeyError, TypeError):
                 continue
-        return False, "", ""
+        return _empty
 
     # -- Main detection entry point -----------------------------------------
 
@@ -316,19 +319,19 @@ class DetectionService(BaseService):
             info = all_ps.get(pid)
             if not info:
                 continue
-            tty = info["tty"]
+            tty = info.tty
             if tty == "??":
-                walk_pid = info["ppid"]
+                walk_pid = info.ppid
                 for _ in range(5):
                     if walk_pid <= 1:
                         break
                     parent = self._process_service.get_single_info(walk_pid)
                     if not parent:
                         break
-                    if parent["tty"] != "??":
-                        tty = parent["tty"]
+                    if parent.tty != "??":
+                        tty = parent.tty
                         break
-                    walk_pid = parent["ppid"]
+                    walk_pid = parent.ppid
             cwd = cwds.get(pid, "")
             project = os.path.basename(cwd) if cwd else ""
             if not project:
@@ -344,12 +347,15 @@ class DetectionService(BaseService):
             if host_app in (HostApp.TERMINAL, HostApp.TMUX, HostApp.OTHER):
                 if terminal_windows is None:
                     terminal_windows = self._get_terminal_windows()
-                window_title, window_id, host_app = _match_terminal_window(
+                match = _match_terminal_window(
                     tty,
                     project,
                     host_app,
                     terminal_windows,
                 )
+                window_title = match.window_title
+                window_id = match.window_id
+                host_app = match.host_app
 
             status = _determine_status(window_title)
 
@@ -372,11 +378,11 @@ class DetectionService(BaseService):
         checked_cwds: set[str] = set()
         for s in sessions:
             if s.cwd and s.cwd not in checked_cwds:
-                pending, one_line, context = self._check_jsonl_for_pending_tool(s.cwd)
-                if pending:
+                tool_result = self._check_jsonl_for_pending_tool(s.cwd)
+                if tool_result.has_pending:
                     s.status = SessionStatus.ATTENTION
-                    s.prompt_text = one_line
-                    s.prompt_context = context
+                    s.prompt_text = tool_result.one_line
+                    s.prompt_context = tool_result.context
                 elif s.status != SessionStatus.IDLE:
                     s.status = self._check_jsonl_for_idle(s.cwd)
                 checked_cwds.add(s.cwd)
@@ -404,9 +410,9 @@ def _extract_last_output(buffer: str) -> str:
     return ""
 
 
-def _extract_prompt_info(buffer: str) -> tuple[str, str]:
+def _extract_prompt_info(buffer: str) -> PromptInfo:
     """Extract permission prompt context from the terminal buffer.
-    Returns (one_line_summary, full_context) for menu and alert respectively."""
+    Returns PromptInfo with one_line summary and full context."""
     lines = buffer.splitlines()
     prompt_line_idx = None
 
@@ -417,7 +423,7 @@ def _extract_prompt_info(buffer: str) -> tuple[str, str]:
             break
 
     if prompt_line_idx is None:
-        return "", ""
+        return PromptInfo(one_line="", context="")
 
     block_start = prompt_line_idx
     one_line = ""
@@ -442,11 +448,11 @@ def _extract_prompt_info(buffer: str) -> tuple[str, str]:
     if one_line and len(one_line) > _TEXT_MAX_LEN:
         one_line = one_line[:77] + "..."
 
-    return one_line, full_context
+    return PromptInfo(one_line=one_line, context=full_context)
 
 
-def _format_tool_use(tool: dict) -> tuple[str, str]:
-    """Format a tool_use block into (one_line, full_context)."""
+def _format_tool_use(tool: dict) -> ToolUseInfo:
+    """Format a tool_use block into ToolUseInfo with one_line and context."""
     name = tool.get("name", "Unknown")
     inp = tool.get("input", {})
     one_line = name
@@ -463,7 +469,7 @@ def _format_tool_use(tool: dict) -> tuple[str, str]:
             context_parts.append(f"Pattern: {inp['pattern']}")
     if len(one_line) > _TEXT_MAX_LEN:
         one_line = one_line[:77] + "..."
-    return one_line, "\n".join(context_parts)
+    return ToolUseInfo(one_line=one_line, context="\n".join(context_parts))
 
 
 def _determine_status(window_title: str) -> SessionStatus:
@@ -478,20 +484,20 @@ def _match_terminal_window(
     project: str,
     host_app: HostApp,
     terminal_windows: dict[str, tuple[str, int]],
-) -> tuple[str, int | None, HostApp]:
+) -> TerminalMatch:
     """Try to match a session to a Terminal.app window by TTY or project name.
-    Returns (window_title, window_id, possibly-updated host_app)."""
+    Returns TerminalMatch with window_title, window_id, and possibly-updated host_app."""
     full_tty = tty if tty.startswith("/dev/") else f"/dev/{tty}"
 
     if full_tty in terminal_windows:
         title, wid = terminal_windows[full_tty]
         if host_app == HostApp.OTHER:
             host_app = HostApp.TERMINAL
-        return title, wid, host_app
+        return TerminalMatch(window_title=title, window_id=wid, host_app=host_app)
 
     if host_app == HostApp.TMUX:
         for _, (tw_title, tw_wid) in terminal_windows.items():
             if project in tw_title:
-                return tw_title, tw_wid, host_app
+                return TerminalMatch(window_title=tw_title, window_id=tw_wid, host_app=host_app)
 
-    return host_app.value, None, host_app
+    return TerminalMatch(window_title=host_app.value, window_id=None, host_app=host_app)

--- a/claudewatch/backend/history/repository.py
+++ b/claudewatch/backend/history/repository.py
@@ -4,7 +4,9 @@ import json
 import logging
 import os
 from datetime import UTC, datetime
+from typing import TypedDict
 
+from claudewatch.backend.core.dto import HistoryEntryDTO
 from claudewatch.backend.core.paths import CLAUDE_PROJECTS_DIR, HISTORY_PATH, proj_key_to_cwd
 from claudewatch.backend.core.session_log.jsonl import is_safe_jsonl_path, read_jsonl_tail
 
@@ -14,7 +16,16 @@ _PATH = HISTORY_PATH
 _MAX_ENTRIES = 50
 
 
-def _load() -> list[dict]:
+class _HistoryRecord(TypedDict):
+    session_id: str
+    project: str
+    cwd: str
+    model: str
+    host_app: str
+    ended_at: str
+
+
+def _load() -> list[_HistoryRecord]:
     try:
         with open(_PATH) as f:
             data = json.load(f)
@@ -29,7 +40,7 @@ def _load() -> list[dict]:
     return data
 
 
-def _save(entries: list[dict]) -> None:
+def _save(entries: list[_HistoryRecord]) -> None:
     tmp = _PATH + ".tmp"
     try:
         with open(tmp, "w") as f:
@@ -44,16 +55,16 @@ def record_session(session_id: str, project: str, cwd: str, model: str, host_app
     entries = _load()
     ts = datetime.now(tz=UTC).isoformat()
     # Remove existing entry for same CWD (keep only latest)
-    entries = [e for e in entries if not (isinstance(e, dict) and e.get("cwd") == cwd)]
+    entries = [e for e in entries if e["cwd"] != cwd]
     entries.append(
-        {
-            "session_id": session_id,
-            "project": project,
-            "cwd": cwd,
-            "model": model,
-            "host_app": host_app,
-            "ended_at": ts,
-        }
+        _HistoryRecord(
+            session_id=session_id,
+            project=project,
+            cwd=cwd,
+            model=model,
+            host_app=host_app,
+            ended_at=ts,
+        )
     )
     # Cap at max
     if len(entries) > _MAX_ENTRIES:
@@ -62,20 +73,30 @@ def record_session(session_id: str, project: str, cwd: str, model: str, host_app
     log.info("history.recorded project=%s", project)
 
 
-def get_history() -> list[dict]:
+def get_history() -> list[HistoryEntryDTO]:
     """Return session history, newest first. Seeds from JSONL on first call."""
     entries = _load()
     if not entries:
         entries = _seed_from_jsonl()
-    return list(reversed(entries))
+    return [
+        HistoryEntryDTO(
+            session_id=e.get("session_id", ""),
+            project=e.get("project", ""),
+            cwd=e.get("cwd", ""),
+            model=e.get("model", ""),
+            host_app=e.get("host_app", ""),
+            ended_at=e.get("ended_at", ""),
+        )
+        for e in reversed(entries)
+    ]
 
 
-def _seed_from_jsonl() -> list[dict]:
+def _seed_from_jsonl() -> list[_HistoryRecord]:
     """Scan ~/.claude/projects/ for existing sessions and populate history."""
     if not os.path.isdir(CLAUDE_PROJECTS_DIR):
         return []
 
-    entries: list[dict] = []
+    entries: list[_HistoryRecord] = []
     try:
         for proj_key in os.listdir(CLAUDE_PROJECTS_DIR):
             proj_dir = os.path.join(CLAUDE_PROJECTS_DIR, proj_key)
@@ -106,19 +127,19 @@ def _seed_from_jsonl() -> list[dict]:
 
             mtime = os.path.getmtime(jsonl_path)
             entries.append(
-                {
-                    "session_id": session_id,
-                    "project": project,
-                    "cwd": cwd,
-                    "model": model,
-                    "host_app": "Terminal",
-                    "ended_at": datetime.fromtimestamp(mtime, tz=UTC).isoformat(),
-                }
+                _HistoryRecord(
+                    session_id=session_id,
+                    project=project,
+                    cwd=cwd,
+                    model=model,
+                    host_app="Terminal",
+                    ended_at=datetime.fromtimestamp(mtime, tz=UTC).isoformat(),
+                )
             )
     except OSError:
         return []
 
-    entries.sort(key=lambda e: e.get("ended_at", ""))
+    entries.sort(key=lambda e: e["ended_at"])
     if len(entries) > _MAX_ENTRIES:
         entries = entries[-_MAX_ENTRIES:]
     _save(entries)
@@ -129,5 +150,5 @@ def _seed_from_jsonl() -> list[dict]:
 def remove_history_entry(cwd: str) -> None:
     """Remove a history entry by CWD."""
     entries = _load()
-    entries = [e for e in entries if not (isinstance(e, dict) and e.get("cwd") == cwd)]
+    entries = [e for e in entries if e["cwd"] != cwd]
     _save(entries)

--- a/claudewatch/backend/history/service.py
+++ b/claudewatch/backend/history/service.py
@@ -14,17 +14,7 @@ class HistoryService(BaseService):
 
     def get_all(self) -> list[HistoryEntryDTO]:
         """Return all history entries as DTOs, newest first."""
-        return [
-            HistoryEntryDTO(
-                session_id=e.get("session_id", ""),
-                project=e.get("project", ""),
-                cwd=e.get("cwd", ""),
-                model=e.get("model", ""),
-                host_app=e.get("host_app", ""),
-                ended_at=e.get("ended_at", ""),
-            )
-            for e in history_repo.get_history()
-        ]
+        return history_repo.get_history()
 
     def remove(self, cwd: str) -> None:
         """Remove a history entry by CWD."""

--- a/claudewatch/backend/notifications/models.py
+++ b/claudewatch/backend/notifications/models.py
@@ -1,0 +1,13 @@
+"""Typed models for notification-internal data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FrontmostWindow:
+    """The frontmost macOS window."""
+
+    app_name: str
+    window_title: str

--- a/claudewatch/backend/notifications/service.py
+++ b/claudewatch/backend/notifications/service.py
@@ -13,6 +13,7 @@ from claudewatch.backend.core import features
 from claudewatch.backend.core.helpers import run_applescript
 from claudewatch.backend.core.models import ClaudeSession
 from claudewatch.backend.core.service import BaseService
+from claudewatch.backend.notifications.models import FrontmostWindow
 
 log = logging.getLogger("claudewatch")
 
@@ -26,8 +27,8 @@ def set_focus_callback(callback: object) -> None:
     _focus_callback = callback
 
 
-def _get_frontmost_window() -> tuple[str, str]:
-    """Return (app_name, window_title) of the frontmost window."""
+def _get_frontmost_window() -> FrontmostWindow:
+    """Return the frontmost macOS window."""
     result = run_applescript("""
     tell application "System Events"
         set frontApp to first application process whose frontmost is true
@@ -41,8 +42,8 @@ def _get_frontmost_window() -> tuple[str, str]:
     """)
     if "|" in result:
         app, title = result.split("|", 1)
-        return app, title
-    return "", ""
+        return FrontmostWindow(app_name=app, window_title=title)
+    return FrontmostWindow(app_name="", window_title="")
 
 
 class _NotificationDelegate(NSObject):
@@ -121,8 +122,8 @@ class NotificationService(BaseService):
         if now - self.last_notification_time < self.cooldown:
             return
 
-        front_app, front_title = _get_frontmost_window()
-        new_attention = [s for s in new_attention if f" {s.project} " not in f" {front_title} "]
+        front = _get_frontmost_window()
+        new_attention = [s for s in new_attention if f" {s.project} " not in f" {front.window_title} "]
         if not new_attention:
             return
 

--- a/claudewatch/backend/summary/models.py
+++ b/claudewatch/backend/summary/models.py
@@ -1,0 +1,14 @@
+"""Typed models for summary cache entries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SummaryEntry:
+    """Cached summary for a CWD."""
+
+    title: str
+    summary: str
+    mtime: float

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -18,6 +18,7 @@ from claudewatch.backend.core.paths import SUMMARIES_PATH
 from claudewatch.backend.core.process.service import ProcessService
 from claudewatch.backend.core.service import BaseService
 from claudewatch.backend.core.session_log.service import SessionLogService
+from claudewatch.backend.summary.models import SummaryEntry
 
 log = logging.getLogger("claudewatch")
 
@@ -95,8 +96,8 @@ class SummaryService(BaseService):
         self._process_service = process_service
         self._store_path = store_path
 
-        # In-memory mirror of the persistent store: CWD -> {"summary": str, "mtime": float}
-        self._store: dict[str, dict] = {}
+        # In-memory mirror of the persistent store: CWD -> SummaryEntry
+        self._store: dict[str, SummaryEntry] = {}
         self._store_loaded = False
         self._store_lock = threading.Lock()
 
@@ -125,16 +126,24 @@ class SummaryService(BaseService):
             with open(self._store_path) as f:
                 data = json.load(f)
                 if isinstance(data, dict):
-                    self._store = data
+                    self._store = {
+                        k: SummaryEntry(
+                            title=v.get("title", ""),
+                            summary=v.get("summary", ""),
+                            mtime=v.get("mtime", 0),
+                        )
+                        for k, v in data.items()
+                        if isinstance(v, dict)
+                    }
         except (OSError, json.JSONDecodeError):
             self._store = {}
         # Prune entries older than 30 days
         cutoff = time.time() - _STORE_MAX_AGE
         before = len(self._store)
-        self._store = {k: v for k, v in self._store.items() if v.get("mtime", 0) > cutoff}
+        self._store = {k: v for k, v in self._store.items() if v.mtime > cutoff}
         # Cap total entries
         if len(self._store) > _MAX_STORE_ENTRIES:
-            sorted_keys = sorted(self._store, key=lambda k: self._store[k].get("mtime", 0))
+            sorted_keys = sorted(self._store, key=lambda k: self._store[k].mtime)
             for k in sorted_keys[: len(self._store) - _MAX_STORE_ENTRIES]:
                 del self._store[k]
         if len(self._store) < before:
@@ -144,22 +153,23 @@ class SummaryService(BaseService):
     def _save_store(self) -> None:
         tmp = self._store_path + ".tmp"
         try:
+            serialized = {k: {"title": v.title, "summary": v.summary, "mtime": v.mtime} for k, v in self._store.items()}
             with open(tmp, "w") as f:
-                json.dump(self._store, f, indent=2)
+                json.dump(serialized, f, indent=2)
             os.replace(tmp, self._store_path)
         except OSError:
             log.warning("Failed to save summaries to %s", self._store_path)
 
     # -- Public API ---------------------------------------------------------
 
-    def _get_entry(self, cwd: str) -> dict | None:
+    def _get_entry(self, cwd: str) -> SummaryEntry | None:
         """Return the cached entry if JSONL hasn't changed since generation."""
         with self._store_lock:
             self._load_store()
             entry = self._store.get(cwd)
         if not entry:
             return None
-        cached_mtime = entry.get("mtime", 0)
+        cached_mtime = entry.mtime
         current_mtime = self._get_jsonl_mtime(cwd)
         if current_mtime and current_mtime <= cached_mtime:
             return entry
@@ -171,7 +181,7 @@ class SummaryService(BaseService):
         if not entry:
             return None
         # Support old format (plain "summary" string) and new format ("title" + "summary")
-        return entry.get("title") or entry.get("summary", "")
+        return entry.title or entry.summary
 
     def get_cached_title(self, cwd: str) -> str | None:
         """Return the short title (what's happening now)."""
@@ -182,19 +192,19 @@ class SummaryService(BaseService):
         entry = self._get_entry(cwd)
         if not entry:
             return None
-        return entry.get("summary", "")
+        return entry.summary
 
     def cache(self, cwd: str, summary: str) -> None:
         """Persist a summary. Accepts plain string (becomes title) or title+summary."""
         mtime = self._get_jsonl_mtime(cwd) or time.time()
         with self._store_lock:
             self._load_store()
-            existing = self._store.get(cwd, {})
-            if isinstance(existing, dict) and existing.get("summary"):
+            existing = self._store.get(cwd)
+            if existing and existing.summary:
                 # Preserve existing summary if only updating title
-                self._store[cwd] = {"title": summary, "summary": existing["summary"], "mtime": mtime}
+                self._store[cwd] = SummaryEntry(title=summary, summary=existing.summary, mtime=mtime)
             else:
-                self._store[cwd] = {"title": summary, "summary": "", "mtime": mtime}
+                self._store[cwd] = SummaryEntry(title=summary, summary="", mtime=mtime)
             self._save_store()
 
     def cache_full(self, cwd: str, title: str, summary: str) -> None:
@@ -202,7 +212,7 @@ class SummaryService(BaseService):
         mtime = self._get_jsonl_mtime(cwd) or time.time()
         with self._store_lock:
             self._load_store()
-            self._store[cwd] = {"title": title, "summary": summary, "mtime": mtime}
+            self._store[cwd] = SummaryEntry(title=title, summary=summary, mtime=mtime)
             self._save_store()
 
     def clear_all(self) -> None:

--- a/claudewatch/backend/updates/service.py
+++ b/claudewatch/backend/updates/service.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 
 from claudewatch import __version__
 from claudewatch.backend.core import features
-from claudewatch.backend.core.dto import UpdateInfoDTO
+from claudewatch.backend.core.dto import ChangelogEntryDTO, UpdateInfoDTO
 from claudewatch.backend.core.service import BaseService
 
 log = logging.getLogger("claudewatch")
@@ -176,8 +176,8 @@ class UpdateService(BaseService):
         with self._cache_lock:
             return self._cached_update
 
-    def fetch_changelog(self, limit: int = 10) -> list[tuple[str, str]]:
-        """Fetch recent release notes from GitHub. Returns [(tag, body), ...]."""
+    def fetch_changelog(self, limit: int = 10) -> list[ChangelogEntryDTO]:
+        """Fetch recent release notes from GitHub. Returns list of ChangelogEntryDTO."""
         try:
             result = subprocess.run(  # noqa: S603, S607
                 [
@@ -195,7 +195,7 @@ class UpdateService(BaseService):
             if result.returncode == 0:
                 releases = json.loads(result.stdout)
                 return [
-                    (r.get("tag_name", ""), r.get("body", "").strip())
+                    ChangelogEntryDTO(tag=r.get("tag_name", ""), body=r.get("body", "").strip())
                     for r in releases
                     if r.get("tag_name") and not r.get("prerelease")
                 ]

--- a/claudewatch/backend/usage/service.py
+++ b/claudewatch/backend/usage/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 
+from claudewatch.backend.core.dto import TokenUsageDTO
 from claudewatch.backend.core.service import BaseService
 from claudewatch.backend.core.session_log.service import SessionLogService
 
@@ -19,12 +20,7 @@ MODEL_DISPLAY_NAMES: dict[str, str] = {
 
 _MAX_TOKEN_CACHE = 200
 
-_EMPTY_TOKENS: dict[str, int] = {
-    "input": 0,
-    "output": 0,
-    "cache_create": 0,
-    "cache_read": 0,
-}
+_EMPTY_TOKENS = TokenUsageDTO(input=0, output=0, cache_create=0, cache_read=0)
 
 _M = 1_000_000
 _K = 1000
@@ -39,11 +35,11 @@ def _fmt_tokens(n: int) -> str:
     return str(n)
 
 
-def format_tokens_compact(tokens: dict[str, int]) -> str:
+def format_tokens_compact(tokens: TokenUsageDTO) -> str:
     """Single-line compact summary for cards: '49K in · 591K out · 288M cache'."""
-    total_in = tokens["input"]
-    total_out = tokens["output"]
-    cache = tokens["cache_create"] + tokens["cache_read"]
+    total_in = tokens.input
+    total_out = tokens.output
+    cache = tokens.cache_create + tokens.cache_read
     if total_in + total_out + cache == 0:
         return ""
     total = total_in + total_out + cache
@@ -54,20 +50,20 @@ def format_tokens_compact(tokens: dict[str, int]) -> str:
     return " · ".join(parts)
 
 
-def format_tokens_breakdown(tokens: dict[str, int]) -> list[str]:
+def format_tokens_breakdown(tokens: TokenUsageDTO) -> list[str]:
     """Detailed breakdown lines for a submenu."""
-    total_in = tokens["input"] + tokens["cache_create"] + tokens["cache_read"]
-    total_out = tokens["output"]
+    total_in = tokens.input + tokens.cache_create + tokens.cache_read
+    total_out = tokens.output
     if total_in + total_out == 0:
         return []
     lines = [
-        f"Input: {_fmt_tokens(tokens['input'])} tokens",
+        f"Input: {_fmt_tokens(tokens.input)} tokens",
         f"Output: {_fmt_tokens(total_out)} tokens",
     ]
-    if tokens["cache_create"]:
-        lines.append(f"Cache write: {_fmt_tokens(tokens['cache_create'])} tokens")
-    if tokens["cache_read"]:
-        lines.append(f"Cache read: {_fmt_tokens(tokens['cache_read'])} tokens")
+    if tokens.cache_create:
+        lines.append(f"Cache write: {_fmt_tokens(tokens.cache_create)} tokens")
+    if tokens.cache_read:
+        lines.append(f"Cache read: {_fmt_tokens(tokens.cache_read)} tokens")
     lines.append(f"Total: {_fmt_tokens(total_in + total_out)} tokens")
     return lines
 
@@ -78,8 +74,8 @@ class UsageService(BaseService):
     def __init__(self, session_log_service: SessionLogService) -> None:
         super().__init__()
         self._session_log_service = session_log_service
-        # CWD -> (tokens_dict, jsonl_mtime)
-        self._token_cache: dict[str, tuple[dict[str, int], float]] = {}
+        # CWD -> (tokens_dto, jsonl_mtime)
+        self._token_cache: dict[str, tuple[TokenUsageDTO, float]] = {}
 
     def get_model(self, cwd: str) -> str:
         """Get the model name for the most recent session at a CWD.
@@ -109,20 +105,20 @@ class UsageService(BaseService):
 
         return MODEL_DISPLAY_NAMES.get(last_model, last_model)
 
-    def get_tokens(self, cwd: str) -> dict[str, int]:
+    def get_tokens(self, cwd: str) -> TokenUsageDTO:
         """Get token usage breakdown for the most recent session at a CWD.
 
-        Returns {input, output, cache_create, cache_read} summed across all messages.
+        Returns TokenUsageDTO(input, output, cache_create, cache_read) summed across all messages.
         Cached by JSONL mtime — only re-reads when the file changes.
         """
         path = self._session_log_service.find_most_recent(cwd)
         if not path:
-            return dict(_EMPTY_TOKENS)
+            return _EMPTY_TOKENS
 
         try:
             mtime = os.path.getmtime(path)
         except OSError:
-            return dict(_EMPTY_TOKENS)
+            return _EMPTY_TOKENS
 
         cached = self._token_cache.get(cwd)
         if cached and cached[1] >= mtime:
@@ -149,12 +145,12 @@ class UsageService(BaseService):
             total_cache_read += usage.get("cache_read_input_tokens", 0)
             total_out += usage.get("output_tokens", 0)
 
-        result = {
-            "input": total_in,
-            "output": total_out,
-            "cache_create": total_cache_create,
-            "cache_read": total_cache_read,
-        }
+        result = TokenUsageDTO(
+            input=total_in,
+            output=total_out,
+            cache_create=total_cache_create,
+            cache_read=total_cache_read,
+        )
         if len(self._token_cache) >= _MAX_TOKEN_CACHE:
             # Evict oldest entry by mtime
             oldest = min(self._token_cache, key=lambda k: self._token_cache[k][1])

--- a/claudewatch/ui/preferences.py
+++ b/claudewatch/ui/preferences.py
@@ -7,6 +7,7 @@ import threading
 import time
 import webbrowser
 from datetime import UTC, datetime, timedelta
+from typing import NamedTuple
 
 import objc
 from AppKit import (
@@ -45,6 +46,7 @@ from Foundation import NSMakeRect, NSObject, NSRange
 from claudewatch import __version__
 from claudewatch.backend.bookmark.dependencies import get_bookmark_service
 from claudewatch.backend.core import features
+from claudewatch.backend.core.dto import TokenUsageDTO
 from claudewatch.backend.core.features import FacetType
 from claudewatch.backend.core.helpers import escape_applescript, run_applescript
 from claudewatch.backend.core.login_item import sync_login_item
@@ -64,6 +66,13 @@ from claudewatch.ui.safety import (
 )
 
 _REPO_URL = "https://github.com/wingatethomas/claudewatch"
+
+
+class _SessionStat(NamedTuple):
+    project: str
+    tokens: TokenUsageDTO
+    ended_at: str
+
 
 # Layout
 _W = 660
@@ -1056,7 +1065,7 @@ def _add_history_row(  # noqa: PLR0912, PLR0913, PLR0915
     # ── Line 2: time · model · tokens (total)
     ly2 = ly1 - 17
     time_str = _relative_time(ended_at)
-    tokens = usage_svc.get_tokens(cwd) if cwd else {}
+    tokens = usage_svc.get_tokens(cwd) if cwd else None
     token_str = format_tokens_compact(tokens) if tokens else ""
     parts = [time_str]
     if model:
@@ -1106,28 +1115,32 @@ def _build_usage_pane(delegate: _PrefsDelegate, w: int, h: int) -> NSView:  # no
     history = get_history_service().get_all()
     usage_svc = get_usage_service()
 
-    # Gather per-session stats: (project, tokens, ended_at)
-    session_stats: list[tuple[str, dict[str, int], str]] = []
-    total: dict[str, int] = {"input": 0, "output": 0, "cache_create": 0, "cache_read": 0}
+    # Gather per-session stats
+    session_stats: list[_SessionStat] = []
+    total_in = total_out = total_cc = total_cr = 0
     _month_seconds = 30 * 86400
     now_ts = time.time()
 
     for entry in history:
         tokens = usage_svc.get_tokens(entry.cwd)
-        session_total = sum(tokens.values())
-        if session_total > 0:
-            session_stats.append((entry.project, tokens, entry.ended_at))
+        if tokens.total > 0:
+            session_stats.append(_SessionStat(entry.project, tokens, entry.ended_at))
             # Only count toward total if within past month
             try:
                 ended = datetime.fromisoformat(entry.ended_at).timestamp()
                 if now_ts - ended < _month_seconds:
-                    for k in total:
-                        total[k] += tokens[k]
+                    total_in += tokens.input
+                    total_out += tokens.output
+                    total_cc += tokens.cache_create
+                    total_cr += tokens.cache_read
             except (ValueError, TypeError, AttributeError):
-                for k in total:
-                    total[k] += tokens[k]
+                total_in += tokens.input
+                total_out += tokens.output
+                total_cc += tokens.cache_create
+                total_cr += tokens.cache_read
 
-    total_sum = sum(total.values())
+    total = TokenUsageDTO(input=total_in, output=total_out, cache_create=total_cc, cache_read=total_cr)
+    total_sum = total.total
     card_w = w - _PAD * 2
 
     if total_sum == 0:
@@ -1143,10 +1156,10 @@ def _build_usage_pane(delegate: _PrefsDelegate, w: int, h: int) -> NSView:  # no
     y -= 6
     _row_h = 22
     total_lines = [
-        ("Input", total["input"]),
-        ("Output", total["output"]),
-        ("Cache", total["cache_create"] + total["cache_read"]),
-        ("Total", sum(total.values())),
+        ("Input", total.input),
+        ("Output", total.output),
+        ("Cache", total.cache_create + total.cache_read),
+        ("Total", total.total),
     ]
     total_card_h = _CARD_PAD + len(total_lines) * _row_h + _CARD_PAD
     total_card = _make_card(_PAD, y - total_card_h, card_w, total_card_h)
@@ -1172,7 +1185,7 @@ def _build_usage_pane(delegate: _PrefsDelegate, w: int, h: int) -> NSView:  # no
     view.addSubview_(top_header)
     y -= 6
 
-    session_stats.sort(key=lambda s: sum(s[1].values()), reverse=True)
+    session_stats.sort(key=lambda s: s.tokens.total, reverse=True)
     _top_n = 10
     top_entries = session_stats[:_top_n]
     _top_row_h = 22
@@ -1203,7 +1216,7 @@ def _build_usage_pane(delegate: _PrefsDelegate, w: int, h: int) -> NSView:  # no
         date_str = _relative_time(ended_at)
         date_label = _make_secondary_label(date_str, _col_date, tpy, 75, 11.0)
         tpc.addSubview_(date_label)
-        total_tok = sum(tokens.values())
+        total_tok = tokens.total
         val = _make_secondary_label(
             _fmt_token_count(total_tok), _col_tokens, tpy, card_w - _CARD_PAD - _col_tokens, 11.0
         )
@@ -1400,14 +1413,14 @@ def _build_about_pane(delegate: _PrefsDelegate, w: int, h: int) -> NSView:  # no
         # Phase 1: Background — fetch and parse (no AppKit objects)
         releases = get_update_service().fetch_changelog()
         changelog: list[tuple[str, list[str]]] = []
-        for tag, body in releases:
-            items = _parse_release_notes(body)
+        for entry in releases:
+            items = _parse_release_notes(entry.body)
             if items:
-                changelog.append((tag, items))
-            elif body:
-                changelog.append((tag, [body[:100]]))
+                changelog.append((entry.tag, items))
+            elif entry.body:
+                changelog.append((entry.tag, [entry.body[:100]]))
             else:
-                changelog.append((tag, ["No release notes"]))
+                changelog.append((entry.tag, ["No release notes"]))
 
         # Phase 2: Build views on main thread (NSView is not thread-safe)
         def _build_views() -> None:

--- a/tests/bookmark/test_bookmark_service.py
+++ b/tests/bookmark/test_bookmark_service.py
@@ -25,20 +25,20 @@ class TestBookmarkService:
     @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
     def test_get_all_returns_bookmark_dtos(self, mock_repo):
         mock_repo.get_bookmarks.return_value = [
-            {
-                "session_id": "s1",
-                "project": "proj",
-                "cwd": "/tmp/a",
-                "note": "n1",
-                "timestamp": "2025-01-01T00:00:00+00:00",
-            },
-            {
-                "session_id": "s2",
-                "project": "proj2",
-                "cwd": "/tmp/b",
-                "note": "n2",
-                "timestamp": "2025-01-02T00:00:00+00:00",
-            },
+            BookmarkDTO(
+                session_id="s1",
+                project="proj",
+                cwd="/tmp/a",
+                note="n1",
+                timestamp="2025-01-01T00:00:00+00:00",
+            ),
+            BookmarkDTO(
+                session_id="s2",
+                project="proj2",
+                cwd="/tmp/b",
+                note="n2",
+                timestamp="2025-01-02T00:00:00+00:00",
+            ),
         ]
         result = self.svc.get_all()
         assert len(result) == 2
@@ -53,8 +53,10 @@ class TestBookmarkService:
         assert self.svc.get_all() == []
 
     @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
-    def test_get_all_handles_missing_fields(self, mock_repo):
-        mock_repo.get_bookmarks.return_value = [{"session_id": "s1"}]
+    def test_get_all_handles_empty_fields(self, mock_repo):
+        mock_repo.get_bookmarks.return_value = [
+            BookmarkDTO(session_id="s1", project="", cwd="", note="", timestamp=""),
+        ]
         result = self.svc.get_all()
         assert len(result) == 1
         assert result[0].session_id == "s1"
@@ -73,13 +75,13 @@ class TestBookmarkService:
     @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
     def test_get_all_returns_frozen_dtos(self, mock_repo):
         mock_repo.get_bookmarks.return_value = [
-            {
-                "session_id": "s1",
-                "project": "proj",
-                "cwd": "/tmp/a",
-                "note": "n1",
-                "timestamp": "2025-01-01T00:00:00+00:00",
-            },
+            BookmarkDTO(
+                session_id="s1",
+                project="proj",
+                cwd="/tmp/a",
+                note="n1",
+                timestamp="2025-01-01T00:00:00+00:00",
+            ),
         ]
         result = self.svc.get_all()
         bookmark = result[0]

--- a/tests/bookmark/test_bookmarks.py
+++ b/tests/bookmark/test_bookmarks.py
@@ -17,11 +17,11 @@ class TestBookmarkSaveAndGetAll:
             result = bookmarks.get_bookmarks()
 
         assert len(result) == 1
-        assert result[0]["session_id"] == "abc-123"
-        assert result[0]["project"] == "myproject"
-        assert result[0]["cwd"] == "/tmp/myproject"
-        assert result[0]["note"] == "working on auth"
-        assert "timestamp" in result[0]
+        assert result[0].session_id == "abc-123"
+        assert result[0].project == "myproject"
+        assert result[0].cwd == "/tmp/myproject"
+        assert result[0].note == "working on auth"
+        assert result[0].timestamp
 
     def test_save_multiple(self, tmp_path):
         fake_path = str(tmp_path / "sessions.json")
@@ -31,8 +31,8 @@ class TestBookmarkSaveAndGetAll:
             result = bookmarks.get_bookmarks()
 
         assert len(result) == 2
-        assert result[0]["session_id"] == "id-1"
-        assert result[1]["session_id"] == "id-2"
+        assert result[0].session_id == "id-1"
+        assert result[1].session_id == "id-2"
 
     def test_save_persists_to_disk(self, tmp_path):
         fake_path = str(tmp_path / "sessions.json")
@@ -52,14 +52,14 @@ class TestBookmarkUpdateExisting:
         fake_path = str(tmp_path / "sessions.json")
         with patch.object(bookmarks, "_PATH", fake_path):
             bookmarks.add_bookmark("abc-123", "proj", "/cwd", "old note")
-            old_ts = bookmarks.get_bookmarks()[0]["timestamp"]
+            old_ts = bookmarks.get_bookmarks()[0].timestamp
 
             bookmarks.add_bookmark("abc-123", "proj", "/cwd", "new note")
             result = bookmarks.get_bookmarks()
 
         assert len(result) == 1
-        assert result[0]["note"] == "new note"
-        assert result[0]["timestamp"] >= old_ts
+        assert result[0].note == "new note"
+        assert result[0].timestamp >= old_ts
 
     def test_update_does_not_duplicate(self, tmp_path):
         fake_path = str(tmp_path / "sessions.json")
@@ -70,7 +70,7 @@ class TestBookmarkUpdateExisting:
             result = bookmarks.get_bookmarks()
 
         assert len(result) == 1
-        assert result[0]["note"] == "third"
+        assert result[0].note == "third"
 
 
 class TestBookmarkRemove:
@@ -85,7 +85,7 @@ class TestBookmarkRemove:
             result = bookmarks.get_bookmarks()
 
         assert len(result) == 1
-        assert result[0]["session_id"] == "id-2"
+        assert result[0].session_id == "id-2"
 
     def test_remove_nonexistent_is_noop(self, tmp_path):
         fake_path = str(tmp_path / "sessions.json")
@@ -125,7 +125,7 @@ class TestBookmarkTTLPruning:
             result = bookmarks.get_bookmarks()
 
         assert len(result) == 1
-        assert result[0]["session_id"] == "new"
+        assert result[0].session_id == "new"
 
     def test_pruning_persists_to_disk(self, tmp_path):
         fake_path = str(tmp_path / "sessions.json")
@@ -173,7 +173,7 @@ class TestBookmarkTTLPruning:
             result = bookmarks.get_bookmarks()
 
         assert len(result) == 1
-        assert result[0]["session_id"] == "bad-ts"
+        assert result[0].session_id == "bad-ts"
 
     def test_entry_with_missing_timestamp_kept(self, tmp_path):
         """Entries with no timestamp field survive pruning."""
@@ -243,7 +243,7 @@ class TestBookmarkEmptyFileHandling:
             result = bookmarks.get_bookmarks()
 
         assert len(result) == 1
-        assert result[0]["session_id"] == "good"
+        assert result[0].session_id == "good"
 
     def test_save_to_new_file_creates_it(self, tmp_path):
         fake_path = str(tmp_path / "brand-new.json")

--- a/tests/core/test_dto.py
+++ b/tests/core/test_dto.py
@@ -6,7 +6,9 @@ from claudewatch.backend.core.dto import (
     ActivityEventDTO,
     BaseDTO,
     BookmarkDTO,
+    ChangelogEntryDTO,
     HistoryEntryDTO,
+    TokenUsageDTO,
     UpdateInfoDTO,
 )
 
@@ -60,3 +62,41 @@ class TestActivityEventDTO:
     def test_construction(self):
         dto = ActivityEventDTO(kind="tool_use", summary="Read file", detail="foo.py", timestamp="12:00")
         assert dto.kind == "tool_use"
+
+
+class TestTokenUsageDTO:
+    def test_construction(self):
+        dto = TokenUsageDTO(input=100, output=50, cache_create=200, cache_read=300)
+        assert dto.input == 100
+        assert dto.output == 50
+
+    def test_total_property(self):
+        dto = TokenUsageDTO(input=100, output=50, cache_create=200, cache_read=300)
+        assert dto.total == 650
+
+    def test_total_zero(self):
+        dto = TokenUsageDTO(input=0, output=0, cache_create=0, cache_read=0)
+        assert dto.total == 0
+
+    def test_frozen(self):
+        dto = TokenUsageDTO(input=100, output=50, cache_create=0, cache_read=0)
+        with pytest.raises(AttributeError):
+            dto.input = 999  # type: ignore[misc]
+
+    def test_to_dict(self):
+        dto = TokenUsageDTO(input=100, output=50, cache_create=200, cache_read=300)
+        d = dto.to_dict()
+        assert d["input"] == 100
+        assert d["cache_create"] == 200
+
+
+class TestChangelogEntryDTO:
+    def test_construction(self):
+        dto = ChangelogEntryDTO(tag="v1.0.0", body="- Added feature\n- Fixed bug")
+        assert dto.tag == "v1.0.0"
+        assert "feature" in dto.body
+
+    def test_frozen(self):
+        dto = ChangelogEntryDTO(tag="v1.0.0", body="notes")
+        with pytest.raises(AttributeError):
+            dto.tag = "v2.0.0"  # type: ignore[misc]

--- a/tests/core/test_jsonl.py
+++ b/tests/core/test_jsonl.py
@@ -47,9 +47,9 @@ class TestCheckJsonlForPendingTool:
         os.utime(jsonl, (time.time() - 10, time.time() - 10))
 
         svc = _make_service(str(jsonl), jsonl.read_text())
-        pending, one_line, ctx = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
-        assert pending is True
-        assert "Bash" in one_line
+        result = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
+        assert result.has_pending is True
+        assert "Bash" in result.one_line
 
     def test_user_message_means_not_pending(self, tmp_path):
         jsonl = tmp_path / "session.jsonl"
@@ -70,8 +70,8 @@ class TestCheckJsonlForPendingTool:
         os.utime(jsonl, (time.time() - 10, time.time() - 10))
 
         svc = _make_service(str(jsonl), jsonl.read_text())
-        pending, _, _ = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
-        assert pending is False
+        result = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
+        assert result.has_pending is False
 
     def test_assistant_without_tool_use_not_pending(self, tmp_path):
         jsonl = tmp_path / "session.jsonl"
@@ -91,8 +91,8 @@ class TestCheckJsonlForPendingTool:
         os.utime(jsonl, (time.time() - 10, time.time() - 10))
 
         svc = _make_service(str(jsonl), jsonl.read_text())
-        pending, _, _ = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
-        assert pending is False
+        result = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
+        assert result.has_pending is False
 
     def test_too_old_file_ignored(self, tmp_path):
         jsonl = tmp_path / "session.jsonl"
@@ -112,8 +112,8 @@ class TestCheckJsonlForPendingTool:
         os.utime(jsonl, (time.time() - 600, time.time() - 600))
 
         svc = _make_service(str(jsonl), jsonl.read_text())
-        pending, _, _ = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
-        assert pending is False
+        result = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
+        assert result.has_pending is False
 
     def test_too_fresh_file_ignored(self, tmp_path):
         jsonl = tmp_path / "session.jsonl"
@@ -133,18 +133,18 @@ class TestCheckJsonlForPendingTool:
         os.utime(jsonl, (time.time(), time.time()))
 
         svc = _make_service(str(jsonl), jsonl.read_text())
-        pending, _, _ = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
-        assert pending is False
+        result = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
+        assert result.has_pending is False
 
     def test_nonexistent_project_dir(self):
         svc = _make_service(None)
-        pending, _, _ = svc._check_jsonl_for_pending_tool("/Users/dev/nonexistent")
-        assert pending is False
+        result = svc._check_jsonl_for_pending_tool("/Users/dev/nonexistent")
+        assert result.has_pending is False
 
     def test_empty_project_dir(self):
         svc = _make_service(None)
-        pending, _, _ = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
-        assert pending is False
+        result = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
+        assert result.has_pending is False
 
     def test_progress_message_with_tool_use(self, tmp_path):
         jsonl = tmp_path / "session.jsonl"
@@ -169,9 +169,9 @@ class TestCheckJsonlForPendingTool:
         os.utime(jsonl, (time.time() - 10, time.time() - 10))
 
         svc = _make_service(str(jsonl), jsonl.read_text())
-        pending, one_line, _ = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
-        assert pending is True
-        assert "Edit" in one_line
+        result = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
+        assert result.has_pending is True
+        assert "Edit" in result.one_line
 
     def test_skips_system_types(self, tmp_path):
         jsonl = tmp_path / "session.jsonl"
@@ -192,8 +192,8 @@ class TestCheckJsonlForPendingTool:
         os.utime(jsonl, (time.time() - 10, time.time() - 10))
 
         svc = _make_service(str(jsonl), jsonl.read_text())
-        pending, _, _ = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
-        assert pending is True
+        result = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
+        assert result.has_pending is True
 
     def test_malformed_json_skipped(self, tmp_path):
         jsonl = tmp_path / "session.jsonl"
@@ -215,5 +215,5 @@ class TestCheckJsonlForPendingTool:
         os.utime(jsonl, (time.time() - 10, time.time() - 10))
 
         svc = _make_service(str(jsonl), jsonl.read_text())
-        pending, _, _ = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
-        assert pending is True
+        result = svc._check_jsonl_for_pending_tool("/Users/dev/myapp")
+        assert result.has_pending is True

--- a/tests/core/test_process_models.py
+++ b/tests/core/test_process_models.py
@@ -1,0 +1,35 @@
+"""Tests for process info typed models."""
+
+import pytest
+
+from claudewatch.backend.core.process.models import ProcessEntry, ProcessInfo
+
+
+class TestProcessInfo:
+    def test_construction(self):
+        info = ProcessInfo(tty="ttys001", ppid=1, comm="/bin/zsh")
+        assert info.tty == "ttys001"
+        assert info.ppid == 1
+        assert info.comm == "/bin/zsh"
+
+    def test_frozen(self):
+        info = ProcessInfo(tty="ttys001", ppid=1, comm="/bin/zsh")
+        with pytest.raises(AttributeError):
+            info.tty = "ttys002"  # type: ignore[misc]
+
+    def test_equality(self):
+        a = ProcessInfo(tty="ttys001", ppid=1, comm="/bin/zsh")
+        b = ProcessInfo(tty="ttys001", ppid=1, comm="/bin/zsh")
+        assert a == b
+
+
+class TestProcessEntry:
+    def test_construction(self):
+        entry = ProcessEntry(pid=42, tty="ttys001", ppid=1, comm="/bin/zsh")
+        assert entry.pid == 42
+        assert entry.tty == "ttys001"
+
+    def test_frozen(self):
+        entry = ProcessEntry(pid=42, tty="ttys001", ppid=1, comm="/bin/zsh")
+        with pytest.raises(AttributeError):
+            entry.pid = 99  # type: ignore[misc]

--- a/tests/core/test_process_service.py
+++ b/tests/core/test_process_service.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+from claudewatch.backend.core.process.models import ProcessEntry, ProcessInfo
 from claudewatch.backend.core.process.service import ProcessService
 
 
@@ -13,16 +14,16 @@ class TestProcessServiceDelegation:
 
     @patch("claudewatch.backend.core.process.service.procinfo.list_all_processes")
     def test_list_all(self, mock_list_all):
-        mock_list_all.return_value = [{"pid": 1, "ppid": 0, "tty": "??", "comm": "/sbin/launchd"}]
+        mock_list_all.return_value = [ProcessEntry(pid=1, tty="??", ppid=0, comm="/sbin/launchd")]
         result = self.svc.list_all()
-        assert result == [{"pid": 1, "ppid": 0, "tty": "??", "comm": "/sbin/launchd"}]
+        assert result == [ProcessEntry(pid=1, tty="??", ppid=0, comm="/sbin/launchd")]
         mock_list_all.assert_called_once()
 
     @patch("claudewatch.backend.core.process.service.procinfo.get_process_info")
     def test_get_info(self, mock_get_info):
-        mock_get_info.return_value = {42: {"tty": "ttys001", "ppid": 1, "comm": "/bin/zsh"}}
+        mock_get_info.return_value = {42: ProcessInfo(tty="ttys001", ppid=1, comm="/bin/zsh")}
         result = self.svc.get_info([42])
-        assert result == {42: {"tty": "ttys001", "ppid": 1, "comm": "/bin/zsh"}}
+        assert result == {42: ProcessInfo(tty="ttys001", ppid=1, comm="/bin/zsh")}
         mock_get_info.assert_called_once_with([42])
 
     @patch("claudewatch.backend.core.process.service.procinfo.get_process_info")
@@ -56,9 +57,9 @@ class TestProcessServiceDelegation:
 
     @patch("claudewatch.backend.core.process.service.procinfo.get_single_process_info")
     def test_get_single_info(self, mock_single):
-        mock_single.return_value = {"tty": "ttys001", "ppid": 1, "comm": "/bin/zsh"}
+        mock_single.return_value = ProcessInfo(tty="ttys001", ppid=1, comm="/bin/zsh")
         result = self.svc.get_single_info(42)
-        assert result == {"tty": "ttys001", "ppid": 1, "comm": "/bin/zsh"}
+        assert result == ProcessInfo(tty="ttys001", ppid=1, comm="/bin/zsh")
         mock_single.assert_called_once_with(42)
 
     @patch("claudewatch.backend.core.process.service.procinfo.get_single_process_info")

--- a/tests/detection/test_detection.py
+++ b/tests/detection/test_detection.py
@@ -44,20 +44,20 @@ class TestExtractPromptInfo:
 
     def test_finds_permission_prompt(self):
         buffer = "\u23fa Update(auth.py)\n  Do you want to proceed with this edit?\n  Yes, allow | No\n"
-        one_line, context = _extract_prompt_info(buffer)
-        assert "Update" in one_line or "auth" in one_line
-        assert "allow" in context.lower() or "Update" in context
+        result = _extract_prompt_info(buffer)
+        assert "Update" in result.one_line or "auth" in result.one_line
+        assert "allow" in result.context.lower() or "Update" in result.context
 
     def test_no_prompt_returns_empty(self):
         buffer = "\u23fa Working on something\nno prompts here\n"
-        one_line, context = _extract_prompt_info(buffer)
-        assert one_line == ""
-        assert context == ""
+        result = _extract_prompt_info(buffer)
+        assert result.one_line == ""
+        assert result.context == ""
 
     def test_truncates_long_one_line(self):
         buffer = "\u23fa " + "x" * 100 + "\n  yes, allow\n"
-        one_line, _ = _extract_prompt_info(buffer)
-        assert len(one_line) <= 80
+        result = _extract_prompt_info(buffer)
+        assert len(result.one_line) <= 80
 
 
 class TestFormatToolUse:
@@ -65,33 +65,33 @@ class TestFormatToolUse:
 
     def test_command_tool(self):
         tool = {"name": "Bash", "input": {"command": "ls -la /tmp"}}
-        one_line, context = _format_tool_use(tool)
-        assert "Bash" in one_line
-        assert "ls -la" in one_line
-        assert "Command:" in context
+        result = _format_tool_use(tool)
+        assert "Bash" in result.one_line
+        assert "ls -la" in result.one_line
+        assert "Command:" in result.context
 
     def test_file_tool(self):
         tool = {"name": "Edit", "input": {"file_path": "/tmp/auth.py"}}
-        one_line, context = _format_tool_use(tool)
-        assert "Edit" in one_line
-        assert "auth.py" in one_line
-        assert "File:" in context
+        result = _format_tool_use(tool)
+        assert "Edit" in result.one_line
+        assert "auth.py" in result.one_line
+        assert "File:" in result.context
 
     def test_pattern_tool(self):
         tool = {"name": "Grep", "input": {"pattern": "def login"}}
-        one_line, context = _format_tool_use(tool)
-        assert "Grep" in one_line
-        assert "def login" in one_line
+        result = _format_tool_use(tool)
+        assert "Grep" in result.one_line
+        assert "def login" in result.one_line
 
     def test_unknown_tool(self):
         tool = {"name": "CustomTool", "input": {}}
-        one_line, context = _format_tool_use(tool)
-        assert one_line == "CustomTool"
+        result = _format_tool_use(tool)
+        assert result.one_line == "CustomTool"
 
     def test_truncates_long_command(self):
         tool = {"name": "Bash", "input": {"command": "x" * 100}}
-        one_line, _ = _format_tool_use(tool)
-        assert len(one_line) <= 80
+        result = _format_tool_use(tool)
+        assert len(result.one_line) <= 80
 
 
 class TestDetermineStatus:
@@ -112,36 +112,36 @@ class TestMatchTerminalWindow:
 
     def test_direct_tty_match(self):
         windows = {"/dev/ttys001": ("myapp \u2014 \u2733 Done", 42)}
-        title, wid, app = _match_terminal_window("ttys001", "myapp", HostApp.TERMINAL, windows)
-        assert title == "myapp \u2014 \u2733 Done"
-        assert wid == 42
-        assert app == HostApp.TERMINAL
+        result = _match_terminal_window("ttys001", "myapp", HostApp.TERMINAL, windows)
+        assert result.window_title == "myapp \u2014 \u2733 Done"
+        assert result.window_id == 42
+        assert result.host_app == HostApp.TERMINAL
 
     def test_tty_with_dev_prefix(self):
         windows = {"/dev/ttys001": ("myapp", 42)}
-        title, wid, app = _match_terminal_window("/dev/ttys001", "myapp", HostApp.TERMINAL, windows)
-        assert wid == 42
+        result = _match_terminal_window("/dev/ttys001", "myapp", HostApp.TERMINAL, windows)
+        assert result.window_id == 42
 
     def test_upgrades_other_to_terminal(self):
         windows = {"/dev/ttys001": ("myapp", 42)}
-        _, _, app = _match_terminal_window("ttys001", "myapp", HostApp.OTHER, windows)
-        assert app == HostApp.TERMINAL
+        result = _match_terminal_window("ttys001", "myapp", HostApp.OTHER, windows)
+        assert result.host_app == HostApp.TERMINAL
 
     def test_tmux_fallback_by_project_name(self):
         windows = {"/dev/ttys099": ("tmux: myapp \u2014 session", 99)}
-        title, wid, app = _match_terminal_window("ttys001", "myapp", HostApp.TMUX, windows)
-        assert wid == 99
-        assert "myapp" in title
-        assert app == HostApp.TMUX
+        result = _match_terminal_window("ttys001", "myapp", HostApp.TMUX, windows)
+        assert result.window_id == 99
+        assert "myapp" in result.window_title
+        assert result.host_app == HostApp.TMUX
 
     def test_no_match_returns_host_app_value(self):
         windows = {"/dev/ttys099": ("other project", 99)}
-        title, wid, app = _match_terminal_window("ttys001", "myapp", HostApp.PYCHARM, windows)
-        assert title == "PyCharm"
-        assert wid is None
-        assert app == HostApp.PYCHARM
+        result = _match_terminal_window("ttys001", "myapp", HostApp.PYCHARM, windows)
+        assert result.window_title == "PyCharm"
+        assert result.window_id is None
+        assert result.host_app == HostApp.PYCHARM
 
     def test_empty_windows(self):
-        title, wid, app = _match_terminal_window("ttys001", "myapp", HostApp.TERMINAL, {})
-        assert title == "Terminal"
-        assert wid is None
+        result = _match_terminal_window("ttys001", "myapp", HostApp.TERMINAL, {})
+        assert result.window_title == "Terminal"
+        assert result.window_id is None

--- a/tests/detection/test_detection_extra.py
+++ b/tests/detection/test_detection_extra.py
@@ -129,21 +129,21 @@ class TestDetermineStatus:
 class TestExtractPromptInfo:
     def test_extracts_prompt_context(self):
         buf = "some output\n⏺ Bash: ls -la\n  Allow once  \n  Allow always  "
-        one_line, context = _extract_prompt_info(buf)
-        assert "Bash" in one_line or "ls" in context
+        result = _extract_prompt_info(buf)
+        assert "Bash" in result.one_line or "ls" in result.context
 
     def test_no_prompt_returns_empty(self):
         buf = "just regular output\nno prompts here"
-        one_line, context = _extract_prompt_info(buf)
-        assert one_line == ""
-        assert context == ""
+        result = _extract_prompt_info(buf)
+        assert result.one_line == ""
+        assert result.context == ""
 
     def test_truncates_long_one_liner(self):
         long_cmd = "x" * 200
         buf = f"⏺ {long_cmd}\n  Allow once  "
-        one_line, _ = _extract_prompt_info(buf)
-        assert len(one_line) <= 80
-        assert one_line.endswith("...")
+        result = _extract_prompt_info(buf)
+        assert len(result.one_line) <= 80
+        assert result.one_line.endswith("...")
 
 
 class TestGetSessionId:

--- a/tests/detection/test_detection_models.py
+++ b/tests/detection/test_detection_models.py
@@ -1,0 +1,68 @@
+"""Tests for detection domain typed models."""
+
+import pytest
+
+from claudewatch.backend.core.models import HostApp
+from claudewatch.backend.detection.models import (
+    PendingToolResult,
+    PromptInfo,
+    TerminalMatch,
+    ToolUseInfo,
+)
+
+
+class TestPendingToolResult:
+    def test_construction(self):
+        result = PendingToolResult(has_pending=True, one_line="Bash: ls", context="Tool: Bash\nCommand: ls")
+        assert result.has_pending is True
+        assert result.one_line == "Bash: ls"
+
+    def test_frozen(self):
+        result = PendingToolResult(has_pending=False, one_line="", context="")
+        with pytest.raises(AttributeError):
+            result.has_pending = True  # type: ignore[misc]
+
+    def test_empty(self):
+        result = PendingToolResult(has_pending=False, one_line="", context="")
+        assert not result.has_pending
+        assert result.one_line == ""
+
+
+class TestToolUseInfo:
+    def test_construction(self):
+        info = ToolUseInfo(one_line="Edit: auth.py", context="Tool: Edit\nFile: /tmp/auth.py")
+        assert "Edit" in info.one_line
+        assert "File:" in info.context
+
+    def test_frozen(self):
+        info = ToolUseInfo(one_line="x", context="y")
+        with pytest.raises(AttributeError):
+            info.one_line = "z"  # type: ignore[misc]
+
+
+class TestPromptInfo:
+    def test_construction(self):
+        info = PromptInfo(one_line="Bash: ls -la", context="Allow once")
+        assert "Bash" in info.one_line
+
+    def test_empty(self):
+        info = PromptInfo(one_line="", context="")
+        assert info.one_line == ""
+        assert info.context == ""
+
+
+class TestTerminalMatch:
+    def test_construction(self):
+        match = TerminalMatch(window_title="myapp — claude", window_id=42, host_app=HostApp.TERMINAL)
+        assert match.window_title == "myapp — claude"
+        assert match.window_id == 42
+        assert match.host_app == HostApp.TERMINAL
+
+    def test_no_window_id(self):
+        match = TerminalMatch(window_title="PyCharm", window_id=None, host_app=HostApp.PYCHARM)
+        assert match.window_id is None
+
+    def test_frozen(self):
+        match = TerminalMatch(window_title="x", window_id=1, host_app=HostApp.TERMINAL)
+        with pytest.raises(AttributeError):
+            match.window_title = "y"  # type: ignore[misc]

--- a/tests/history/test_history.py
+++ b/tests/history/test_history.py
@@ -65,8 +65,8 @@ class TestGetHistory:
             history.record_session("sess-2", "proj-b", "/b", "", "Terminal")
             result = history.get_history()
 
-        assert result[0]["session_id"] == "sess-2"
-        assert result[1]["session_id"] == "sess-1"
+        assert result[0].session_id == "sess-2"
+        assert result[1].session_id == "sess-1"
 
     def test_seeds_from_jsonl_when_empty(self, tmp_path):
         fake_path = str(tmp_path / "history.json")
@@ -84,7 +84,7 @@ class TestGetHistory:
             result = history.get_history()
 
         assert len(result) >= 1
-        assert result[0]["project"] == "myapp"
+        assert result[0].project == "myapp"
 
 
 class TestSeedFromJsonl:

--- a/tests/history/test_history_service.py
+++ b/tests/history/test_history_service.py
@@ -20,22 +20,22 @@ class TestHistoryService:
     @patch("claudewatch.backend.history.service.history_repo")
     def test_get_all_returns_history_entry_dtos(self, mock_repo):
         mock_repo.get_history.return_value = [
-            {
-                "session_id": "s1",
-                "project": "proj",
-                "cwd": "/tmp/a",
-                "model": "opus-4",
-                "host_app": "Terminal",
-                "ended_at": "2025-01-01T00:00:00+00:00",
-            },
-            {
-                "session_id": "s2",
-                "project": "proj2",
-                "cwd": "/tmp/b",
-                "model": "sonnet-4",
-                "host_app": "VSCode",
-                "ended_at": "2025-01-02T00:00:00+00:00",
-            },
+            HistoryEntryDTO(
+                session_id="s1",
+                project="proj",
+                cwd="/tmp/a",
+                model="opus-4",
+                host_app="Terminal",
+                ended_at="2025-01-01T00:00:00+00:00",
+            ),
+            HistoryEntryDTO(
+                session_id="s2",
+                project="proj2",
+                cwd="/tmp/b",
+                model="sonnet-4",
+                host_app="VSCode",
+                ended_at="2025-01-02T00:00:00+00:00",
+            ),
         ]
         result = self.svc.get_all()
         assert len(result) == 2
@@ -50,8 +50,10 @@ class TestHistoryService:
         assert self.svc.get_all() == []
 
     @patch("claudewatch.backend.history.service.history_repo")
-    def test_get_all_handles_missing_fields(self, mock_repo):
-        mock_repo.get_history.return_value = [{"session_id": "s1"}]
+    def test_get_all_handles_empty_fields(self, mock_repo):
+        mock_repo.get_history.return_value = [
+            HistoryEntryDTO(session_id="s1", project="", cwd="", model="", host_app="", ended_at=""),
+        ]
         result = self.svc.get_all()
         assert len(result) == 1
         assert result[0].session_id == "s1"
@@ -69,14 +71,14 @@ class TestHistoryService:
     @patch("claudewatch.backend.history.service.history_repo")
     def test_get_all_returns_frozen_dtos(self, mock_repo):
         mock_repo.get_history.return_value = [
-            {
-                "session_id": "s1",
-                "project": "proj",
-                "cwd": "/tmp/a",
-                "model": "opus-4",
-                "host_app": "Terminal",
-                "ended_at": "2025-01-01T00:00:00+00:00",
-            },
+            HistoryEntryDTO(
+                session_id="s1",
+                project="proj",
+                cwd="/tmp/a",
+                model="opus-4",
+                host_app="Terminal",
+                ended_at="2025-01-01T00:00:00+00:00",
+            ),
         ]
         result = self.svc.get_all()
         entry = result[0]

--- a/tests/notifications/test_notification_models.py
+++ b/tests/notifications/test_notification_models.py
@@ -1,0 +1,22 @@
+"""Tests for notification domain typed models."""
+
+import pytest
+
+from claudewatch.backend.notifications.models import FrontmostWindow
+
+
+class TestFrontmostWindow:
+    def test_construction(self):
+        fw = FrontmostWindow(app_name="Terminal", window_title="myapp — claude")
+        assert fw.app_name == "Terminal"
+        assert fw.window_title == "myapp — claude"
+
+    def test_frozen(self):
+        fw = FrontmostWindow(app_name="x", window_title="y")
+        with pytest.raises(AttributeError):
+            fw.app_name = "z"  # type: ignore[misc]
+
+    def test_empty(self):
+        fw = FrontmostWindow(app_name="", window_title="")
+        assert fw.app_name == ""
+        assert fw.window_title == ""

--- a/tests/notifications/test_notifications.py
+++ b/tests/notifications/test_notifications.py
@@ -3,10 +3,26 @@
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from claudewatch.backend.core.models import ClaudeSession, HostApp, SessionStatus
+from claudewatch.backend.notifications import service as svc_mod
+from claudewatch.backend.notifications.models import FrontmostWindow
 from claudewatch.backend.notifications.service import NotificationService
 
 _MOD = "claudewatch.backend.notifications.service"
+
+
+@pytest.fixture(autouse=True)
+def _mock_notification_center():
+    """Mock NSUserNotificationCenter so tests work without a display server."""
+    svc_mod._delegate = None
+    with (
+        patch(f"{_MOD}._ensure_delegate"),
+        patch(f"{_MOD}.NSUserNotificationCenter") as mock_center_cls,
+    ):
+        mock_center_cls.defaultUserNotificationCenter.return_value = MagicMock()
+        yield
 
 
 def _make_session(**kwargs):
@@ -98,7 +114,7 @@ class TestNotifyIfNeeded:
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
             patch(f"{_MOD}.NSUserNotification", mock_cls),
-            patch(f"{_MOD}._get_frontmost_window", return_value=("Finder", "")),
+            patch(f"{_MOD}._get_frontmost_window", return_value=FrontmostWindow(app_name="Finder", window_title="")),
         ):
             s = _make_session(pid=200, status=SessionStatus.ATTENTION)
             svc.notify_if_needed([s])
@@ -113,7 +129,7 @@ class TestNotifyIfNeeded:
         svc._center = mock_center
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
-            patch(f"{_MOD}._get_frontmost_window", return_value=("Finder", "")),
+            patch(f"{_MOD}._get_frontmost_window", return_value=FrontmostWindow(app_name="Finder", window_title="")),
         ):
             s = _make_session(pid=200, status=SessionStatus.ATTENTION)
             svc.notify_if_needed([s])
@@ -129,7 +145,7 @@ class TestNotifyIfNeeded:
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
             patch(f"{_MOD}.NSUserNotification", mock_cls),
-            patch(f"{_MOD}._get_frontmost_window", return_value=("Finder", "")),
+            patch(f"{_MOD}._get_frontmost_window", return_value=FrontmostWindow(app_name="Finder", window_title="")),
         ):
             s = _make_session(pid=200, status=SessionStatus.ATTENTION)
             svc.notify_if_needed([s])
@@ -143,7 +159,7 @@ class TestNotifyIfNeeded:
         svc._center = mock_center
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
-            patch(f"{_MOD}._get_frontmost_window", return_value=("Finder", "")),
+            patch(f"{_MOD}._get_frontmost_window", return_value=FrontmostWindow(app_name="Finder", window_title="")),
         ):
             s = _make_session(pid=100, status=SessionStatus.ATTENTION)
             svc.notify_if_needed([s])
@@ -158,7 +174,7 @@ class TestNotifyIfNeeded:
             patch(f"{_MOD}.features.is_enabled", return_value=True),
             patch(
                 f"{_MOD}._get_frontmost_window",
-                return_value=("Terminal", "myproject — claude"),
+                return_value=FrontmostWindow(app_name="Terminal", window_title="myproject — claude"),
             ),
         ):
             s = _make_session(
@@ -180,7 +196,7 @@ class TestNotifyIfNeeded:
             patch(f"{_MOD}.NSUserNotification", mock_cls),
             patch(
                 f"{_MOD}._get_frontmost_window",
-                return_value=("Terminal", "other-project — claude"),
+                return_value=FrontmostWindow(app_name="Terminal", window_title="other-project — claude"),
             ),
         ):
             s = _make_session(
@@ -200,7 +216,7 @@ class TestNotifyIfNeeded:
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
             patch(f"{_MOD}.NSUserNotification", mock_cls),
-            patch(f"{_MOD}._get_frontmost_window", return_value=("Finder", "")),
+            patch(f"{_MOD}._get_frontmost_window", return_value=FrontmostWindow(app_name="Finder", window_title="")),
         ):
             s = _make_session(pid=500, status=SessionStatus.ATTENTION)
             svc.notify_if_needed([s])
@@ -234,7 +250,7 @@ class TestNotifyIfNeeded:
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
             patch(f"{_MOD}.NSUserNotification", mock_cls),
-            patch(f"{_MOD}._get_frontmost_window", return_value=("Finder", "")),
+            patch(f"{_MOD}._get_frontmost_window", return_value=FrontmostWindow(app_name="Finder", window_title="")),
         ):
             s = _make_session(
                 pid=600,

--- a/tests/summary/test_summary_models.py
+++ b/tests/summary/test_summary_models.py
@@ -1,0 +1,23 @@
+"""Tests for summary domain typed models."""
+
+import pytest
+
+from claudewatch.backend.summary.models import SummaryEntry
+
+
+class TestSummaryEntry:
+    def test_construction(self):
+        entry = SummaryEntry(title="Refactoring auth", summary="- Updated login flow", mtime=1234567890.0)
+        assert entry.title == "Refactoring auth"
+        assert entry.summary == "- Updated login flow"
+        assert entry.mtime == 1234567890.0
+
+    def test_frozen(self):
+        entry = SummaryEntry(title="x", summary="y", mtime=1.0)
+        with pytest.raises(AttributeError):
+            entry.title = "z"  # type: ignore[misc]
+
+    def test_equality(self):
+        a = SummaryEntry(title="x", summary="y", mtime=1.0)
+        b = SummaryEntry(title="x", summary="y", mtime=1.0)
+        assert a == b

--- a/tests/summary/test_summary_service.py
+++ b/tests/summary/test_summary_service.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from claudewatch.backend.core.process.service import ProcessService
 from claudewatch.backend.core.session_log.service import SessionLogService
+from claudewatch.backend.summary.models import SummaryEntry
 from claudewatch.backend.summary.service import SummaryService
 
 
@@ -203,7 +204,7 @@ class TestPersistentStore:
         store_file.write_text(json.dumps({"/test": {"summary": "hello", "mtime": time.time()}}))
         svc = SummaryService(SessionLogService(), ProcessService(), store_path=str(store_file))
         svc._load_store()
-        assert svc._store["/test"]["summary"] == "hello"
+        assert svc._store["/test"].summary == "hello"
 
     def test_load_missing_file(self, tmp_path):
         svc = SummaryService(SessionLogService(), ProcessService(), store_path=str(tmp_path / "nope.json"))
@@ -220,7 +221,7 @@ class TestPersistentStore:
     def test_save_writes_to_disk(self, tmp_path):
         store_file = tmp_path / "summaries.json"
         svc = SummaryService(SessionLogService(), ProcessService(), store_path=str(store_file))
-        svc._store = {"/test": {"summary": "hi", "mtime": 1.0}}
+        svc._store = {"/test": SummaryEntry(title="", summary="hi", mtime=1.0)}
         svc._save_store()
         with open(store_file) as f:
             data = json.load(f)
@@ -257,7 +258,7 @@ class TestCacheSummary:
 
         svc = SummaryService(SessionLogService(), ProcessService(), store_path=str(tmp_path / "store.json"))
         svc._store_loaded = True
-        svc._store = {"/test": {"summary": "old", "mtime": 1.0}}
+        svc._store = {"/test": SummaryEntry(title="", summary="old", mtime=1.0)}
         with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
             result = svc.get_cached("/test")
         # mtime of jsonl > cached mtime of 1.0, so stale

--- a/tests/usage/test_usage_tokens.py
+++ b/tests/usage/test_usage_tokens.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import MagicMock
 
+from claudewatch.backend.core.dto import TokenUsageDTO
 from claudewatch.backend.usage.service import (
     UsageService,
     _fmt_tokens,
@@ -44,7 +45,7 @@ class TestFmtTokens:
 
 class TestFormatTokensBreakdown:
     def test_full_breakdown(self):
-        tokens = {"input": 5000, "output": 2000, "cache_create": 3000, "cache_read": 10000}
+        tokens = TokenUsageDTO(input=5000, output=2000, cache_create=3000, cache_read=10000)
         lines = format_tokens_breakdown(tokens)
         assert any("Input" in ln for ln in lines)
         assert any("Output" in ln for ln in lines)
@@ -53,13 +54,13 @@ class TestFormatTokensBreakdown:
         assert any("Total" in ln for ln in lines)
 
     def test_no_cache(self):
-        tokens = {"input": 5000, "output": 2000, "cache_create": 0, "cache_read": 0}
+        tokens = TokenUsageDTO(input=5000, output=2000, cache_create=0, cache_read=0)
         lines = format_tokens_breakdown(tokens)
         assert not any("Cache" in ln for ln in lines)
         assert any("Total" in ln for ln in lines)
 
     def test_zeros(self):
-        tokens = {"input": 0, "output": 0, "cache_create": 0, "cache_read": 0}
+        tokens = TokenUsageDTO(input=0, output=0, cache_create=0, cache_read=0)
         assert format_tokens_breakdown(tokens) == []
 
 
@@ -69,12 +70,14 @@ class TestUsageServiceGetTokens:
     def test_returns_empty_when_no_jsonl(self):
         svc = _make_service(find_most_recent=None)
         result = svc.get_tokens("/Users/dev/myapp")
-        assert result == {"input": 0, "output": 0, "cache_create": 0, "cache_read": 0}
+        assert isinstance(result, TokenUsageDTO)
+        assert result.total == 0
 
     def test_returns_empty_when_file_gone(self, tmp_path):
         svc = _make_service(find_most_recent=str(tmp_path / "gone.jsonl"))
         result = svc.get_tokens("/Users/dev/myapp")
-        assert result == {"input": 0, "output": 0, "cache_create": 0, "cache_read": 0}
+        assert isinstance(result, TokenUsageDTO)
+        assert result.total == 0
 
     def test_parses_usage_from_lines(self, tmp_path):
         # Need a real file for os.path.getmtime
@@ -104,10 +107,10 @@ class TestUsageServiceGetTokens:
 
         svc = _make_service(find_most_recent=str(jsonl_file), read_full=lines)
         result = svc.get_tokens("/Users/dev/myapp")
-        assert result["input"] == 110
-        assert result["output"] == 55
-        assert result["cache_create"] == 200
-        assert result["cache_read"] == 300
+        assert result.input == 110
+        assert result.output == 55
+        assert result.cache_create == 200
+        assert result.cache_read == 300
 
     def test_caches_by_mtime(self, tmp_path):
         jsonl_file = tmp_path / "session.jsonl"
@@ -118,7 +121,7 @@ class TestUsageServiceGetTokens:
         r1 = svc.get_tokens("/Users/dev/myapp")
         r2 = svc.get_tokens("/Users/dev/myapp")
         assert r1 == r2
-        assert r1["input"] == 42
+        assert r1.input == 42
         # read_full should only be called once (second call uses cache)
         assert svc._session_log_service.read_full.call_count == 1
 
@@ -132,7 +135,7 @@ class TestUsageServiceGetTokens:
 
         svc = _make_service(find_most_recent=str(jsonl_file), read_full=lines)
         result = svc.get_tokens("/Users/dev/myapp")
-        assert result["input"] == 5
+        assert result.input == 5
 
     def test_instance_cache_is_isolated(self, tmp_path):
         """Each UsageService instance has its own cache."""
@@ -149,18 +152,18 @@ class TestUsageServiceGetTokens:
 
 class TestFormatTokensCompact:
     def test_zero_returns_empty(self):
-        tokens = {"input": 0, "output": 0, "cache_create": 0, "cache_read": 0}
+        tokens = TokenUsageDTO(input=0, output=0, cache_create=0, cache_read=0)
         assert format_tokens_compact(tokens) == ""
 
     def test_basic_in_out(self):
-        tokens = {"input": 1000, "output": 500, "cache_create": 0, "cache_read": 0}
+        tokens = TokenUsageDTO(input=1000, output=500, cache_create=0, cache_read=0)
         result = format_tokens_compact(tokens)
         assert "1K in" in result
         assert "500 out" in result
         assert "cache" not in result
 
     def test_with_cache(self):
-        tokens = {"input": 1000, "output": 500, "cache_create": 200, "cache_read": 300}
+        tokens = TokenUsageDTO(input=1000, output=500, cache_create=200, cache_read=300)
         result = format_tokens_compact(tokens)
         assert "cache" in result
         assert "total" in result


### PR DESCRIPTION
## Summary
- Replace all raw `dict` and `tuple` returns with frozen dataclasses across 8 backend domains
- New domain models: `ProcessInfo`, `ProcessEntry`, `PendingToolResult`, `ToolUseInfo`, `PromptInfo`, `TerminalMatch`, `SummaryEntry`, `FrontmostWindow`
- New cross-boundary DTOs: `TokenUsageDTO` (with `total` property), `ChangelogEntryDTO`
- Bookmark/history repos now return DTOs directly, eliminating manual `.get()` conversion in services
- Fix pre-existing notification test failure (mock `NSUserNotificationCenter` for headless environments)