### PR TITLE
fix: launch-at-login survives Homebrew upgrades (#134)

### DIFF
--- a/claudewatch/backend/core/login_item.py
+++ b/claudewatch/backend/core/login_item.py
@@ -90,3 +90,30 @@ def sync_login_item(enabled: bool) -> None:
         add_login_item()
     else:
         remove_login_item()
+
+
+def refresh_login_item() -> None:
+    """If launch_at_login is active, ensure the plist points to the current binary.
+
+    Fixes stale plists after Homebrew upgrades move the app bundle.
+    Called on every launch from main().
+    """
+    if not os.path.isfile(_PLIST_PATH):
+        return
+
+    try:
+        with open(_PLIST_PATH, "rb") as f:
+            plist = plistlib.load(f)
+    except (OSError, plistlib.InvalidFileException):
+        log.warning("login_item.refresh: could not read plist")
+        return
+
+    stored_args = plist.get("ProgramArguments", [])
+    stored_path = stored_args[0] if stored_args else ""
+    current_path = _get_app_path()
+
+    if stored_path == current_path:
+        return
+
+    log.info("login_item.refresh: updating path from %s to %s", stored_path, current_path)
+    add_login_item()

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -25,13 +25,13 @@ from AppKit import (
 )
 from PyObjCTools import AppHelper
 
-import claudewatch.backend.core.login_item  # noqa: F401 — registers feature
 from claudewatch.backend.analytics.dependencies import get_analytics_service
 from claudewatch.backend.analytics.service import AnalyticsService
 from claudewatch.backend.bookmark.dependencies import get_bookmark_service
 from claudewatch.backend.bookmark.service import BookmarkService
 from claudewatch.backend.core import features
 from claudewatch.backend.core.helpers import escape_applescript, run_applescript
+from claudewatch.backend.core.login_item import refresh_login_item
 from claudewatch.backend.core.models import ClaudeSession
 from claudewatch.backend.core.paths import LOG_PATH, ensure_data_dir
 from claudewatch.backend.core.session_log.dependencies import get_session_log_service
@@ -613,6 +613,7 @@ def main() -> None:
 
     ensure_data_dir()
     ensure_defaults_migrated()
+    refresh_login_item()
     if not os.path.exists(LOG_PATH):
         os.open(LOG_PATH, os.O_CREAT | os.O_WRONLY, 0o600)
     file_handler = logging.handlers.RotatingFileHandler(


### PR DESCRIPTION
## Summary
- Added `refresh_login_item()` that compares the plist's stored binary path with the current `_get_app_path()`
- If the path changed (Homebrew moved the binary), re-writes the plist automatically
- Called on every launch from `main()`, before service initialization
- No-op if launch-at-login is not enabled (no plist file)

Closes #134