### PR TITLE
fix: pre-release polish — analytics crash, UI overflow, empty state

### DIFF
--- a/claudewatch/backend/analytics/repository.py
+++ b/claudewatch/backend/analytics/repository.py
@@ -10,6 +10,7 @@ import time
 from datetime import UTC, datetime
 
 from sqlalchemy import desc, distinct, func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
 from claudewatch.backend.analytics.models import (
@@ -96,7 +97,7 @@ class Ingest:
                     log.exception("ingest: error processing %s", path)
         return stats
 
-    def process_file(
+    def process_file(  # noqa: PLR0912
         self,
         path: str,
         session_id: str,
@@ -138,8 +139,11 @@ class Ingest:
                             continue
                         if not isinstance(entry, dict):
                             continue
-                        self._process_entry(s, entry, session_id, proj_key)
-                        count += 1
+                        try:
+                            self._process_entry(s, entry, session_id, proj_key)
+                            count += 1
+                        except IntegrityError:
+                            s.rollback()  # duplicate UUID — skip this entry
             except OSError:
                 log.warning("ingest: failed to read %s", path)
                 return 0

--- a/claudewatch/ui/preferences/panes/sessions.py
+++ b/claudewatch/ui/preferences/panes/sessions.py
@@ -28,8 +28,10 @@ from claudewatch.backend.usage.dependencies import get_usage_service
 from claudewatch.backend.usage.service import MODEL_DISPLAY_NAMES, format_tokens_compact
 from claudewatch.ui.components.composites.session_row import build_session_row
 from claudewatch.ui.components.tokens import Font, Spacing
+from claudewatch.ui.components.widgets.labels import secondary_label
 from claudewatch.ui.icons import sf_icon
 from claudewatch.ui.preferences.panes.common import BasePane
+from claudewatch.ui.theme import theme
 
 _PAD = 24
 _CARD_PAD = 16
@@ -159,10 +161,17 @@ def rebuild_rows(delegate: object) -> None:
     total_h = max(scroll.frame().size.height, len(entries) * _ROW_H)
     inner = NSView.alloc().initWithFrame_(NSMakeRect(0, 0, w, total_h))
 
-    y = total_h
-    for entry in entries:
-        y -= _ROW_H
-        _add_row(inner, delegate, entry, 0, y, w, _ROW_H, pinned_cwds, usage_svc, summary_svc)
+    if not entries:
+        empty_label = secondary_label("No sessions found", size=13.0)
+        empty_label.setTextColor_(theme.tertiary)
+        empty_label.setAlignment_(1)  # NSTextAlignmentCenter
+        empty_label.setFrame_(NSMakeRect(0, total_h // 2, w, 18))
+        inner.addSubview_(empty_label)
+    else:
+        y = total_h
+        for entry in entries:
+            y -= _ROW_H
+            _add_row(inner, delegate, entry, 0, y, w, _ROW_H, pinned_cwds, usage_svc, summary_svc)
 
     scroll.setDocumentView_(inner)
     inner.scrollPoint_((0, total_h))  # scroll to top (newest first)

--- a/claudewatch/ui/preferences/panes/usage.py
+++ b/claudewatch/ui/preferences/panes/usage.py
@@ -186,6 +186,7 @@ def _build_top_sessions_card(delegate: object, card_w: float, top: list[tuple[st
         project_btn.setBordered_(False)
         project_btn.setAlignment_(0)
         project_btn.cell().setRepresentedObject_(project)
+        project_btn.setLineBreakMode_(5)  # NSLineBreakByTruncatingTail
         project_btn.setFrame_(NSMakeRect(_CARD_PAD, row_y, 160, 18))
         content.addSubview_(project_btn)
         # Date


### PR DESCRIPTION
## Summary
- Analytics ingest: catch IntegrityError per-entry instead of crashing on duplicate UUIDs (1000+ errors in logs)
- Usage pane: truncate long project names with ellipsis instead of overflowing columns
- Sessions pane: show "No sessions found" placeholder when search/filter is empty