### PR TITLE
fix: resume session opens Terminal in correct project directory

### DIFF
--- a/claudewatch/ui/activity.py
+++ b/claudewatch/ui/activity.py
@@ -122,9 +122,10 @@ class _ActivityDelegate(NSObject):
             return
         safe_cwd = escape_applescript(self._cwd)
         run_applescript(f'''
+            do shell script "open -a Terminal \\"{safe_cwd}\\""
+            delay 0.5
             tell application "Terminal"
-                activate
-                do script "cd \\"{safe_cwd}\\" && claude -r {sid}"
+                do script "claude -r {sid}" in front window
             end tell
         ''')
 

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -497,13 +497,21 @@ class ClaudeWatchApp:
                 return
             # Open a new Terminal tab, cd to the project dir, and resume
             safe_cwd = escape_applescript(cwd) if cwd else ""
-            cd_cmd = f'cd \\"{safe_cwd}\\" && ' if safe_cwd else ""
-            run_applescript(f"""
-                tell application "Terminal"
-                    activate
-                    do script "{cd_cmd}claude -r {session_id}"
-                end tell
-            """)
+            if safe_cwd:
+                run_applescript(f"""
+                    do shell script "open -a Terminal \\"{safe_cwd}\\""
+                    delay 0.5
+                    tell application "Terminal"
+                        do script "claude -r {session_id}" in front window
+                    end tell
+                """)
+            else:
+                run_applescript(f"""
+                    tell application "Terminal"
+                        activate
+                        do script "claude -r {session_id}"
+                    end tell
+                """)
             log.info("session resumed: %s", session_id[:8])
 
         return handler

--- a/claudewatch/ui/preferences/handlers/actions.py
+++ b/claudewatch/ui/preferences/handlers/actions.py
@@ -33,9 +33,10 @@ def handle_resume(delegate: object, sender: object) -> None:  # noqa: ARG001
         return
     safe_cwd = escape_applescript(cwd)
     run_applescript(f'''
+        do shell script "open -a Terminal \\"{safe_cwd}\\""
+        delay 0.5
         tell application "Terminal"
-            activate
-            do script "cd \\"{safe_cwd}\\" && claude -r {sid}"
+            do script "claude -r {sid}" in front window
         end tell
     ''')
 


### PR DESCRIPTION
Uses 'open -a Terminal <dir>' so the shell starts in the project directory, then runs claude -r in that window. Fixes cd command getting mangled by slow zsh init.