### PR TITLE
bump v0.8.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,20 @@ jobs:
 
       - name: Build .app bundle
         run: |
-          uv run briefcase create macOS --no-input || true
-          uv run briefcase build macOS --no-input
+          uv run briefcase create macOS --no-input --python-version 3.13
+          uv run briefcase build macOS --no-input --python-version 3.13
           uv run briefcase package macOS --adhoc-sign --no-input
+
+      - name: Verify bundle has packages
+        run: |
+          APP_PKGS="build/claudewatch/macos/app/ClaudeWatch.app/Contents/Resources/app_packages"
+          COUNT=$(find "$APP_PKGS" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')
+          if [ "$COUNT" -lt 5 ]; then
+            echo "ERROR: app_packages has only $COUNT entries — package installation likely failed"
+            ls "$APP_PKGS"
+            exit 1
+          fi
+          echo "OK: app_packages has $COUNT entries"
 
       - name: Zip the app and generate checksums
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: 4924b0e01e032fea073ad04a1c5cfa7e4add0afb  # v0.15.6
     hooks:
       - id: ruff
         args: [--fix, --config=ruff.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.15.6
     hooks:
       - id: ruff
         args: [--fix, --config=ruff.toml]

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -448,21 +448,40 @@ class SummaryService(BaseService):
         session_id = self._summary_session_id
         if session_id and use_session:
             cmd = [
-                claude_path, "-p", _CONVERSATION_PREFIX + conversation,
-                "-r", session_id, "--model", model, "--effort", effort,
+                claude_path,
+                "-p",
+                _CONVERSATION_PREFIX + conversation,
+                "-r",
+                session_id,
+                "--model",
+                model,
+                "--effort",
+                effort,
             ]
             log.debug("summarize: reusing session %s", session_id[:8])
         elif use_session:
             session_id = str(uuid.uuid4())
             cmd = [
-                claude_path, "-p", _SYSTEM_PROMPT + _CONVERSATION_PREFIX + conversation,
-                "--session-id", session_id, "--model", model, "--effort", effort,
+                claude_path,
+                "-p",
+                _SYSTEM_PROMPT + _CONVERSATION_PREFIX + conversation,
+                "--session-id",
+                session_id,
+                "--model",
+                model,
+                "--effort",
+                effort,
             ]
             log.info("summarize: creating session %s", session_id[:8])
         else:
             cmd = [
-                claude_path, "-p", _SYSTEM_PROMPT + _CONVERSATION_PREFIX + conversation,
-                "--model", model, "--effort", effort,
+                claude_path,
+                "-p",
+                _SYSTEM_PROMPT + _CONVERSATION_PREFIX + conversation,
+                "--model",
+                model,
+                "--effort",
+                effort,
             ]
             log.debug("summarize: using non-session fallback")
 

--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -325,9 +325,9 @@ class MenuBuilder:
             bookmark=self._app._make_bookmark_handler(s) if not pinned and s.session_id else None,
             unbookmark=self._app._make_unbookmark_handler(s.cwd) if pinned else None,
             quit=self._app._make_quit_handler(s),
-            track_summary=lambda cwd=s.cwd,
-            sid=s.session_id,
-            urgent=is_active: self._app._summary_service.track_session(cwd, urgent=urgent, session_id=sid),
+            track_summary=lambda cwd=s.cwd, sid=s.session_id, urgent=is_active: (
+                self._app._summary_service.track_session(cwd, urgent=urgent, session_id=sid)
+            ),
             usage_lines=format_tokens_breakdown(token_data),
         )
         agents = self._app._analytics_service.agents_for_session(s.session_id) if s.session_id else []

--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -325,9 +325,9 @@ class MenuBuilder:
             bookmark=self._app._make_bookmark_handler(s) if not pinned and s.session_id else None,
             unbookmark=self._app._make_unbookmark_handler(s.cwd) if pinned else None,
             quit=self._app._make_quit_handler(s),
-            track_summary=lambda cwd=s.cwd, sid=s.session_id, urgent=is_active: self._app._summary_service.track_session(
-                cwd, urgent=urgent, session_id=sid
-            ),
+            track_summary=lambda cwd=s.cwd,
+            sid=s.session_id,
+            urgent=is_active: self._app._summary_service.track_session(cwd, urgent=urgent, session_id=sid),
             usage_lines=format_tokens_breakdown(token_data),
         )
         agents = self._app._analytics_service.agents_for_session(s.session_id) if s.session_id else []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claudewatch"
-version = "0.7.7"
+version = "0.8.0"
 description = "macOS menu bar app for monitoring Claude Code sessions"
 readme = "README.md"
 license = "MIT"
@@ -37,7 +37,7 @@ packages = ["claudewatch"]
 [tool.briefcase]
 project_name = "ClaudeWatch"
 bundle = "com.claudewatch"
-version = "0.7.7"
+version = "0.8.0"
 url = "https://github.com/wingatethomas/claudewatch"
 license.file = "LICENSE"
 author = "ClaudeWatch Contributors"

--- a/tests/notifications/test_notifications.py
+++ b/tests/notifications/test_notifications.py
@@ -114,7 +114,6 @@ class TestNotifyIfNeeded:
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
             patch(f"{_MOD}.NSUserNotification", mock_cls),
-
         ):
             s = _make_session(pid=200, status=SessionStatus.ATTENTION)
             svc.notify_if_needed([s])
@@ -129,7 +128,6 @@ class TestNotifyIfNeeded:
         svc._center = mock_center
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
-
         ):
             s = _make_session(pid=200, status=SessionStatus.ATTENTION)
             svc.notify_if_needed([s])
@@ -145,7 +143,6 @@ class TestNotifyIfNeeded:
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
             patch(f"{_MOD}.NSUserNotification", mock_cls),
-
         ):
             s = _make_session(pid=200, status=SessionStatus.ATTENTION)
             svc.notify_if_needed([s])
@@ -159,7 +156,6 @@ class TestNotifyIfNeeded:
         svc._center = mock_center
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
-
         ):
             s = _make_session(pid=100, status=SessionStatus.ATTENTION)
             svc.notify_if_needed([s])
@@ -193,7 +189,6 @@ class TestNotifyIfNeeded:
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
             patch(f"{_MOD}.NSUserNotification", mock_cls),
-
         ):
             s = _make_session(pid=500, status=SessionStatus.ATTENTION)
             svc.notify_if_needed([s])
@@ -227,7 +222,6 @@ class TestNotifyIfNeeded:
         with (
             patch(f"{_MOD}.features.is_enabled", return_value=True),
             patch(f"{_MOD}.NSUserNotification", mock_cls),
-
         ):
             s = _make_session(
                 pid=600,

--- a/tests/security/test_security_service.py
+++ b/tests/security/test_security_service.py
@@ -277,12 +277,8 @@ class TestDiffSnapshots:
 
     def test_remote_control_enabled_nested(self) -> None:
         svc = _make_service()
-        old = ConfigSnapshot(
-            policy_limits={"restrictions": {"allow_remote_control": {"allowed": False}}}
-        )
-        new = ConfigSnapshot(
-            policy_limits={"restrictions": {"allow_remote_control": {"allowed": True}}}
-        )
+        old = ConfigSnapshot(policy_limits={"restrictions": {"allow_remote_control": {"allowed": False}}})
+        new = ConfigSnapshot(policy_limits={"restrictions": {"allow_remote_control": {"allowed": True}}})
         alerts = svc.diff_snapshots(old, new)
 
         assert len(alerts) == 1
@@ -357,9 +353,7 @@ class TestPublicDataExtraction:
 
     def test_get_policy_value_nested(self) -> None:
         svc = _make_service()
-        snap = ConfigSnapshot(
-            policy_limits={"restrictions": {"allow_remote_control": {"allowed": True}}}
-        )
+        snap = ConfigSnapshot(policy_limits={"restrictions": {"allow_remote_control": {"allowed": True}}})
         assert svc.get_policy_value(snap, "allow_remote_control") is True
 
     def test_get_blocklist_entries(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,7 @@ wheels = [
 
 [[package]]
 name = "claudewatch"
-version = "0.7.7"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "kuzu" },


### PR DESCRIPTION
- Bump version to 0.8.0 in pyproject.toml and uv.lock
- Fix release workflow: remove `|| true` from `briefcase create` so package install failures surface instead of producing an empty app bundle
- Pin briefcase to Python 3.13 (`--python-version 3.13`) to avoid kuzu wheel gaps on Python 3.14
- Add bundle integrity check — fails CI if `app_packages` has fewer than 5 entries after create