### PR TITLE
feat: native recap summaries from Claude session logs

### DIFF
--- a/claudewatch/backend/activity/service.py
+++ b/claudewatch/backend/activity/service.py
@@ -43,7 +43,19 @@ class ActivityService(BaseService):
             if not isinstance(msg, dict):
                 continue
 
-            if dtype == "user":
+            if dtype == "system" and d.get("subtype") == "away_summary":
+                content = d.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    entries.append(
+                        ActivityEventDTO(
+                            kind="recap",
+                            summary=_truncate(content.strip(), 80),
+                            detail=content.strip(),
+                            timestamp=ts,
+                        )
+                    )
+
+            elif dtype == "user":
                 content = msg.get("content", "")
                 if isinstance(content, str) and content.strip():
                     entries.append(

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -208,12 +208,50 @@ class SummaryService(BaseService):
                     return "failed"
         return "pending"
 
-    def generate_and_cache(self, cwd: str, session_id: str = "") -> str:  # noqa: PLR0912
+    def _extract_recap(self, cwd: str) -> str | None:
+        """Extract the most recent away_summary (recap) from the JSONL session log.
+
+        Claude Code writes these automatically when a session is resumed.
+        Returns the recap text, or None if no recap exists.
+        """
+        path = self._session_log_service.find_most_recent(cwd)
+        if not path:
+            return None
+
+        tail = self._session_log_service.read_tail(path, tail_bytes=200000)
+        if not tail:
+            return None
+
+        recap = None
+        for line in tail.strip().splitlines():
+            try:
+                d = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if d.get("type") == "system" and d.get("subtype") == "away_summary":
+                content = d.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    recap = content.strip()
+        return recap
+
+    def generate_and_cache(self, cwd: str, session_id: str = "") -> str:  # noqa: PLR0912, PLR0915
         """Generate a summary via claude -p and persist it."""
         key = self._cache_key(cwd, session_id)
         cached = self.get_cached(cwd, session_id)
         if cached is not None:
             return cached
+
+        # Check for a native Claude recap before spawning a subprocess
+        recap = self._extract_recap(cwd)
+        if recap:
+            _max_title = 30
+            title = recap[:_max_title]
+            last_space = title.rfind(" ")
+            if len(recap) > _max_title and last_space > _max_title // 2:
+                title = title[:last_space]
+            self.cache_full(cwd, title, recap, session_id)
+            log.debug("summarize: using native recap for %s", os.path.basename(cwd))
+            return title
 
         with self._failures_lock:
             fail_entry = self._failures.get(key)

--- a/claudewatch/ui/activity.py
+++ b/claudewatch/ui/activity.py
@@ -48,6 +48,7 @@ _KIND_CONFIG = {
     "user": {"icon": "❯", "color": NSColor.systemGreenColor(), "label": "You"},
     "assistant": {"icon": "◇", "color": NSColor.systemBlueColor(), "label": "Claude"},
     "tool": {"icon": "⚙", "color": NSColor.systemOrangeColor(), "label": "Tool"},
+    "recap": {"icon": "✻", "color": NSColor.systemPurpleColor(), "label": "Recap"},
 }
 _MONO = NSFont.monospacedSystemFontOfSize_weight_(Font.SMALL, 0)
 _MONO_BOLD = NSFont.monospacedSystemFontOfSize_weight_(Font.SMALL, 0.5)

--- a/tests/activity/test_activity.py
+++ b/tests/activity/test_activity.py
@@ -288,6 +288,40 @@ class TestParseActivity:
         assert len(result) == 1
         assert result[0].detail == "new msg"
 
+    def test_parses_recap_from_away_summary(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [
+                {"type": "user", "message": {"content": "fix auth"}, "timestamp": "2026-01-01T00:00:00Z"},
+                {
+                    "type": "system",
+                    "subtype": "away_summary",
+                    "content": "Fixed auth middleware and added tests.",
+                    "timestamp": "2026-01-01T00:05:00Z",
+                },
+            ],
+        )
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = ActivityService(SessionLogService()).parse("/Users/dev/myapp")
+        recaps = [e for e in result if e.kind == "recap"]
+        assert len(recaps) == 1
+        assert recaps[0].detail == "Fixed auth middleware and added tests."
+
+    def test_ignores_non_recap_system_entries(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [
+                {"type": "system", "subtype": "other", "content": "not a recap", "timestamp": ""},
+            ],
+        )
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = ActivityService(SessionLogService()).parse("/Users/dev/myapp")
+        assert result == []
+
     def test_skips_non_list_assistant_content(self, tmp_path):
         proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
         proj_dir.mkdir(parents=True)

--- a/tests/summary/test_summary_service.py
+++ b/tests/summary/test_summary_service.py
@@ -153,6 +153,126 @@ class TestExtractConversationText:
         assert result == ""
 
 
+class TestExtractRecap:
+    """Tests for SummaryService._extract_recap."""
+
+    def test_returns_recap_from_away_summary(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [
+                {"type": "user", "message": {"content": "fix auth"}, "timestamp": ""},
+                {
+                    "type": "system",
+                    "subtype": "away_summary",
+                    "content": "Fixed auth middleware and added tests.",
+                    "timestamp": "2026-01-01T00:05:00Z",
+                },
+            ],
+        )
+        svc, _ = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = svc._extract_recap("/Users/dev/myapp")
+        assert result == "Fixed auth middleware and added tests."
+
+    def test_returns_most_recent_recap(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [
+                {
+                    "type": "system",
+                    "subtype": "away_summary",
+                    "content": "Old recap.",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                },
+                {"type": "user", "message": {"content": "more work"}, "timestamp": ""},
+                {
+                    "type": "system",
+                    "subtype": "away_summary",
+                    "content": "Newer recap after more work.",
+                    "timestamp": "2026-01-01T01:00:00Z",
+                },
+            ],
+        )
+        svc, _ = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = svc._extract_recap("/Users/dev/myapp")
+        assert result == "Newer recap after more work."
+
+    def test_returns_none_when_no_recap(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [{"type": "user", "message": {"content": "hello"}, "timestamp": ""}],
+        )
+        svc, _ = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = svc._extract_recap("/Users/dev/myapp")
+        assert result is None
+
+    def test_returns_none_for_missing_project(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "nope")):
+            result = svc._extract_recap("/Users/dev/myapp")
+        assert result is None
+
+    def test_ignores_other_system_subtypes(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [
+                {"type": "system", "subtype": "other_thing", "content": "not a recap", "timestamp": ""},
+            ],
+        )
+        svc, _ = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = svc._extract_recap("/Users/dev/myapp")
+        assert result is None
+
+    def test_skips_empty_recap_content(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [
+                {"type": "system", "subtype": "away_summary", "content": "", "timestamp": ""},
+            ],
+        )
+        svc, _ = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = svc._extract_recap("/Users/dev/myapp")
+        assert result is None
+
+    def test_generate_uses_recap_over_claude_p(self, tmp_path):
+        """generate_and_cache should use native recap instead of spawning claude -p."""
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [
+                {"type": "user", "message": {"content": "fix auth"}, "timestamp": ""},
+                {
+                    "type": "system",
+                    "subtype": "away_summary",
+                    "content": "Fixed auth middleware and added integration tests.",
+                    "timestamp": "2026-01-01T00:05:00Z",
+                },
+            ],
+        )
+        svc, _ = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = svc.generate_and_cache("/Users/dev/myapp")
+            assert result  # got a title back
+            # Full recap should be in the cached summary
+            cached = svc.get_cached_summary("/Users/dev/myapp")
+            assert cached == "Fixed auth middleware and added integration tests."
+
+
 class TestCallClaude:
     """Tests for SummaryService._call_claude."""
 


### PR DESCRIPTION
- Read `away_summary` entries from JSONL session logs for instant, free session summaries
- Falls back to `claude -p` only when no native recap exists (session never resumed)
- Show recaps in activity feed with purple ✻ icon