### PR TITLE
fix: recap summaries work with background_summaries disabled

### DIFF
--- a/claudewatch/backend/bookmark/dependencies.py
+++ b/claudewatch/backend/bookmark/dependencies.py
@@ -1,11 +1,11 @@
 from functools import lru_cache
 
 from claudewatch.backend.bookmark.service import BookmarkService
-from claudewatch.backend.core.features import Facet, FacetType, Feature, register
+from claudewatch.backend.core.features import Facet, FacetType, Feature, FeatureKey, register
 
 register(
     Feature(
-        key="bookmarks",
+        key=FeatureKey.BOOKMARKS,
         description="Bookmarks",
         facets=(
             Facet(

--- a/claudewatch/backend/bookmark/repository.py
+++ b/claudewatch/backend/bookmark/repository.py
@@ -8,6 +8,7 @@ from typing import TypedDict
 
 from claudewatch.backend.core import features
 from claudewatch.backend.core.dto import BookmarkDTO
+from claudewatch.backend.core.features import FeatureKey
 from claudewatch.backend.core.paths import PINS_PATH
 
 log = logging.getLogger("claudewatch")
@@ -31,7 +32,7 @@ def _load() -> list[_BookmarkRecord]:
                 return []
     except (OSError, json.JSONDecodeError):
         return []
-    raw = features.get_facet("bookmarks", "expiry_days") or "30 days"
+    raw = features.get_facet(FeatureKey.BOOKMARKS, "expiry_days") or "30 days"
     try:
         ttl_days = 0 if raw == "Never" else int(str(raw).rstrip(" days"))
     except (ValueError, TypeError):

--- a/claudewatch/backend/core/features.py
+++ b/claudewatch/backend/core/features.py
@@ -18,6 +18,16 @@ log = logging.getLogger("claudewatch")
 _registry: dict[str, Feature] = {}
 
 
+class FeatureKey(StrEnum):
+    ACCESSIBILITY = "accessibility"
+    AUTO_UPDATES = "auto_updates"
+    BACKGROUND_SUMMARIES = "background_summaries"
+    BOOKMARKS = "bookmarks"
+    LAUNCH_AT_LOGIN = "launch_at_login"
+    NOTIFICATIONS = "notifications"
+    SECURITY = "security"
+
+
 class FacetType(StrEnum):
     BOOL = "bool"
     INT = "int"

--- a/claudewatch/backend/core/login_item.py
+++ b/claudewatch/backend/core/login_item.py
@@ -8,14 +8,14 @@ import os
 import plistlib
 import sys
 
-from claudewatch.backend.core.features import Facet, FacetType, Feature, register
+from claudewatch.backend.core.features import Facet, FacetType, Feature, FeatureKey, register
 
 log = logging.getLogger("claudewatch")
 
-register(Feature(key="launch_at_login", description="Launch at login", default_enabled=False))
+register(Feature(key=FeatureKey.LAUNCH_AT_LOGIN, description="Launch at login", default_enabled=False))
 register(
     Feature(
-        key="accessibility",
+        key=FeatureKey.ACCESSIBILITY,
         description="Accessibility",
         default_enabled=True,
         facets=(

--- a/claudewatch/backend/notifications/dependencies.py
+++ b/claudewatch/backend/notifications/dependencies.py
@@ -1,12 +1,12 @@
 from functools import lru_cache
 
-from claudewatch.backend.core.features import Facet, FacetType, Feature, register
+from claudewatch.backend.core.features import Facet, FacetType, Feature, FeatureKey, register
 from claudewatch.backend.core.settings import get_available_sounds
 from claudewatch.backend.notifications.service import NotificationService
 
 register(
     Feature(
-        key="notifications",
+        key=FeatureKey.NOTIFICATIONS,
         description="Notifications",
         facets=(
             Facet(

--- a/claudewatch/backend/notifications/service.py
+++ b/claudewatch/backend/notifications/service.py
@@ -10,6 +10,7 @@ import time
 from Foundation import NSObject, NSUserNotification, NSUserNotificationCenter
 
 from claudewatch.backend.core import features
+from claudewatch.backend.core.features import FeatureKey
 from claudewatch.backend.core.helpers import is_accessibility_trusted, run_applescript
 from claudewatch.backend.core.models import ClaudeSession
 from claudewatch.backend.core.service import BaseService
@@ -102,7 +103,7 @@ class NotificationService(BaseService):
 
     def send(self, title: str, subtitle: str, message: str, *, sound: str | None = None) -> None:
         """Send a single notification (fire-and-forget)."""
-        if not features.is_enabled("notifications") or self._center is None:
+        if not features.is_enabled(FeatureKey.NOTIFICATIONS) or self._center is None:
             return
         n = NSUserNotification.alloc().init()
         n.setTitle_(title)
@@ -114,7 +115,7 @@ class NotificationService(BaseService):
 
     def notify_if_needed(self, sessions: list[ClaudeSession]) -> None:  # noqa: PLR0912
         """Send notifications for sessions that need attention."""
-        if not features.is_enabled("notifications"):
+        if not features.is_enabled(FeatureKey.NOTIFICATIONS):
             return
 
         attention = [s for s in sessions if s.needs_attention]
@@ -165,7 +166,7 @@ class NotificationService(BaseService):
             n.setActionButtonTitle_("Focus")
             n.setUserInfo_({"pid": s.pid, "project": s.project})
 
-            sound_name = str(features.get_facet("notifications", "sound") or "Glass")
+            sound_name = str(features.get_facet(FeatureKey.NOTIFICATIONS, "sound") or "Glass")
             if sound_name:
                 n.setSoundName_(sound_name)
 

--- a/claudewatch/backend/onboarding/service.py
+++ b/claudewatch/backend/onboarding/service.py
@@ -11,6 +11,7 @@ import time
 from typing import TYPE_CHECKING
 
 from claudewatch.backend.core import features
+from claudewatch.backend.core.features import FeatureKey
 from claudewatch.backend.core.service import BaseService
 from claudewatch.backend.core.settings import get_setting, set_setting
 
@@ -73,7 +74,7 @@ class OnboardingService(BaseService):
         """
         if self.is_tip_shown(tip_id):
             return False
-        if not features.is_enabled("notifications"):
+        if not features.is_enabled(FeatureKey.NOTIFICATIONS):
             return False
 
         tip = TIPS.get(tip_id)

--- a/claudewatch/backend/security/dependencies.py
+++ b/claudewatch/backend/security/dependencies.py
@@ -2,7 +2,7 @@
 
 from functools import lru_cache
 
-from claudewatch.backend.core.features import Facet, FacetType, Feature, register
+from claudewatch.backend.core.features import Facet, FacetType, Feature, FeatureKey, register
 from claudewatch.backend.core.session_log.dependencies import get_session_log_service
 from claudewatch.backend.notifications.dependencies import get_notification_service
 from claudewatch.backend.security.repository import SecurityRepository
@@ -10,7 +10,7 @@ from claudewatch.backend.security.service import SecurityService
 
 register(
     Feature(
-        key="security",
+        key=FeatureKey.SECURITY,
         description="Security Monitoring",
         default_enabled=True,
         facets=(

--- a/claudewatch/backend/summary/dependencies.py
+++ b/claudewatch/backend/summary/dependencies.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 
-from claudewatch.backend.core.features import Facet, FacetType, Feature, register
+from claudewatch.backend.core.features import Facet, FacetType, Feature, FeatureKey, register
 from claudewatch.backend.core.paths import SUMMARIES_PATH
 from claudewatch.backend.core.process.dependencies import get_process_service
 from claudewatch.backend.core.session_log.dependencies import get_session_log_service
@@ -9,7 +9,7 @@ from claudewatch.backend.summary.service import SummaryService
 
 register(
     Feature(
-        key="background_summaries",
+        key=FeatureKey.BACKGROUND_SUMMARIES,
         description="Background summaries",
         facets=(
             Facet(

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -234,7 +234,7 @@ class SummaryService(BaseService):
                     recap = content.strip()
         return recap
 
-    def generate_and_cache(self, cwd: str, session_id: str = "") -> str:  # noqa: PLR0912, PLR0915
+    def generate_and_cache(self, cwd: str, session_id: str = "") -> str:  # noqa: PLR0911, PLR0912, PLR0915
         """Generate a summary via claude -p and persist it."""
         key = self._cache_key(cwd, session_id)
         cached = self.get_cached(cwd, session_id)
@@ -266,6 +266,10 @@ class SummaryService(BaseService):
                         self._failures.pop(key, None)
                     else:
                         return ""
+
+        # Recap-only mode: if claude -p is disabled, don't attempt subprocess
+        if not features.is_enabled("background_summaries"):
+            return ""
 
         with self._in_progress_lock:
             if key in self._in_progress:
@@ -338,8 +342,6 @@ class SummaryService(BaseService):
             self._tracked_cwds.discard(cwd)
 
     def _ensure_bg_thread(self) -> None:
-        if not features.is_enabled("background_summaries"):
-            return
         if self._bg_thread is not None and self._bg_thread.is_alive():
             return
         self._bg_thread = threading.Thread(target=self._bg_refresh_loop, daemon=True)

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -15,6 +15,7 @@ import time
 import uuid
 
 from claudewatch.backend.core import features
+from claudewatch.backend.core.features import FeatureKey
 from claudewatch.backend.core.process.service import ProcessService
 from claudewatch.backend.core.service import BaseService
 from claudewatch.backend.core.session_log.service import SessionLogService
@@ -268,7 +269,7 @@ class SummaryService(BaseService):
                         return ""
 
         # Recap-only mode: if claude -p is disabled, don't attempt subprocess
-        if not features.is_enabled("background_summaries"):
+        if not features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES):
             return ""
 
         with self._in_progress_lock:
@@ -480,8 +481,8 @@ class SummaryService(BaseService):
         if not conversation:
             return ""
 
-        model = str(features.get_facet("background_summaries", "model") or "haiku")
-        effort = str(features.get_facet("background_summaries", "effort") or "low")
+        model = str(features.get_facet(FeatureKey.BACKGROUND_SUMMARIES, "model") or "haiku")
+        effort = str(features.get_facet(FeatureKey.BACKGROUND_SUMMARIES, "effort") or "low")
 
         use_session = self._session_failures < self._session_failure_threshold
 

--- a/claudewatch/backend/updates/dependencies.py
+++ b/claudewatch/backend/updates/dependencies.py
@@ -1,9 +1,9 @@
 from functools import lru_cache
 
-from claudewatch.backend.core.features import Feature, register
+from claudewatch.backend.core.features import Feature, FeatureKey, register
 from claudewatch.backend.updates.service import UpdateService
 
-register(Feature(key="auto_updates", description="Auto-update"))
+register(Feature(key=FeatureKey.AUTO_UPDATES, description="Auto-update"))
 
 
 @lru_cache(maxsize=1)

--- a/claudewatch/backend/updates/service.py
+++ b/claudewatch/backend/updates/service.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from claudewatch import __version__
 from claudewatch.backend.core import features
 from claudewatch.backend.core.dto import ChangelogEntryDTO, UpdateInfoDTO
+from claudewatch.backend.core.features import FeatureKey
 from claudewatch.backend.core.service import BaseService
 
 log = logging.getLogger("claudewatch")
@@ -142,7 +143,7 @@ class UpdateService(BaseService):
 
     def check(self) -> UpdateInfoDTO | None:
         """Check for a newer release. Updates instance cache. Thread-safe."""
-        if not features.is_enabled("auto_updates"):
+        if not features.is_enabled(FeatureKey.AUTO_UPDATES):
             return None
         now = time.time()
         with self._cache_lock:

--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -14,6 +14,7 @@ from AppKit import (
 from Foundation import NSRange
 
 from claudewatch.backend.core import features
+from claudewatch.backend.core.features import FeatureKey
 from claudewatch.backend.core.models import ClaudeSession, SessionStatus
 from claudewatch.backend.core.paths import is_homebrew_install
 from claudewatch.backend.usage.service import MODEL_DISPLAY_NAMES, format_tokens_breakdown
@@ -169,7 +170,7 @@ class MenuBuilder:
                     self._add_session_items(s, suffixes[s.pid], pinned=is_pinned)
 
         # Bookmarked sessions that are NOT currently active (respects feature toggle)
-        pins = self._app._bookmark_service.get_all() if features.is_enabled("bookmarks") else []
+        pins = self._app._bookmark_service.get_all() if features.is_enabled(FeatureKey.BOOKMARKS) else []
         inactive_pins = [p for p in pins if p.cwd not in active_cwds]
         if inactive_pins:
             self._menu.addItem_(NSMenuItem.separatorItem())

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -30,6 +30,7 @@ from claudewatch.backend.analytics.service import AnalyticsService
 from claudewatch.backend.bookmark.dependencies import get_bookmark_service
 from claudewatch.backend.bookmark.service import BookmarkService
 from claudewatch.backend.core import features
+from claudewatch.backend.core.features import FeatureKey
 from claudewatch.backend.core.helpers import escape_applescript, run_applescript
 from claudewatch.backend.core.login_item import refresh_login_item
 from claudewatch.backend.core.models import ClaudeSession
@@ -224,7 +225,7 @@ class ClaudeWatchApp:
 
     def _run_security_checks(self) -> None:
         """Run throttled security config + runtime checks."""
-        interval_str = str(features.get_facet("security", "check_interval") or "30s")
+        interval_str = str(features.get_facet(FeatureKey.SECURITY, "check_interval") or "30s")
         interval = self._INTERVAL_MAP.get(interval_str, 30)
         now = time.time()
         if now - self._last_security_check < interval:

--- a/claudewatch/ui/preferences/delegate.py
+++ b/claudewatch/ui/preferences/delegate.py
@@ -238,8 +238,9 @@ class PrefsDelegate(NSObject):
         from AppKit import NSSound
 
         from claudewatch.backend.core import features
+        from claudewatch.backend.core.features import FeatureKey
 
-        sound_name = features.get_facet("notifications", "sound") or "Glass"
+        sound_name = features.get_facet(FeatureKey.NOTIFICATIONS, "sound") or "Glass"
         sound = NSSound.soundNamed_(sound_name)
         if sound:
             sound.play()

--- a/claudewatch/ui/preferences/panes/settings.py
+++ b/claudewatch/ui/preferences/panes/settings.py
@@ -16,7 +16,7 @@ from AppKit import (
 from Foundation import NSMakeRect
 
 from claudewatch.backend.core import features
-from claudewatch.backend.core.features import FacetType
+from claudewatch.backend.core.features import FacetType, FeatureKey
 from claudewatch.ui.components.tokens import Font, Spacing, get_scheme
 from claudewatch.ui.components.widgets.buttons import Size, button
 from claudewatch.ui.components.widgets.cards import card
@@ -25,20 +25,20 @@ from claudewatch.ui.preferences.panes.common import CONTENT_PADDING, BasePane
 from claudewatch.ui.theme import theme
 
 _FEATURE_DETAILS: dict[str, str] = {
-    "bookmarks": "Save sessions to resume later from the menu bar.",
-    "notifications": "Get alerts when Claude needs your attention.",
-    "background_summaries": "Periodically regenerate session summaries in the background.",
-    "auto_updates": "Check GitHub for new releases periodically.",
-    "launch_at_login": "Start ClaudeWatch automatically when you log in.",
-    "accessibility": "Color scheme for status dots in the menu bar.",
-    "security": "Monitor Claude Code config for plugin installs, policy changes, and unsafe sessions.",
+    FeatureKey.BOOKMARKS: "Save sessions to resume later from the menu bar.",
+    FeatureKey.NOTIFICATIONS: "Get alerts when Claude needs your attention.",
+    FeatureKey.BACKGROUND_SUMMARIES: "Periodically regenerate session summaries in the background.",
+    FeatureKey.AUTO_UPDATES: "Check GitHub for new releases periodically.",
+    FeatureKey.LAUNCH_AT_LOGIN: "Start ClaudeWatch automatically when you log in.",
+    FeatureKey.ACCESSIBILITY: "Color scheme for status dots in the menu bar.",
+    FeatureKey.SECURITY: "Monitor Claude Code config for plugin installs, policy changes, and unsafe sessions.",
 }
 
 # Feature groups — defines section order and which features belong to each
 _FEATURE_GROUPS: list[tuple[str, list[str]]] = [
-    ("Sessions", ["bookmarks", "background_summaries"]),
-    ("Notifications", ["notifications"]),
-    ("App", ["launch_at_login", "auto_updates", "accessibility"]),
+    ("Sessions", [FeatureKey.BOOKMARKS, FeatureKey.BACKGROUND_SUMMARIES]),
+    ("Notifications", [FeatureKey.NOTIFICATIONS]),
+    ("App", [FeatureKey.LAUNCH_AT_LOGIN, FeatureKey.AUTO_UPDATES, FeatureKey.ACCESSIBILITY]),
 ]
 
 

--- a/claudewatch/ui/theme.py
+++ b/claudewatch/ui/theme.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from AppKit import NSColor, NSFont
 
 from claudewatch.backend.core import features
+from claudewatch.backend.core.features import FeatureKey
 from claudewatch.backend.core.models import SessionStatus
 from claudewatch.ui.components.tokens import Colors, Font, StatusScheme, get_scheme
 
@@ -32,7 +33,7 @@ class Theme:
 
     @property
     def scheme(self) -> StatusScheme:
-        scheme_name = str(features.get_facet("accessibility", "color_scheme") or "Default")
+        scheme_name = str(features.get_facet(FeatureKey.ACCESSIBILITY, "color_scheme") or "Default")
         return get_scheme(scheme_name)
 
     def status_color(self, status: SessionStatus) -> NSColor:


### PR DESCRIPTION
The bg thread feature gate blocked recap extraction too. Now the thread always starts (recaps are free), and only the claude -p subprocess is gated.