### PR TITLE
test: recap feature gate and FeatureKey enum coverage

### DIFF
--- a/tests/core/test_features.py
+++ b/tests/core/test_features.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 from claudewatch.backend.core import features
-from claudewatch.backend.core.features import Facet, Feature
+from claudewatch.backend.core.features import Facet, Feature, FeatureKey
 
 
 class TestFeatureRegistry:
@@ -124,3 +124,20 @@ class TestFacets:
     def test_get_facet_unregistered_facet(self):
         features.register(Feature(key="x", description="X"))
         assert features.get_facet("x", "nope") is None
+
+
+class TestFeatureKeyEnum:
+    """Verify FeatureKey enum matches registered features."""
+
+    def test_all_enum_values_are_strings(self):
+        for key in FeatureKey:
+            assert isinstance(key.value, str)
+
+    def test_enum_compares_equal_to_string(self):
+        assert FeatureKey.BOOKMARKS == "bookmarks"
+        assert FeatureKey.SECURITY == "security"
+
+    def test_enum_works_as_feature_key(self):
+        features._registry.clear()
+        features.register(Feature(key=FeatureKey.NOTIFICATIONS, description="Notifications"))
+        assert features.get_all()[0].key == "notifications"

--- a/tests/summary/test_summary_service.py
+++ b/tests/summary/test_summary_service.py
@@ -272,7 +272,6 @@ class TestExtractRecap:
             cached = svc.get_cached_summary("/Users/dev/myapp")
             assert cached == "Fixed auth middleware and added integration tests."
 
-
     def test_generate_skips_claude_p_when_feature_off(self, tmp_path):
         """With background_summaries off and no recap, generate_and_cache returns empty without subprocess."""
         proj_dir = tmp_path / "projects" / "-Users-dev-myapp"

--- a/tests/summary/test_summary_service.py
+++ b/tests/summary/test_summary_service.py
@@ -273,6 +273,51 @@ class TestExtractRecap:
             assert cached == "Fixed auth middleware and added integration tests."
 
 
+    def test_generate_skips_claude_p_when_feature_off(self, tmp_path):
+        """With background_summaries off and no recap, generate_and_cache returns empty without subprocess."""
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [{"type": "user", "message": {"content": "fix auth"}, "timestamp": ""}],
+        )
+        svc, _ = _make_service(tmp_path)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=False),
+            patch.object(svc, "_call_claude") as mock_claude,
+        ):
+            result = svc.generate_and_cache("/Users/dev/myapp")
+            mock_claude.assert_not_called()
+        assert result == ""
+
+    def test_generate_uses_recap_even_when_feature_off(self, tmp_path):
+        """Native recaps work regardless of the background_summaries toggle."""
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [
+                {"type": "user", "message": {"content": "fix auth"}, "timestamp": ""},
+                {
+                    "type": "system",
+                    "subtype": "away_summary",
+                    "content": "Fixed auth middleware.",
+                    "timestamp": "2026-01-01T00:05:00Z",
+                },
+            ],
+        )
+        svc, _ = _make_service(tmp_path)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=False),
+            patch.object(svc, "_call_claude") as mock_claude,
+        ):
+            result = svc.generate_and_cache("/Users/dev/myapp")
+            mock_claude.assert_not_called()
+        assert result  # recap title returned
+
+
 class TestCallClaude:
     """Tests for SummaryService._call_claude."""
 

--- a/tests/ui/menu/test_session_submenu.py
+++ b/tests/ui/menu/test_session_submenu.py
@@ -70,3 +70,16 @@ class TestSessionSubmenu:
         sub = build_session_submenu(delegate=self._make_delegate(), summary=None, actions=act)
         titles = _menu_titles(sub)
         assert "Remove" in titles
+
+    def test_no_generating_when_not_generating(self) -> None:
+        """When generating=False and no summary, submenu should not show 'Generating...'."""
+        sub = build_session_submenu(delegate=self._make_delegate(), summary=None, generating=False)
+        summary_item = sub.itemArray()[0]
+        sub_titles = _menu_titles(summary_item.submenu())
+        assert not any("Generating" in t for t in sub_titles)
+
+    def test_track_summary_called_when_no_summary(self) -> None:
+        tracker = MagicMock()
+        act = SessionActions(track_summary=tracker)
+        build_session_submenu(delegate=self._make_delegate(), summary=None, actions=act)
+        tracker.assert_called_once()


### PR DESCRIPTION
7 new tests: submenu respects generating flag, generate_and_cache skips claude-p when feature off, recaps work regardless, FeatureKey enum basics.