### PR TITLE
fix: all summary UI respects background_summaries toggle

### DIFF
--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -45,6 +45,13 @@ class MenuBuilder:
         self._app = app
         self._menu = menu
         self._delegate = delegate
+        self._summaries_on = features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES)
+
+    def _get_summary(self, cwd: str, session_id: str = "") -> str | None:
+        """Return cached summary if summaries are enabled, else None."""
+        if not self._summaries_on:
+            return None
+        return self._app._summary_service.get_cached_summary(cwd, session_id)
 
     def build(self, sessions: list[ClaudeSession]) -> None:  # noqa: PLR0912, PLR0915
         attention = [s for s in sessions if s.status == SessionStatus.ATTENTION]
@@ -197,7 +204,7 @@ class MenuBuilder:
                 pin_agents = self._app._analytics_service.agents_for_session(pin.session_id) if pin.session_id else []
                 sub = build_session_submenu(
                     delegate=d,
-                    summary=self._app._summary_service.get_cached_summary(pin.cwd, pin.session_id or ""),
+                    summary=self._get_summary(pin.cwd, pin.session_id or ""),
                     actions=actions,
                     agents=pin_agents,
                 )
@@ -254,7 +261,7 @@ class MenuBuilder:
                 )
                 item_sub = build_session_submenu(
                     delegate=d,
-                    summary=self._app._summary_service.get_cached_summary(entry.cwd, entry.session_id or ""),
+                    summary=self._get_summary(entry.cwd, entry.session_id or ""),
                     actions=actions,
                     agents=entry_agents,
                 )
@@ -321,7 +328,6 @@ class MenuBuilder:
         # Build submenu using shared session_submenu builder
         is_active = s.status in (SessionStatus.ATTENTION, SessionStatus.WORKING)
         token_data = self._app._usage_service.get_tokens(s.cwd)
-        summaries_on = features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES)
         actions = SessionActions(
             activity=self._app._make_activity_handler(s),
             bookmark=self._app._make_bookmark_handler(s) if not pinned and s.session_id else None,
@@ -333,11 +339,10 @@ class MenuBuilder:
             usage_lines=format_tokens_breakdown(token_data),
         )
         agents = self._app._analytics_service.agents_for_session(s.session_id) if s.session_id else []
-        cached_summary = self._app._summary_service.get_cached_summary(s.cwd, s.session_id)
         sub = build_session_submenu(
             delegate=d,
-            summary=cached_summary,
-            generating=summaries_on and self._app._summary_service.is_generating(s.cwd, s.session_id),
+            summary=self._get_summary(s.cwd, s.session_id),
+            generating=self._summaries_on and self._app._summary_service.is_generating(s.cwd, s.session_id),
             actions=actions,
             agents=agents,
         )
@@ -346,11 +351,11 @@ class MenuBuilder:
         self._menu.addItem_(item)
         # Detail line: model + summary (or status as fallback)
         model = self._app._usage_service.get_model(s.cwd)
-        cached = self._app._summary_service.get_cached(s.cwd, s.session_id)
+        cached = self._get_summary(s.cwd, s.session_id)
         _max_detail_total = 55
         if cached:
             oneliner = cached.replace("\n", " ").strip()
-        elif summaries_on:
+        elif self._summaries_on:
             status = self._app._summary_service.get_status(s.cwd, s.session_id)
             if status == "generating":
                 oneliner = "Generating summary…"

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -326,7 +326,11 @@ class ClaudeWatchApp:
     def _menu_key(self) -> str:
         parts = [f"scheme:{theme.scheme.name}"]
         for s in self.sessions:
-            cached = self._summary_service.get_cached(s.cwd) or ""
+            cached = (
+                (self._summary_service.get_cached(s.cwd) or "")
+                if features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES)
+                else ""
+            )
             parts.append(f"{s.pid}:{s.status.value}:{s.project}:{s.task_summary}:{s.last_output}:{cached}")
         return "|".join(parts)
 

--- a/claudewatch/ui/preferences/panes/sessions.py
+++ b/claudewatch/ui/preferences/panes/sessions.py
@@ -22,6 +22,8 @@ from AppKit import (
 from Foundation import NSMakeRect
 
 from claudewatch.backend.bookmark.dependencies import get_bookmark_service
+from claudewatch.backend.core import features
+from claudewatch.backend.core.features import FeatureKey
 from claudewatch.backend.history.dependencies import get_history_service
 from claudewatch.backend.summary.dependencies import get_summary_service
 from claudewatch.backend.usage.dependencies import get_usage_service
@@ -146,7 +148,11 @@ def rebuild_rows(delegate: object) -> None:
             if search in proj:
                 filtered.append(e)
                 continue
-            cached = summary_svc.get_cached(e.get("cwd", ""))
+            cached = (
+                summary_svc.get_cached(e.get("cwd", ""))
+                if features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES)
+                else None
+            )
             if cached and search in cached.lower():
                 filtered.append(e)
         entries = filtered
@@ -249,7 +255,9 @@ def _build_row_menu(  # noqa: PLR0913, ARG001
     menu = NSMenu.alloc().init()
 
     # Summary bullets
-    bullets = summary_svc.get_cached_summary(cwd) if cwd else None
+    bullets = (
+        summary_svc.get_cached_summary(cwd) if cwd and features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES) else None
+    )
     if bullets:
         for line in bullets.splitlines():
             stripped = line.strip()


### PR DESCRIPTION
Previous fix only gated active session detail lines. Now gates: bookmarks submenu, recent sessions submenu, sessions pane search, sessions pane context menu, and menu key cache.