### PR TITLE
fix: backend audit — recap robustness, skip cache, encapsulation

### DIFF
--- a/claudewatch/backend/core/features.py
+++ b/claudewatch/backend/core/features.py
@@ -48,7 +48,7 @@ class Facet:
 
 @dataclass(frozen=True)
 class Feature:
-    key: str
+    key: FeatureKey | str
     description: str
     default_enabled: bool = True
     facets: tuple[Facet, ...] = ()
@@ -56,7 +56,7 @@ class Feature:
 
 def register(feature: Feature) -> None:
     """Register a feature. Overwrites if key already exists."""
-    _registry[feature.key] = feature
+    _registry[str(feature.key)] = feature
 
 
 def get_all() -> list[Feature]:
@@ -64,8 +64,9 @@ def get_all() -> list[Feature]:
     return list(_registry.values())
 
 
-def is_enabled(key: str) -> bool:
+def is_enabled(key: FeatureKey | str) -> bool:
     """Check if a feature is enabled. Returns False for unregistered features."""
+    key = str(key)
     feature = _registry.get(key)
     if feature is None:
         log.warning("is_enabled called for unregistered feature: %s", key)
@@ -76,13 +77,14 @@ def is_enabled(key: str) -> bool:
     return feature.default_enabled
 
 
-def set_enabled(key: str, enabled: bool) -> None:
+def set_enabled(key: FeatureKey | str, enabled: bool) -> None:
     """Set whether a feature is enabled."""
-    set_setting(f"feature.{key}.enabled", enabled)
+    set_setting(f"feature.{str(key)}.enabled", enabled)
 
 
-def get_facet(key: str, facet_name: str) -> bool | int | str | None:
+def get_facet(key: FeatureKey | str, facet_name: str) -> bool | int | str | None:
     """Get a facet value. Returns None if feature or facet is unregistered."""
+    key = str(key)
     feature = _registry.get(key)
     if feature is None:
         log.warning("get_facet called for unregistered feature: %s", key)
@@ -96,6 +98,6 @@ def get_facet(key: str, facet_name: str) -> bool | int | str | None:
     return facet.default
 
 
-def set_facet(key: str, facet_name: str, value: bool | int | str) -> None:
+def set_facet(key: FeatureKey | str, facet_name: str, value: bool | int | str) -> None:
     """Set a facet value."""
-    set_setting(f"feature.{key}.{facet_name}", value)
+    set_setting(f"feature.{str(key)}.{facet_name}", value)

--- a/claudewatch/backend/summary/repository.py
+++ b/claudewatch/backend/summary/repository.py
@@ -78,13 +78,13 @@ class SummaryRepository:
     # -- Entry access -------------------------------------------------------
 
     @staticmethod
-    def _cache_key(cwd: str, session_id: str = "") -> str:
+    def cache_key(cwd: str, session_id: str = "") -> str:
         """Build a unique cache key."""
         return f"{cwd}::{session_id}" if session_id else cwd
 
     def get_entry(self, cwd: str, session_id: str = "") -> SummaryEntry | None:
         """Return the cached entry if JSONL hasn't changed significantly since generation."""
-        key = self._cache_key(cwd, session_id)
+        key = self.cache_key(cwd, session_id)
         with self._store_lock:
             self.load_store()
             entry = self._store.get(key)
@@ -100,7 +100,7 @@ class SummaryRepository:
 
     def cache(self, cwd: str, summary: str, session_id: str = "") -> None:
         """Persist a summary string as the title."""
-        key = self._cache_key(cwd, session_id)
+        key = self.cache_key(cwd, session_id)
         mtime = self.get_jsonl_mtime(cwd) or time.time()
         with self._store_lock:
             self.load_store()
@@ -113,7 +113,7 @@ class SummaryRepository:
 
     def cache_full(self, cwd: str, title: str, summary: str, session_id: str = "") -> None:
         """Persist both title and bulleted summary."""
-        key = self._cache_key(cwd, session_id)
+        key = self.cache_key(cwd, session_id)
         mtime = self.get_jsonl_mtime(cwd) or time.time()
         size = self.get_jsonl_size(cwd)
         with self._store_lock:
@@ -129,7 +129,7 @@ class SummaryRepository:
 
     def invalidate_entry(self, cwd: str, session_id: str = "") -> None:
         """Remove a single entry from the store."""
-        key = self._cache_key(cwd, session_id)
+        key = self.cache_key(cwd, session_id)
         with self._store_lock:
             self.load_store()
             self._store.pop(key, None)

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -47,6 +47,21 @@ _SYSTEM_PROMPT = (
 _CONVERSATION_PREFIX = "Summarize this session:\n\n"
 
 
+def _find_last_recap(lines: list[str]) -> str | None:
+    """Scan JSONL lines (oldest-first) and return the last away_summary content."""
+    recap = None
+    for line in lines:
+        try:
+            d = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if d.get("type") == "system" and d.get("subtype") == "away_summary":
+            content = d.get("content", "")
+            if isinstance(content, str) and content.strip():
+                recap = content.strip()
+    return recap
+
+
 def _parse_summary_response(raw: str) -> tuple[str, str]:  # noqa: PLR0912
     """Parse the TITLE + bullets format from claude -p output.
 
@@ -144,6 +159,12 @@ class SummaryService(BaseService):
         self._failures: dict[str, tuple[int, float]] = {}
         self._failures_lock = threading.Lock()
 
+        # No-recap skip cache: {key: jsonl_mtime_at_last_check}
+        # Avoids re-scanning the JSONL for every poll when the feature is off
+        # and the session has no recap.
+        self._no_recap_mtimes: dict[str, float] = {}
+        self._no_recap_lock = threading.Lock()
+
         # Background thread
         self._bg_thread: threading.Thread | None = None
         self._tracked_cwds: set[str] = set()  # cache keys
@@ -155,7 +176,7 @@ class SummaryService(BaseService):
 
     @staticmethod
     def _cache_key(cwd: str, session_id: str = "") -> str:
-        return SummaryRepository._cache_key(cwd, session_id)
+        return SummaryRepository.cache_key(cwd, session_id)
 
     def get_cached(self, cwd: str, session_id: str = "") -> str | None:
         """Return the title (one-liner)."""
@@ -203,37 +224,35 @@ class SummaryService(BaseService):
                 return "generating"
         with self._failures_lock:
             fail_entry = self._failures.get(key)
-            if fail_entry is not None:
-                fail_count = fail_entry[0] if isinstance(fail_entry, tuple) else fail_entry
-                if fail_count >= _MAX_FAILURES:
-                    return "failed"
+            if fail_entry is not None and fail_entry[0] >= _MAX_FAILURES:
+                return "failed"
         return "pending"
 
     def _extract_recap(self, cwd: str) -> str | None:
         """Extract the most recent away_summary (recap) from the JSONL session log.
 
         Claude Code writes these automatically when a session is resumed.
-        Returns the recap text, or None if no recap exists.
+        Checks the tail first (fast path), falls back to full scan if no recap
+        is found — recaps sit where the pause happened and can scroll out of
+        the tail window for active sessions.
         """
         path = self._session_log_service.find_most_recent(cwd)
         if not path:
             return None
 
         tail = self._session_log_service.read_tail(path, tail_bytes=200000)
-        if not tail:
-            return None
+        recap = _find_last_recap(tail.strip().splitlines()) if tail else None
+        if recap is not None:
+            return recap
 
-        recap = None
-        for line in tail.strip().splitlines():
-            try:
-                d = json.loads(line)
-            except (json.JSONDecodeError, ValueError):
-                continue
-            if d.get("type") == "system" and d.get("subtype") == "away_summary":
-                content = d.get("content", "")
-                if isinstance(content, str) and content.strip():
-                    recap = content.strip()
-        return recap
+        # Fallback: full scan — handles sessions where activity pushed the recap
+        # past the 200KB tail window.
+        try:
+            with open(path) as f:
+                lines = f.readlines()
+        except OSError:
+            return None
+        return _find_last_recap(lines)
 
     def generate_and_cache(self, cwd: str, session_id: str = "") -> str:  # noqa: PLR0911, PLR0912, PLR0915
         """Generate a summary via claude -p and persist it."""
@@ -241,6 +260,13 @@ class SummaryService(BaseService):
         cached = self.get_cached(cwd, session_id)
         if cached is not None:
             return cached
+
+        # Skip if we already checked and found no recap, and the JSONL hasn't changed
+        current_mtime = self._repo.get_jsonl_mtime(cwd)
+        with self._no_recap_lock:
+            last_check = self._no_recap_mtimes.get(key)
+            if last_check is not None and current_mtime and last_check == current_mtime:
+                return ""
 
         # Check for a native Claude recap before spawning a subprocess
         recap = self._extract_recap(cwd)
@@ -257,19 +283,20 @@ class SummaryService(BaseService):
         with self._failures_lock:
             fail_entry = self._failures.get(key)
             if fail_entry is not None:
-                if isinstance(fail_entry, tuple):
-                    fail_count, fail_mtime = fail_entry
-                else:
-                    fail_count, fail_mtime = fail_entry, 0.0
+                fail_count, fail_mtime = fail_entry
                 if fail_count >= _MAX_FAILURES:
-                    current_mtime = self._repo.get_jsonl_mtime(cwd)
-                    if current_mtime and current_mtime > fail_mtime:
+                    fresh_mtime = self._repo.get_jsonl_mtime(cwd)
+                    if fresh_mtime and fresh_mtime > fail_mtime:
                         self._failures.pop(key, None)
                     else:
                         return ""
 
-        # Recap-only mode: if claude -p is disabled, don't attempt subprocess
+        # Recap-only mode: if claude -p is disabled, don't attempt subprocess.
+        # Record the JSONL mtime so subsequent polls skip until the file changes.
         if not features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES):
+            mtime = self._repo.get_jsonl_mtime(cwd)
+            with self._no_recap_lock:
+                self._no_recap_mtimes[key] = mtime
             return ""
 
         with self._in_progress_lock:
@@ -290,7 +317,7 @@ class SummaryService(BaseService):
                 else:
                     with self._failures_lock:
                         prev = self._failures.get(key)
-                        prev_count = prev[0] if isinstance(prev, tuple) else (prev or 0)
+                        prev_count = prev[0] if prev else 0
                         mtime = self._repo.get_jsonl_mtime(cwd)
                         self._failures[key] = (prev_count + 1, mtime)
                         count = prev_count + 1

--- a/tests/core/test_features.py
+++ b/tests/core/test_features.py
@@ -141,3 +141,25 @@ class TestFeatureKeyEnum:
         features._registry.clear()
         features.register(Feature(key=FeatureKey.NOTIFICATIONS, description="Notifications"))
         assert features.get_all()[0].key == "notifications"
+
+    def test_every_enum_value_has_a_registered_feature(self):
+        """Importing dependency modules registers all features — no dead enum entries."""
+        features._registry.clear()
+        # Importing these modules triggers features.register() as a side effect.
+        from claudewatch.backend.bookmark import dependencies as _bookmark_deps  # noqa: F401
+        from claudewatch.backend.core import login_item as _login_item  # noqa: F401
+        from claudewatch.backend.notifications import dependencies as _notif_deps  # noqa: F401
+        from claudewatch.backend.security import dependencies as _security_deps  # noqa: F401
+        from claudewatch.backend.summary import dependencies as _summary_deps  # noqa: F401
+        from claudewatch.backend.updates import dependencies as _updates_deps  # noqa: F401
+
+        registered = set(features._registry.keys())
+        enum_values = {str(k) for k in FeatureKey}
+        assert enum_values == registered, f"enum vs registry mismatch: {enum_values ^ registered}"
+
+    def test_is_enabled_accepts_enum(self):
+        features._registry.clear()
+        features.register(Feature(key=FeatureKey.BOOKMARKS, description="B", default_enabled=True))
+        # Works with both enum and string
+        assert features.is_enabled(FeatureKey.BOOKMARKS) is True
+        assert features.is_enabled("bookmarks") is True

--- a/tests/summary/test_summary_service.py
+++ b/tests/summary/test_summary_service.py
@@ -1,6 +1,7 @@
 """Tests for claudewatch.backend.summary.service.SummaryService."""
 
 import json
+import os
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -317,6 +318,149 @@ class TestExtractRecap:
         assert result  # recap title returned
 
 
+class TestNoRecapSkip:
+    """Tests for the no-recap skip cache that avoids re-reading unchanged JSONLs."""
+
+    def test_skips_second_call_when_mtime_unchanged(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [{"type": "user", "message": {"content": "work"}, "timestamp": ""}],
+        )
+        svc, _ = _make_service(tmp_path)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=False),
+            patch.object(svc, "_extract_recap", return_value=None) as mock_extract,
+        ):
+            svc.generate_and_cache("/Users/dev/myapp")
+            svc.generate_and_cache("/Users/dev/myapp")
+            # First call scans; second call should skip
+            assert mock_extract.call_count == 1
+
+    def test_rescans_when_mtime_changes(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        jsonl = proj_dir / "session.jsonl"
+        _write_jsonl(jsonl, [{"type": "user", "message": {"content": "work"}, "timestamp": ""}])
+        svc, _ = _make_service(tmp_path)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=False),
+            patch.object(svc, "_extract_recap", return_value=None) as mock_extract,
+        ):
+            svc.generate_and_cache("/Users/dev/myapp")
+            # Bump mtime
+            os.utime(jsonl, (9999999999, 9999999999))
+            svc.generate_and_cache("/Users/dev/myapp")
+            assert mock_extract.call_count == 2
+
+
+class TestFailureTracking:
+    """Tests for the _failures counting and MAX_FAILURES threshold."""
+
+    def test_increments_on_empty_claude_response(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [{"type": "user", "message": {"content": "work"}, "timestamp": ""}],
+        )
+        svc, _ = _make_service(tmp_path)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=True),
+            patch.object(svc, "_call_claude", return_value=""),
+        ):
+            svc.generate_and_cache("/Users/dev/myapp")
+            assert svc._failures["/Users/dev/myapp"][0] == 1
+            svc.generate_and_cache("/Users/dev/myapp")
+            assert svc._failures["/Users/dev/myapp"][0] == 2
+
+    def test_resets_failures_on_success(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [{"type": "user", "message": {"content": "work"}, "timestamp": ""}],
+        )
+        svc, _ = _make_service(tmp_path)
+        svc._failures["/Users/dev/myapp"] = (2, 100.0)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=True),
+            patch.object(svc, "_call_claude", return_value="TITLE: Done\n• did a thing"),
+        ):
+            svc.generate_and_cache("/Users/dev/myapp")
+        assert "/Users/dev/myapp" not in svc._failures
+
+    def test_gives_up_after_max_failures(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [{"type": "user", "message": {"content": "work"}, "timestamp": ""}],
+        )
+        svc, _ = _make_service(tmp_path)
+        # Seed with MAX_FAILURES threshold already reached at current mtime
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            mtime = svc._repo.get_jsonl_mtime("/Users/dev/myapp")
+        svc._failures["/Users/dev/myapp"] = (5, mtime)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=True),
+            patch.object(svc, "_call_claude") as mock_claude,
+        ):
+            result = svc.generate_and_cache("/Users/dev/myapp")
+            mock_claude.assert_not_called()
+        assert result == ""
+
+    def test_retries_after_mtime_advances_past_failure(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [{"type": "user", "message": {"content": "work"}, "timestamp": ""}],
+        )
+        svc, _ = _make_service(tmp_path)
+        # Seed failures at an old mtime — newer mtime should trigger retry
+        svc._failures["/Users/dev/myapp"] = (5, 100.0)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=True),
+            patch.object(svc, "_call_claude", return_value="TITLE: Recovered\n• got a response"),
+        ):
+            result = svc.generate_and_cache("/Users/dev/myapp")
+        assert result  # should have tried and succeeded
+        assert "/Users/dev/myapp" not in svc._failures
+
+
+class TestExtractRecapFullScan:
+    """Verify the full-scan fallback catches recaps outside the 200KB tail window."""
+
+    def test_full_scan_finds_recap_past_tail(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        entries = [
+            {
+                "type": "system",
+                "subtype": "away_summary",
+                "content": "Early recap deep in the file.",
+                "timestamp": "2026-01-01T00:00:00Z",
+            },
+        ]
+        # Pad with many user messages to push recap past the 200KB tail window
+        filler = {"type": "user", "message": {"content": "x" * 500}, "timestamp": ""}
+        entries.extend([filler] * 500)  # ~250KB of filler
+        _write_jsonl(proj_dir / "session.jsonl", entries)
+
+        svc, _ = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = svc._extract_recap("/Users/dev/myapp")
+        assert result == "Early recap deep in the file."
+
+
 class TestCallClaude:
     """Tests for SummaryService._call_claude."""
 
@@ -479,7 +623,7 @@ class TestPriorityQueue:
 
     def test_pending_count(self, tmp_path):
         svc, _ = _make_service(tmp_path)
-        svc._priority_queue.extend(["/a", "/b", "/c"])
+        svc._priority_queue.extend([("/a", ""), ("/b", ""), ("/c", "")])
         assert svc.pending_summary_count() == 3
 
 


### PR DESCRIPTION
- Recap extraction: full-scan fallback for active sessions where recap scrolled past 200KB tail window
- No-recap skip cache: stop re-scanning JSONL every 60s when feature is off and session has no recap
- Encapsulation: SummaryRepository._cache_key → cache_key (public), service no longer reaches through
- FeatureKey | str on is_enabled/get_facet/set_enabled/set_facet — accepts both
- Feature.key annotation widened to match reality
- Dead isinstance(fail_entry, tuple) branches removed (3 sites)
- 9 new tests: full-scan recap fallback, no-recap skip cache, failure counting path, MAX_FAILURES cap, FeatureKey registry completeness