### PR TITLE
fix: stale sessions classified IDLE not WORKING

### DIFF
--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -24,6 +24,8 @@ _MAX_SESSIONS = 50
 _TEXT_MAX_LEN = 80
 _WIN_SPLIT_FIELDS = 3
 _TERMINAL_CACHE_TTL = 3  # seconds between AppleScript refreshes
+_JSONL_STREAMING_THRESHOLD = 5  # JSONL modified within this → actively streaming
+_JSONL_IDLE_THRESHOLD = 60  # JSONL not modified within this → definitely idle
 
 
 class DetectionService(BaseService):
@@ -188,25 +190,20 @@ class DetectionService(BaseService):
 
     # -- JSONL status helpers -----------------------------------------------
 
-    def _read_jsonl_tail(self, jsonl_path: str | None) -> tuple[str, bool]:
-        """Read the JSONL tail and check freshness. Returns (tail_text, is_fresh).
+    def _read_jsonl_tail(self, jsonl_path: str | None) -> tuple[str, float]:
+        """Read the JSONL tail and return (tail_text, age_seconds).
 
-        Shared by idle and pending-tool checks to avoid duplicate file reads.
+        Age is -1 when the file can't be stat'd. Shared by idle and
+        pending-tool checks to avoid duplicate file reads.
         """
         if not jsonl_path:
-            return ("", False)
-
-        _active_threshold = 5
-        is_fresh = False
+            return ("", -1.0)
         try:
             age = time.time() - os.path.getmtime(jsonl_path)
-            if age < _active_threshold:
-                is_fresh = True
         except OSError:
-            pass
-
+            age = -1.0
         tail = self._session_log_service.read_tail(jsonl_path)
-        return (tail, is_fresh)
+        return (tail, age)
 
     def _check_jsonl_for_idle(self, tail: str) -> SessionStatus:
         """Determine idle/working status from a pre-read JSONL tail."""
@@ -399,14 +396,21 @@ class DetectionService(BaseService):
                 continue
             if s.cwd not in cwd_status_cache:
                 jpath = jsonl_path_cache.get(s.cwd)
-                tail, is_fresh = self._read_jsonl_tail(jpath)
-                if is_fresh:
-                    # JSONL modified < 5s ago — Claude is actively working, skip checks
+                tail, age = self._read_jsonl_tail(jpath)
+                if 0 <= age < _JSONL_STREAMING_THRESHOLD:
+                    # JSONL modified < 5s ago — Claude is actively streaming
                     tool_result = PendingToolResult(has_pending=False, one_line="", context="")
                     jsonl_status = SessionStatus.WORKING
                 else:
                     tool_result = self._check_jsonl_for_pending_tool(tail)
-                    jsonl_status = self._check_jsonl_for_idle(tail) if not tool_result.has_pending else s.status
+                    if tool_result.has_pending:
+                        jsonl_status = s.status
+                    elif age >= _JSONL_IDLE_THRESHOLD:
+                        # Not modified in 60s+ — definitely idle. The last-message
+                        # heuristic is unreliable for abandoned sessions that ended on a user message.
+                        jsonl_status = SessionStatus.IDLE
+                    else:
+                        jsonl_status = self._check_jsonl_for_idle(tail)
                 cwd_status_cache[s.cwd] = (tool_result, jsonl_status)
 
             tool_result, jsonl_status = cwd_status_cache[s.cwd]

--- a/tests/core/test_jsonl.py
+++ b/tests/core/test_jsonl.py
@@ -106,9 +106,9 @@ class TestCheckJsonlForPendingTool:
         result = _make_service()._check_jsonl_for_pending_tool(jsonl.read_text())
         assert result.has_pending is True
 
-    def test_fresh_file_treated_as_working(self, tmp_path):
-        """Fresh JSONL (< 5s) means _read_jsonl_tail returns is_fresh=True.
-        The caller (detect loop) skips pending check when fresh."""
+    def test_fresh_file_has_small_age(self, tmp_path):
+        """Fresh JSONL (< 5s) means _read_jsonl_tail returns a small age.
+        The caller (detect loop) uses age to decide streaming vs idle."""
         jsonl = tmp_path / "session.jsonl"
         _write_jsonl(
             jsonl,
@@ -125,8 +125,8 @@ class TestCheckJsonlForPendingTool:
         )
 
         svc = _make_service(str(jsonl), jsonl.read_text())
-        _, is_fresh = svc._read_jsonl_tail(str(jsonl))
-        assert is_fresh is True
+        _, age = svc._read_jsonl_tail(str(jsonl))
+        assert 0 <= age < 5
 
     def test_nonexistent_project_dir(self):
         result = _make_service()._check_jsonl_for_pending_tool("")

--- a/tests/detection/test_attention_status.py
+++ b/tests/detection/test_attention_status.py
@@ -143,9 +143,9 @@ class TestPendingToolDetection:
                 },
             ],
         )
-        # File was just written — mtime is now, so _read_jsonl_tail returns is_fresh=True
-        tail, is_fresh = service._read_jsonl_tail(jsonl_path)
-        assert is_fresh is True
+        # File was just written — mtime is now, age should be small
+        tail, age = service._read_jsonl_tail(jsonl_path)
+        assert 0 <= age < 5
 
     def test_no_pending_when_tool_result_received(self, tmp_path: str) -> None:
         """Tool completed — tool_result after tool_use means not pending."""

--- a/tests/detection/test_detection_extra.py
+++ b/tests/detection/test_detection_extra.py
@@ -90,27 +90,50 @@ class TestCheckJsonlForIdle:
 class TestReadJsonlTail:
     def test_returns_empty_when_no_path(self):
         svc = _make_detection_service()
-        tail, is_fresh = svc._read_jsonl_tail(None)
+        tail, age = svc._read_jsonl_tail(None)
         assert tail == ""
-        assert is_fresh is False
+        assert age == -1.0
 
-    def test_returns_fresh_when_recently_modified(self, tmp_path):
+    def test_returns_small_age_when_recently_modified(self, tmp_path):
         jsonl = tmp_path / "session.jsonl"
         _write_jsonl(jsonl, [{"type": "assistant", "message": {"content": []}}])
-        # File is fresh (just created)
         svc = _make_detection_service(read_tail=jsonl.read_text())
-        tail, is_fresh = svc._read_jsonl_tail(str(jsonl))
-        assert is_fresh is True
+        tail, age = svc._read_jsonl_tail(str(jsonl))
+        assert 0 <= age < 5
         assert tail != ""
 
-    def test_returns_not_fresh_when_old(self, tmp_path):
+    def test_returns_large_age_when_old(self, tmp_path):
         jsonl = tmp_path / "session.jsonl"
         _write_jsonl(jsonl, [{"type": "assistant", "message": {"content": []}}])
-        os.utime(jsonl, (time.time() - 10, time.time() - 10))
+        os.utime(jsonl, (time.time() - 3600, time.time() - 3600))
         svc = _make_detection_service(read_tail=jsonl.read_text())
-        tail, is_fresh = svc._read_jsonl_tail(str(jsonl))
-        assert is_fresh is False
+        tail, age = svc._read_jsonl_tail(str(jsonl))
+        assert age >= 3600
         assert tail != ""
+
+
+class TestStaleSessionClassification:
+    """Stale JSONLs (>60s) must be classified IDLE regardless of last message type."""
+
+    def test_stale_file_with_last_user_message_is_idle(self, tmp_path):
+        """Regression: 3-day-old session ending on user message should be IDLE, not WORKING."""
+        jsonl = tmp_path / "session.jsonl"
+        _write_jsonl(
+            jsonl,
+            [
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": "hi"}]}},
+                {"type": "user", "message": {"content": "follow-up question"}},
+            ],
+        )
+        three_days_ago = time.time() - 3 * 86400
+        os.utime(jsonl, (three_days_ago, three_days_ago))
+
+        svc = _make_detection_service(read_tail=jsonl.read_text())
+        tail, age = svc._read_jsonl_tail(str(jsonl))
+        # _check_jsonl_for_idle alone would say WORKING (last is user)
+        assert svc._check_jsonl_for_idle(tail) == SessionStatus.WORKING
+        # Caller must gate on age — old files are IDLE
+        assert age > 60
 
 
 class TestCheckJsonlForPendingTool:


### PR DESCRIPTION
**Bug:** Sessions untouched for days could show as WORKING (green) if their JSONL ended on an unanswered user message. The `_check_jsonl_for_idle` heuristic returns WORKING whenever the last user/assistant entry is a `user` message, without considering file age.

**Verified against live data:** `backend-api` JSONL was 5.8 days old, last entry was a user message — detection classified it WORKING.

**Fix:** `_read_jsonl_tail` now returns file age in seconds. The caller uses three tiers:
- age < 5s → WORKING (actively streaming)
- has pending tool → keep existing status (ATTENTION branch handles it)
- age ≥ 60s → IDLE (definitely idle, last-message heuristic unreliable)
- otherwise → fall back to last-message check