### PR TITLE
refactor: remove AI-written sludge in backend

### DIFF
--- a/claudewatch/backend/core/process/procinfo.py
+++ b/claudewatch/backend/core/process/procinfo.py
@@ -11,9 +11,7 @@ import ctypes.util
 
 from claudewatch.backend.core.process.models import ProcessEntry, ProcessInfo
 
-# ---------------------------------------------------------------------------
 # libproc bindings
-# ---------------------------------------------------------------------------
 
 _libproc_path = ctypes.util.find_library("libproc")
 if _libproc_path is None:
@@ -48,9 +46,7 @@ _PBSD_TDEV_OFFSET = 108
 _VNODEPATHINFO_SIZE = 2352
 _VIP_CDIR_PATH_OFFSET = 152
 
-# ---------------------------------------------------------------------------
 # Function prototypes
-# ---------------------------------------------------------------------------
 
 # int proc_listpids(uint32_t type, uint32_t typeinfo, void *buffer, int buffersize)
 _libproc.proc_listpids.argtypes = [
@@ -80,9 +76,7 @@ _libproc.proc_pidpath.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint32
 _libproc.proc_pidpath.restype = ctypes.c_int
 
 
-# ---------------------------------------------------------------------------
 # Internal helpers
-# ---------------------------------------------------------------------------
 
 
 def _list_all_pids() -> list[int]:
@@ -132,9 +126,7 @@ def _dev_to_tty(dev: int) -> str:
     return "??"
 
 
-# ---------------------------------------------------------------------------
 # Public API
-# ---------------------------------------------------------------------------
 
 
 def get_process_info(pids: list[int]) -> dict[int, ProcessInfo]:

--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -433,9 +433,6 @@ class DetectionService(BaseService):
         return sessions
 
 
-# ── Module-level pure functions ─────────────
-
-
 def _format_tool_use(tool: dict) -> ToolUseInfo:
     """Format a tool_use block into ToolUseInfo with one_line and context."""
     name = tool.get("name", "Unknown")

--- a/claudewatch/backend/graph/repository.py
+++ b/claudewatch/backend/graph/repository.py
@@ -28,6 +28,18 @@ from claudewatch.backend.graph.models import (
 
 log = logging.getLogger("claudewatch")
 
+
+def _safe_execute(
+    conn: kuzu.Connection, query: str, params: dict[str, object] | None = None
+) -> kuzu.QueryResult | None:
+    """Execute a Kuzu query, logging and returning None on RuntimeError."""
+    try:
+        return conn.execute(query, params or {})
+    except RuntimeError:
+        log.debug("graph query failed: %s", query[:80])
+        return None
+
+
 _PR_PATTERNS = [
     re.compile(r"https?://github\.com/([^/]+/[^/]+)/pull/(\d+)"),
     re.compile(r"https?://gitlab\.com/([^/]+/[^/]+)/-/merge_requests/(\d+)"),
@@ -450,11 +462,7 @@ class SessionETL:
         )
 
     def _safe_execute(self, query: str, params: dict[str, object] | None = None) -> kuzu.QueryResult | None:
-        try:
-            return self._conn.execute(query, params or {})
-        except RuntimeError:
-            log.debug("graph query failed: %s", query[:80])
-            return None
+        return _safe_execute(self._conn, query, params)
 
     def close(self) -> None:
         self._ckpt.close()
@@ -648,11 +656,7 @@ class CodeETL:
                     )
 
     def _safe_execute(self, query: str, params: dict[str, object] | None = None) -> kuzu.QueryResult | None:
-        try:
-            return self._conn.execute(query, params or {})
-        except RuntimeError:
-            log.debug("code etl query failed: %s", query[:80])
-            return None
+        return _safe_execute(self._conn, query, params)
 
 
 class EditMapper:
@@ -766,11 +770,7 @@ class EditMapper:
         return None
 
     def _safe_execute(self, query: str, params: dict[str, object] | None = None) -> kuzu.QueryResult | None:
-        try:
-            return self._conn.execute(query, params or {})
-        except RuntimeError:
-            log.debug("mapper query failed: %s", query[:80])
-            return None
+        return _safe_execute(self._conn, query, params)
 
 
 class GraphQueries:
@@ -987,8 +987,4 @@ class GraphQueries:
         return result.get_next()[0] or 0
 
     def _safe_execute(self, query: str, params: dict[str, object] | None = None) -> kuzu.QueryResult | None:
-        try:
-            return self._conn.execute(query, params or {})
-        except RuntimeError:
-            log.debug("graph query failed: %s", query[:80])
-            return None
+        return _safe_execute(self._conn, query, params)

--- a/claudewatch/backend/history/repository.py
+++ b/claudewatch/backend/history/repository.py
@@ -54,7 +54,6 @@ def record_session(session_id: str, project: str, cwd: str, model: str, host_app
     """Record a session when it ends. Deduplicates by CWD (keeps latest)."""
     entries = _load()
     ts = datetime.now(tz=UTC).isoformat()
-    # Remove existing entry for same CWD (keep only latest)
     entries = [e for e in entries if e["cwd"] != cwd]
     entries.append(
         _HistoryRecord(
@@ -66,7 +65,6 @@ def record_session(session_id: str, project: str, cwd: str, model: str, host_app
             ended_at=ts,
         )
     )
-    # Cap at max
     if len(entries) > _MAX_ENTRIES:
         entries = entries[-_MAX_ENTRIES:]
     _save(entries)
@@ -105,12 +103,10 @@ def _seed_from_jsonl() -> list[_HistoryRecord]:
             jsonls = [f for f in os.listdir(proj_dir) if f.endswith(".jsonl")]
             if not jsonls:
                 continue
-            # Most recent JSONL
             jsonls.sort(key=lambda f: os.path.getmtime(os.path.join(proj_dir, f)), reverse=True)
             session_id = jsonls[0].removesuffix(".jsonl")
             cwd = proj_key_to_cwd(proj_key)
             project = os.path.basename(cwd)
-            # Get model from last few lines
             model = ""
             jsonl_path = os.path.join(proj_dir, jsonls[0])
             if not is_safe_jsonl_path(jsonl_path):

--- a/claudewatch/backend/security/repository.py
+++ b/claudewatch/backend/security/repository.py
@@ -17,6 +17,7 @@ log = logging.getLogger("claudewatch")
 
 _CLAUDE_DIR = os.path.expanduser("~/.claude")
 _BASELINE_KEY = "security.last_config_snapshot"
+_WHATIS_SETTINGS_KEY = "security.whatis_cache"
 
 
 def _atomic_json_write(path: str, data: dict[str, object]) -> None:
@@ -37,6 +38,8 @@ class SecurityRepository:
         self._session_log = session_log
         self._project_perms_cache: list[tuple[str, str, list[str]]] | None = None
         self._project_perms_cache_time: float = 0.0
+        self._whatis_cache: dict[str, str] | None = None
+        self._whatis_warming: bool = False
 
     # -- Config capture --
 
@@ -337,98 +340,26 @@ class SecurityRepository:
 
     # -- Command descriptions --
 
-    _BUILTIN_DESCRIPTIONS: dict[str, str] = {
-        "gh": "GitHub CLI",
-        "gh pr": "Manage pull requests",
-        "gh pr diff": "View changes in a pull request",
-        "gh pr view": "View a pull request",
-        "gh pr create": "Create a pull request",
-        "gh pr merge": "Merge a pull request",
-        "gh pr checkout": "Check out a pull request",
-        "gh pr list": "List pull requests",
-        "gh issue": "Manage issues",
-        "gh issue list": "List issues",
-        "gh issue create": "Create an issue",
-        "gh issue view": "View an issue",
-        "gh api": "Make GitHub API requests",
-        "git": "Version control",
-        "git fetch": "Download from remote",
-        "git checkout": "Switch branches or restore files",
-        "git rev-parse": "Git reference resolution",
-        "git pull": "Fetch and merge from remote",
-        "git push": "Upload to remote",
-        "git status": "Show working tree status",
-        "git diff": "Show changes",
-        "git add": "Stage file changes",
-        "git commit": "Record changes",
-        "git mv": "Move or rename files",
-        "python3": "Python interpreter",
-        "python3 -m py_compile": "Check Python syntax",
-        "python3 -m pytest": "Run Python tests",
-        "python": "Python interpreter",
-        "node": "Node.js runtime",
-        "npm": "Node package manager",
-        "npx": "Run package binaries",
-        "pnpm": "Fast Node package manager",
-        "uv": "Python package manager",
-        "uv run": "Run in virtual environment",
-        "uv run pytest": "Run tests in venv",
-        "pip": "Python package installer",
-        "pip show": "Show package info",
-        "docker": "Container platform",
-        "ruff": "Python linter",
-        "ruff check": "Run Python linter",
-        "mypy": "Python type checker",
-        "pytest": "Python test framework",
-        "find": "Search for files",
-        "grep": "Search file contents",
-        "cat": "Read file contents",
-        "ls": "List directory contents",
-        "wc": "Count lines/words/bytes",
-        "echo": "Print text",
-        "curl": "Transfer data from URLs",
-        "wget": "Download files",
-        "make": "Build automation",
-        "source": "Execute script in current shell",
-        "poetry": "Python dependency manager",
-        "pnpm run typecheck": "Run type checking",
-        "pnpm run lint": "Run linter",
-        "pnpm test": "Run tests",
-        "pnpm eslint": "Run ESLint",
-        "npx eslint": "Run ESLint",
-        "npx tsc": "Run TypeScript compiler",
-        "pnpm tsc": "Run TypeScript compiler",
-    }
+    def _load_whatis_cache(self) -> dict[str, str]:
+        if self._whatis_cache is None:
+            raw = get_setting(_WHATIS_SETTINGS_KEY)
+            self._whatis_cache = dict(raw) if isinstance(raw, dict) else {}
+        return self._whatis_cache
 
-    _whatis_cache: dict[str, str] | None = None
-    _whatis_warming: bool = False
-    _WHATIS_SETTINGS_KEY = "security.whatis_cache"
+    def _save_whatis_cache(self) -> None:
+        if self._whatis_cache:
+            set_setting(_WHATIS_SETTINGS_KEY, self._whatis_cache)
 
-    @classmethod
-    def _load_whatis_cache(cls) -> dict[str, str]:
-        if cls._whatis_cache is None:
-            raw = get_setting(cls._WHATIS_SETTINGS_KEY)
-            cls._whatis_cache = dict(raw) if isinstance(raw, dict) else {}
-        return cls._whatis_cache
+    def get_command_description(self, command: str) -> str:
+        """Get a one-line description for a command from the whatis cache.
 
-    @classmethod
-    def _save_whatis_cache(cls) -> None:
-        if cls._whatis_cache:
-            set_setting(cls._WHATIS_SETTINGS_KEY, cls._whatis_cache)
-
-    @classmethod
-    def get_command_description(cls, command: str) -> str:
-        """Get a one-line description for a command. Checks built-in table first, then whatis cache."""
+        Returns the longest-matching multi-word key (e.g. `gh pr create` before `gh`).
+        """
         _max_desc = 40
         words = [w for w in command.split() if "=" not in w]
         if not words:
             return ""
-        for length in range(len(words), 0, -1):
-            key = " ".join(words[:length])
-            desc = cls._BUILTIN_DESCRIPTIONS.get(key)
-            if desc:
-                return desc[:_max_desc] if len(desc) > _max_desc else desc
-        cache = cls._load_whatis_cache()
+        cache = self._load_whatis_cache()
         for length in range(len(words), 0, -1):
             key = " ".join(words[:length])
             desc = cache.get(key, "")
@@ -436,14 +367,13 @@ class SecurityRepository:
                 return desc[:_max_desc] if len(desc) > _max_desc else desc
         return ""
 
-    @classmethod
-    def warm_whatis_cache(cls, commands: list[str]) -> None:
+    def warm_whatis_cache(self, commands: list[str]) -> None:
         """Pre-warm the whatis cache for a list of commands. Call from background thread."""
-        if cls._whatis_warming:
+        if self._whatis_warming:
             return
-        cls._whatis_warming = True
+        self._whatis_warming = True
         try:
-            cache = cls._load_whatis_cache()
+            cache = self._load_whatis_cache()
             keys_needed: set[str] = set()
 
             for cmd in commands:
@@ -460,14 +390,14 @@ class SecurityRepository:
                 desc = ""
                 for length in range(len(words), 0, -1):
                     hyphenated = "-".join(words[:length])
-                    desc = cls._lookup_whatis(hyphenated)
+                    desc = self._lookup_whatis(hyphenated)
                     if desc:
                         break
                 cache[key] = desc
 
-            cls._save_whatis_cache()
+            self._save_whatis_cache()
         finally:
-            cls._whatis_warming = False
+            self._whatis_warming = False
 
     @staticmethod
     def _lookup_whatis(command: str) -> str:

--- a/claudewatch/backend/security/service.py
+++ b/claudewatch/backend/security/service.py
@@ -329,7 +329,7 @@ class SecurityService(BaseService):
                     cmd = inner.split(":*")[0] if ":*" in inner else inner
                     bases.append(cmd)
             if bases:
-                SecurityRepository.warm_whatis_cache(bases)
+                self._repo.warm_whatis_cache(bases)
         except Exception:
             log.debug("failed to warm whatis cache", exc_info=True)
 

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -45,6 +45,33 @@ _SYSTEM_PROMPT = (
 )
 
 _CONVERSATION_PREFIX = "Summarize this session:\n\n"
+_MAX_TITLE_LEN = 30
+_REFUSAL_PHRASES = (
+    "i don't see",
+    "i don't have",
+    "no session activity",
+    "no activity to",
+    "paste a prior",
+    "give me instructions",
+    "i can't see",
+    "i cannot see",
+    "there doesn't appear",
+    "could you provide",
+    "could you share",
+    "please provide",
+    "please share",
+)
+
+
+def _truncate_title(title: str) -> str:
+    """Truncate a title to _MAX_TITLE_LEN, preferring word boundaries."""
+    if len(title) <= _MAX_TITLE_LEN:
+        return title
+    truncated = title[:_MAX_TITLE_LEN]
+    last_space = truncated.rfind(" ")
+    if last_space > _MAX_TITLE_LEN // 2:
+        truncated = truncated[:last_space]
+    return truncated
 
 
 def _find_last_recap(lines: list[str]) -> str | None:
@@ -73,22 +100,7 @@ def _parse_summary_response(raw: str) -> tuple[str, str]:  # noqa: PLR0912
 
     # Reject conversational pushback (model refused to summarize)
     lower = raw.lower()
-    _refusal_phrases = (
-        "i don't see",
-        "i don't have",
-        "no session activity",
-        "no activity to",
-        "paste a prior",
-        "give me instructions",
-        "i can't see",
-        "i cannot see",
-        "there doesn't appear",
-        "could you provide",
-        "could you share",
-        "please provide",
-        "please share",
-    )
-    if any(phrase in lower for phrase in _refusal_phrases):
+    if any(phrase in lower for phrase in _REFUSAL_PHRASES):
         return ("", "")
 
     lines = raw.strip().splitlines()
@@ -120,15 +132,7 @@ def _parse_summary_response(raw: str) -> tuple[str, str]:  # noqa: PLR0912
     if not title and not bullets:
         return ("", "")
 
-    _max_title = 30
-    if len(title) > _max_title:
-        truncated = title[:_max_title]
-        last_space = truncated.rfind(" ")
-        if last_space > _max_title // 2:
-            truncated = truncated[:last_space]
-        title = truncated
-
-    return title, "\n".join(bullets)
+    return _truncate_title(title), "\n".join(bullets)
 
 
 class SummaryService(BaseService):
@@ -179,15 +183,11 @@ class SummaryService(BaseService):
         return SummaryRepository.cache_key(cwd, session_id)
 
     def get_cached(self, cwd: str, session_id: str = "") -> str | None:
-        """Return the title (one-liner)."""
+        """Return the cached title (falls back to full summary if title is empty)."""
         entry = self._repo.get_entry(cwd, session_id)
         if not entry:
             return None
         return entry.title or entry.summary
-
-    def get_cached_title(self, cwd: str, session_id: str = "") -> str | None:
-        """Return the short title."""
-        return self.get_cached(cwd, session_id)
 
     def get_cached_summary(self, cwd: str, session_id: str = "") -> str | None:
         """Return the bulleted summary."""
@@ -271,11 +271,7 @@ class SummaryService(BaseService):
         # Check for a native Claude recap before spawning a subprocess
         recap = self._extract_recap(cwd)
         if recap:
-            _max_title = 30
-            title = recap[:_max_title]
-            last_space = title.rfind(" ")
-            if len(recap) > _max_title and last_space > _max_title // 2:
-                title = title[:last_space]
+            title = _truncate_title(recap)
             self.cache_full(cwd, title, recap, session_id)
             log.debug("summarize: using native recap for %s", os.path.basename(cwd))
             return title

--- a/claudewatch/backend/updates/service.py
+++ b/claudewatch/backend/updates/service.py
@@ -26,11 +26,6 @@ _CHECK_INTERVAL = 6 * 60 * 60  # 6 hours
 _REPO = "wingatethomas/claudewatch"
 
 
-# ---------------------------------------------------------------------------
-# Pure / stateless helpers — kept at module level
-# ---------------------------------------------------------------------------
-
-
 def _parse_version(tag: str) -> tuple[int, ...]:
     """Parse 'v1.2.3' or '1.2.3' into (1, 2, 3)."""
     stripped = tag.lstrip("v")
@@ -125,11 +120,6 @@ def _find_app_bundle() -> str | None:
         if part.endswith(".app"):
             return "/".join(parts[: i + 1])
     return None
-
-
-# ---------------------------------------------------------------------------
-# UpdateService class
-# ---------------------------------------------------------------------------
 
 
 class UpdateService(BaseService):

--- a/claudewatch/ui/preferences/panes/security.py
+++ b/claudewatch/ui/preferences/panes/security.py
@@ -19,7 +19,6 @@ from Foundation import NSMakeRect
 from claudewatch.backend.core import features
 from claudewatch.backend.security.dependencies import get_security_service
 from claudewatch.backend.security.models import is_dangerous_permission
-from claudewatch.backend.security.repository import SecurityRepository
 from claudewatch.ui.components.layout import VStack
 from claudewatch.ui.components.tokens import Font, Spacing
 from claudewatch.ui.components.widgets.cards import card
@@ -461,7 +460,7 @@ class SecurityPane(BasePane):
                 clean_cmd = inner.split(":*")[0]
                 words = clean_cmd.split()
                 words = [w for w in words if "=" not in w]  # drop VAR=val prefixes
-                desc = SecurityRepository.get_command_description(" ".join(words))
+                desc = get_security_service().repository.get_command_description(" ".join(words))
                 display = f"{cmd}  —  {desc}" if desc else cmd
                 if len(display) > _MAX_RULE_LEN:
                     return display[: _MAX_RULE_LEN - 1] + "…"
@@ -491,7 +490,7 @@ class SecurityPane(BasePane):
         base_cmd = inner.split(":*")[0] if ":*" in inner else inner.split()[0] if inner.split() else inner
 
         # Look up man page description
-        desc = SecurityRepository.get_command_description(base_cmd)
+        desc = get_security_service().repository.get_command_description(base_cmd)
 
         if ":*" in inner:
             tool = inner.split(":*")[0]

--- a/claudewatch/ui/preferences/panes/sessions.py
+++ b/claudewatch/ui/preferences/panes/sessions.py
@@ -212,7 +212,7 @@ def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001
     # Gather display data
     token_data = usage_svc.get_tokens(cwd)
     token_compact = format_tokens_compact(token_data)
-    cached_title = summary_svc.get_cached_title(cwd) if cwd else ""
+    cached_title = summary_svc.get_cached(cwd) if cwd else ""
 
     # Bookmark callback wiring
     if is_pinned:


### PR DESCRIPTION
- **Summary service**: extract `_truncate_title` helper (was duplicated in 2 places), hoist `_REFUSAL_PHRASES` to module level, delete `get_cached_title` (pure alias for `get_cached`)
- **Graph repository**: consolidate 4 identical copies of `_safe_execute` into a module-level helper; class methods now one-line delegate
- **Security repository**: delete 60-entry `_BUILTIN_COMMAND_DESCRIPTIONS` hardcoded table — `whatis` is the source of truth; move `_whatis_cache`/`_whatis_warming` from class-level mutable state to instance state; switch from classmethod → instance methods (caller goes through `service.repository`)
- **History repository**: strip redundant `# Remove existing entry` / `# Cap at max` / `# Most recent JSONL` what-comments
- **Updates, detection, procinfo**: remove decorative `# -------` banner comments
- Net: 181 lines deleted, 77 added. 732 tests still pass.