### PR TITLE
refactor: drop claude -p summary fallback — native recaps + ai-title cover it

### DIFF
--- a/claudewatch/backend/core/features.py
+++ b/claudewatch/backend/core/features.py
@@ -21,7 +21,6 @@ _registry: dict[str, Feature] = {}
 class FeatureKey(StrEnum):
     ACCESSIBILITY = "accessibility"
     AUTO_UPDATES = "auto_updates"
-    BACKGROUND_SUMMARIES = "background_summaries"
     BOOKMARKS = "bookmarks"
     LAUNCH_AT_LOGIN = "launch_at_login"
     NOTIFICATIONS = "notifications"

--- a/claudewatch/backend/summary/dependencies.py
+++ b/claudewatch/backend/summary/dependencies.py
@@ -1,38 +1,13 @@
 from functools import lru_cache
 
-from claudewatch.backend.core.features import Facet, FacetType, Feature, FeatureKey, register
 from claudewatch.backend.core.paths import SUMMARIES_PATH
-from claudewatch.backend.core.process.dependencies import get_process_service
 from claudewatch.backend.core.session_log.dependencies import get_session_log_service
 from claudewatch.backend.summary.repository import SummaryRepository
 from claudewatch.backend.summary.service import SummaryService
-
-register(
-    Feature(
-        key=FeatureKey.BACKGROUND_SUMMARIES,
-        description="Background summaries",
-        facets=(
-            Facet(
-                name="model",
-                type=FacetType.CHOICE,
-                default="haiku",
-                description="Model",
-                options=("haiku", "sonnet", "opus"),
-            ),
-            Facet(
-                name="effort",
-                type=FacetType.CHOICE,
-                default="low",
-                description="Effort",
-                options=("low", "medium", "high"),
-            ),
-        ),
-    )
-)
 
 
 @lru_cache(maxsize=1)
 def get_summary_service() -> SummaryService:
     session_log = get_session_log_service()
     repo = SummaryRepository(session_log, store_path=SUMMARIES_PATH)
-    return SummaryService(repo, session_log, get_process_service())
+    return SummaryService(repo, session_log)

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -1,66 +1,30 @@
-"""SummaryService — generate conversation summaries via the Claude CLI.
+"""SummaryService — surface session recaps and titles from JSONL.
 
-Persistence is delegated to SummaryRepository. This service owns business
-logic (extraction, prompts, parsing) and orchestration (background threads,
-queues, failure tracking, concurrency control).
+Persistence is delegated to SummaryRepository. This service extracts the
+native entries Claude Code writes to its JSONL session logs:
+
+- ``away_summary`` — bulleted recap content emitted on resume
+- ``ai-title`` — short generated session title
+
+No subprocess invocation, no LLM calls. If a session has no recap yet, we
+return nothing and revisit on the next refresh cycle.
 """
 
 import json
 import logging
 import os
-import shutil
-import subprocess
 import threading
 import time
-import uuid
 
-from claudewatch.backend.core import features
-from claudewatch.backend.core.features import FeatureKey
-from claudewatch.backend.core.process.service import ProcessService
 from claudewatch.backend.core.service import BaseService
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.summary.repository import SummaryRepository
 
 log = logging.getLogger("claudewatch")
 
-_MAX_CONTEXT_CHARS = 16000
-_TIMEOUT_SECONDS = 60
 _REFRESH_INTERVAL = 60  # seconds between background refresh cycles
-_MAX_FAILURES = 5  # stop retrying after this many consecutive failures
-
-_SYSTEM_PROMPT = (
-    "You are a session summarizer. You ONLY output the format below. "
-    "Never ask questions, never refuse, never explain, never say you can't see activity.\n\n"
-    "TITLE: <present-tense verb phrase, max 30 chars>\n"
-    "• <what was done> (max 50 chars)\n"
-    "• <what was done>\n"
-    "• <what was done>\n\n"
-    "Rules:\n"
-    "- Title describes the MOST RECENT activity\n"
-    "- 3-6 bullets covering key actions chronologically\n"
-    "- Skip: greetings, confirmations, tool approvals\n"
-    "- Focus: code changes, files edited, features built, bugs fixed, tests run\n"
-    "- A single user message is enough — summarize its topic\n"
-    "- If the input is short, write fewer bullets. NEVER refuse to summarize.\n"
-)
-
-_CONVERSATION_PREFIX = "Summarize this session:\n\n"
 _MAX_TITLE_LEN = 30
-_REFUSAL_PHRASES = (
-    "i don't see",
-    "i don't have",
-    "no session activity",
-    "no activity to",
-    "paste a prior",
-    "give me instructions",
-    "i can't see",
-    "i cannot see",
-    "there doesn't appear",
-    "could you provide",
-    "could you share",
-    "please provide",
-    "please share",
-)
+_TAIL_BYTES = 200000
 
 
 def _truncate_title(title: str) -> str:
@@ -89,98 +53,50 @@ def _find_last_recap(lines: list[str]) -> str | None:
     return recap
 
 
-def _parse_summary_response(raw: str) -> tuple[str, str]:  # noqa: PLR0912
-    """Parse the TITLE + bullets format from claude -p output.
-
-    Returns (title, bullets_string). Falls back gracefully if format is unexpected.
-    Rejects responses that echo back the prompt.
-    """
-    if "present-tense verb phrase" in raw or "max 30 chars" in raw:
-        return ("", "")
-
-    # Reject conversational pushback (model refused to summarize)
-    lower = raw.lower()
-    if any(phrase in lower for phrase in _REFUSAL_PHRASES):
-        return ("", "")
-
-    lines = raw.strip().splitlines()
-    title = ""
-    bullets: list[str] = []
-
+def _find_last_ai_title(lines: list[str]) -> str | None:
+    """Scan JSONL lines and return the last ai-title content."""
+    title = None
     for line in lines:
-        stripped = line.strip()
-        if stripped.upper().startswith("TITLE:"):
-            title = stripped[6:].strip()
-        elif stripped.startswith("•") or stripped.startswith("-"):
-            bullet = stripped.lstrip("•-").strip()
-            if bullet:
-                bullets.append(f"• {bullet}")
-
-    if not title and bullets:
-        title = bullets[0].lstrip("• ").strip()
-    elif not title and lines:
-        title = lines[0].strip()
-
-    if not bullets:
-        for line in lines:
-            stripped = line.strip()
-            if stripped and not stripped.upper().startswith("TITLE:"):
-                bullets.append(f"• {stripped}")
-                if len(bullets) >= 3:  # noqa: PLR2004
-                    break
-
-    if not title and not bullets:
-        return ("", "")
-
-    return _truncate_title(title), "\n".join(bullets)
+        try:
+            d = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if d.get("type") == "ai-title":
+            value = d.get("aiTitle", "")
+            if isinstance(value, str) and value.strip():
+                title = value.strip()
+    return title
 
 
 class SummaryService(BaseService):
-    """Generates and caches conversation summaries via ``claude -p``."""
+    """Reads native recap and title entries from JSONL and caches them."""
 
     def __init__(
         self,
         repository: SummaryRepository,
         session_log_service: SessionLogService,
-        process_service: ProcessService,
     ) -> None:
         super().__init__()
         self._repo = repository
         self._session_log_service = session_log_service
-        self._process_service = process_service
-
-        # Concurrency control
-        self._generating = threading.Lock()  # only 1 claude -p at a time
-        self._in_progress: set[str] = set()
-        self._in_progress_lock = threading.Lock()
-
-        # Persistent session for summaries — reuse instead of spawning new processes
-        self._summary_session_id: str | None = None
-        self._session_failures: int = 0
-        self._session_failure_threshold = 2
-
-        # Failure tracking: {key: (count, jsonl_mtime_at_failure)}
-        self._failures: dict[str, tuple[int, float]] = {}
-        self._failures_lock = threading.Lock()
 
         # No-recap skip cache: {key: jsonl_mtime_at_last_check}
-        # Avoids re-scanning the JSONL for every poll when the feature is off
-        # and the session has no recap.
+        # Avoids re-scanning JSONLs that have no recap yet and haven't changed.
         self._no_recap_mtimes: dict[str, float] = {}
         self._no_recap_lock = threading.Lock()
 
-        # Background thread
+        # Background thread state
         self._bg_thread: threading.Thread | None = None
-        self._tracked_cwds: set[str] = set()  # cache keys
+        self._tracked_cwds: set[str] = set()
         self._tracked_lock = threading.Lock()
-        self._priority_queue: list[tuple[str, str]] = []  # (cwd, session_id)
+        self._priority_queue: list[tuple[str, str]] = []
         self._priority_lock = threading.Lock()
-
-    # -- Public API (delegates persistence to repository) -------------------
 
     @staticmethod
     def _cache_key(cwd: str, session_id: str = "") -> str:
         return SummaryRepository.cache_key(cwd, session_id)
+
+    # -- Cache access -------------------------------------------------------
 
     def get_cached(self, cwd: str, session_id: str = "") -> str | None:
         """Return the cached title (falls back to full summary if title is empty)."""
@@ -190,7 +106,7 @@ class SummaryService(BaseService):
         return entry.title or entry.summary
 
     def get_cached_summary(self, cwd: str, session_id: str = "") -> str | None:
-        """Return the bulleted summary."""
+        """Return the cached recap content."""
         entry = self._repo.get_entry(cwd, session_id)
         if not entry:
             return None
@@ -208,45 +124,47 @@ class SummaryService(BaseService):
         """Delete all cached summaries."""
         self._repo.clear_all()
 
-    def is_generating(self, cwd: str, session_id: str = "") -> bool:
-        """Check if a summary is currently being generated."""
-        key = self._cache_key(cwd, session_id)
-        with self._in_progress_lock:
-            return key in self._in_progress
-
     def get_status(self, cwd: str, session_id: str = "") -> str:
-        """Get the summary status: 'cached', 'generating', 'failed', or 'pending'."""
-        key = self._cache_key(cwd, session_id)
+        """Get the summary status: 'cached' or 'pending'."""
         if self._repo.get_entry(cwd, session_id):
             return "cached"
-        with self._in_progress_lock:
-            if key in self._in_progress:
-                return "generating"
-        with self._failures_lock:
-            fail_entry = self._failures.get(key)
-            if fail_entry is not None and fail_entry[0] >= _MAX_FAILURES:
-                return "failed"
         return "pending"
 
-    def _extract_recap(self, cwd: str) -> str | None:
-        """Extract the most recent away_summary (recap) from the JSONL session log.
+    def invalidate_cache(self, cwd: str, session_id: str = "") -> None:
+        """Remove a session from the summary store."""
+        key = self._cache_key(cwd, session_id)
+        self._repo.invalidate_entry(cwd, session_id)
+        with self._no_recap_lock:
+            self._no_recap_mtimes.pop(key, None)
 
-        Claude Code writes these automatically when a session is resumed.
-        Checks the tail first (fast path), falls back to full scan if no recap
-        is found — recaps sit where the pause happened and can scroll out of
-        the tail window for active sessions.
+    # -- Extraction ---------------------------------------------------------
+
+    def _read_lines(self, path: str) -> list[str] | None:
+        """Read JSONL lines from path: tail first, fall back to full file."""
+        tail = self._session_log_service.read_tail(path, tail_bytes=_TAIL_BYTES)
+        if tail:
+            return tail.strip().splitlines()
+        try:
+            with open(path) as f:
+                return f.readlines()
+        except OSError:
+            return None
+
+    def _extract_recap(self, cwd: str) -> str | None:
+        """Extract the most recent away_summary from the JSONL session log.
+
+        Tail scan first (fast); falls back to full scan since recaps sit
+        where the pause happened and can scroll past the tail window.
         """
         path = self._session_log_service.find_most_recent(cwd)
         if not path:
             return None
 
-        tail = self._session_log_service.read_tail(path, tail_bytes=200000)
+        tail = self._session_log_service.read_tail(path, tail_bytes=_TAIL_BYTES)
         recap = _find_last_recap(tail.strip().splitlines()) if tail else None
         if recap is not None:
             return recap
 
-        # Fallback: full scan — handles sessions where activity pushed the recap
-        # past the 200KB tail window.
         try:
             with open(path) as f:
                 lines = f.readlines()
@@ -254,89 +172,42 @@ class SummaryService(BaseService):
             return None
         return _find_last_recap(lines)
 
-    def generate_and_cache(self, cwd: str, session_id: str = "") -> str:  # noqa: PLR0911, PLR0912, PLR0915
-        """Generate a summary via claude -p and persist it."""
+    def _extract_ai_title(self, cwd: str) -> str | None:
+        """Extract Claude Code's native ai-title entry from the JSONL session log."""
+        path = self._session_log_service.find_most_recent(cwd)
+        if not path:
+            return None
+        try:
+            with open(path) as f:
+                lines = f.readlines()
+        except OSError:
+            return None
+        return _find_last_ai_title(lines)
+
+    def generate_and_cache(self, cwd: str, session_id: str = "") -> str:
+        """Extract recap+title from JSONL and persist. Returns the title (or empty)."""
         key = self._cache_key(cwd, session_id)
         cached = self.get_cached(cwd, session_id)
         if cached is not None:
             return cached
 
-        # Skip if we already checked and found no recap, and the JSONL hasn't changed
+        # Skip if we already checked and found no recap, and the JSONL hasn't changed.
         current_mtime = self._repo.get_jsonl_mtime(cwd)
         with self._no_recap_lock:
             last_check = self._no_recap_mtimes.get(key)
             if last_check is not None and current_mtime and last_check == current_mtime:
                 return ""
 
-        # Check for a native Claude recap before spawning a subprocess
         recap = self._extract_recap(cwd)
-        if recap:
-            title = _truncate_title(recap)
-            self.cache_full(cwd, title, recap, session_id)
-            log.debug("summarize: using native recap for %s", os.path.basename(cwd))
-            return title
-
-        with self._failures_lock:
-            fail_entry = self._failures.get(key)
-            if fail_entry is not None:
-                fail_count, fail_mtime = fail_entry
-                if fail_count >= _MAX_FAILURES:
-                    fresh_mtime = self._repo.get_jsonl_mtime(cwd)
-                    if fresh_mtime and fresh_mtime > fail_mtime:
-                        self._failures.pop(key, None)
-                    else:
-                        return ""
-
-        # Recap-only mode: if claude -p is disabled, don't attempt subprocess.
-        # Record the JSONL mtime so subsequent polls skip until the file changes.
-        if not features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES):
-            mtime = self._repo.get_jsonl_mtime(cwd)
+        if recap is None:
             with self._no_recap_lock:
-                self._no_recap_mtimes[key] = mtime
+                self._no_recap_mtimes[key] = current_mtime
             return ""
 
-        with self._in_progress_lock:
-            if key in self._in_progress:
-                return ""
-            self._in_progress.add(key)
-
-        try:
-            if not self._generating.acquire(timeout=1):
-                return ""
-            try:
-                raw = self._call_claude(cwd)
-                if raw:
-                    title, bullets = _parse_summary_response(raw)
-                    self.cache_full(cwd, title, bullets, session_id)
-                    with self._failures_lock:
-                        self._failures.pop(key, None)
-                else:
-                    with self._failures_lock:
-                        prev = self._failures.get(key)
-                        prev_count = prev[0] if prev else 0
-                        mtime = self._repo.get_jsonl_mtime(cwd)
-                        self._failures[key] = (prev_count + 1, mtime)
-                        count = prev_count + 1
-                    if count >= _MAX_FAILURES:
-                        log.warning(
-                            "summarize: giving up on %s after %d failures",
-                            os.path.basename(cwd),
-                            count,
-                        )
-                    title = ""
-                return title
-            finally:
-                self._generating.release()
-        finally:
-            with self._in_progress_lock:
-                self._in_progress.discard(key)
-
-    def invalidate_cache(self, cwd: str, session_id: str = "") -> None:
-        """Remove a session from the summary store and reset failure count."""
-        key = self._cache_key(cwd, session_id)
-        self._repo.invalidate_entry(cwd, session_id)
-        with self._failures_lock:
-            self._failures.pop(key, None)
+        title = _truncate_title(self._extract_ai_title(cwd) or recap)
+        self.cache_full(cwd, title, recap, session_id)
+        log.debug("summarize: cached recap for %s", os.path.basename(cwd))
+        return title
 
     # -- Background refresh -------------------------------------------------
 
@@ -356,7 +227,7 @@ class SummaryService(BaseService):
         self._ensure_bg_thread()
 
     def pending_summary_count(self) -> int:
-        """Return the number of sessions queued for summary generation."""
+        """Return the number of sessions queued for summary extraction."""
         with self._priority_lock:
             return len(self._priority_queue)
 
@@ -381,7 +252,7 @@ class SummaryService(BaseService):
                         entry = self._priority_queue.pop(0)
                 if entry:
                     cwd, sid = entry
-                    log.debug("bg_priority: generating summary for %s", cwd)
+                    log.debug("bg_priority: extracting summary for %s", cwd)
                     self.generate_and_cache(cwd, sid)
                     time.sleep(2)
                     continue
@@ -395,195 +266,8 @@ class SummaryService(BaseService):
                     else:
                         cwd, sid = key, ""
                     if self.get_cached(cwd, sid) is None:
-                        log.debug("bg_refresh: regenerating stale summary for %s", cwd)
+                        log.debug("bg_refresh: re-extracting for %s", cwd)
                         self.generate_and_cache(cwd, sid)
             except Exception:
                 log.exception("bg_refresh_loop iteration failed")
                 time.sleep(_REFRESH_INTERVAL)
-
-    # -- Business logic (extraction, LLM calls) -----------------------------
-
-    def _extract_conversation_text(self, cwd: str) -> str:  # noqa: PLR0912, PLR0915
-        """Extract a structured event timeline from JSONL — token-efficient."""
-        path = self._session_log_service.find_most_recent(cwd)
-        if not path:
-            return ""
-
-        tail = self._session_log_service.read_tail(path, tail_bytes=200000)
-        if not tail:
-            return ""
-
-        parts: list[str] = []
-        total = 0
-        last_tool: str = ""
-        last_tool_count: int = 0
-
-        def _flush_tool() -> None:
-            nonlocal last_tool, last_tool_count
-            if last_tool:
-                suffix = f" ({last_tool_count}x)" if last_tool_count > 1 else ""
-                parts.append(f"TOOL: {last_tool}{suffix}")
-                last_tool = ""
-                last_tool_count = 0
-
-        for line in tail.strip().splitlines():
-            try:
-                d = json.loads(line)
-            except (json.JSONDecodeError, ValueError):
-                continue
-
-            dtype = d.get("type", "")
-            msg = d.get("message", {})
-            if not isinstance(msg, dict):
-                continue
-
-            if dtype == "user":
-                _flush_tool()
-                content = msg.get("content", "")
-                if isinstance(content, str) and content.strip():
-                    text = content.strip()[:200]
-                    parts.append(f"USER: {text}")
-                    total += len(text)
-
-            elif dtype == "assistant":
-                content = msg.get("content", [])
-                if isinstance(content, list):
-                    for block in content:
-                        if not isinstance(block, dict):
-                            continue
-                        if block.get("type") == "tool_use":
-                            name = block.get("name", "")
-                            inp = block.get("input", {})
-                            key_arg = ""
-                            if isinstance(inp, dict):
-                                key_arg = str(inp.get("command") or inp.get("file_path") or inp.get("pattern") or "")[
-                                    :100
-                                ]
-                            tool_key = f"{name} → {key_arg}" if key_arg else name
-
-                            if tool_key == last_tool:
-                                last_tool_count += 1
-                            else:
-                                _flush_tool()
-                                last_tool = tool_key
-                                last_tool_count = 1
-                            total += 30
-                        elif block.get("type") == "text":
-                            _flush_tool()
-                            text = block.get("text", "").strip()
-                            _min_text = 20
-                            if text and len(text) > _min_text:
-                                parts.append(f"ASSISTANT: {text[:150]}")
-                                total += min(len(text), 150)
-
-            if total > _MAX_CONTEXT_CHARS:
-                break
-
-        _flush_tool()
-        return "\n".join(parts)
-
-    @staticmethod
-    def _find_claude() -> str | None:
-        """Find the claude CLI, checking common install paths if PATH is limited."""
-        found = shutil.which("claude")
-        if found:
-            return found
-        for path in ("/opt/homebrew/bin/claude", "/usr/local/bin/claude", os.path.expanduser("~/.claude/bin/claude")):
-            if os.path.isfile(path) and os.access(path, os.X_OK):
-                return path
-        return None
-
-    def _call_claude(self, cwd: str) -> str:
-        """Call claude -p to generate a summary. Reuses a persistent session when possible."""
-        claude_path = self._find_claude()
-        if not claude_path:
-            log.warning("summarize: claude CLI not found")
-            return ""
-
-        conversation = self._extract_conversation_text(cwd)
-        if not conversation:
-            return ""
-
-        model = str(features.get_facet(FeatureKey.BACKGROUND_SUMMARIES, "model") or "haiku")
-        effort = str(features.get_facet(FeatureKey.BACKGROUND_SUMMARIES, "effort") or "low")
-
-        use_session = self._session_failures < self._session_failure_threshold
-
-        session_id = self._summary_session_id
-        if session_id and use_session:
-            cmd = [
-                claude_path,
-                "-p",
-                _CONVERSATION_PREFIX + conversation,
-                "-r",
-                session_id,
-                "--model",
-                model,
-                "--effort",
-                effort,
-            ]
-            log.debug("summarize: reusing session %s", session_id[:8])
-        elif use_session:
-            session_id = str(uuid.uuid4())
-            cmd = [
-                claude_path,
-                "-p",
-                _SYSTEM_PROMPT + _CONVERSATION_PREFIX + conversation,
-                "--session-id",
-                session_id,
-                "--model",
-                model,
-                "--effort",
-                effort,
-            ]
-            log.info("summarize: creating session %s", session_id[:8])
-        else:
-            cmd = [
-                claude_path,
-                "-p",
-                _SYSTEM_PROMPT + _CONVERSATION_PREFIX + conversation,
-                "--model",
-                model,
-                "--effort",
-                effort,
-            ]
-            log.debug("summarize: using non-session fallback")
-
-        result = self._run_claude_process(cmd)
-        if result:
-            if use_session:
-                self._summary_session_id = session_id
-                self._session_failures = 0
-            return result
-
-        if use_session:
-            self._session_failures += 1
-            if self._session_failures >= self._session_failure_threshold:
-                log.warning("summarize: persistent sessions failing, falling back to non-session mode")
-        self._summary_session_id = None
-        return ""
-
-    def _run_claude_process(self, cmd: list[str]) -> str:
-        """Execute a claude subprocess and return stdout. Returns empty string on failure."""
-        try:
-            proc = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
-            self._process_service.register_child(proc.pid)
-            try:
-                stdout, _ = proc.communicate(timeout=_TIMEOUT_SECONDS)
-                if proc.returncode == 0 and stdout.strip():
-                    return stdout.strip()
-                log.warning("summarize: claude returned %d", proc.returncode)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()
-                log.warning("summarize: claude timed out after %ds", _TIMEOUT_SECONDS)
-            finally:
-                self._process_service.unregister_child(proc.pid)
-        except OSError as e:
-            log.warning("summarize: failed to run claude: %s", e)
-        return ""

--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -45,12 +45,9 @@ class MenuBuilder:
         self._app = app
         self._menu = menu
         self._delegate = delegate
-        self._summaries_on = features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES)
 
     def _get_summary(self, cwd: str, session_id: str = "") -> str | None:
-        """Return cached summary if summaries are enabled, else None."""
-        if not self._summaries_on:
-            return None
+        """Return cached summary."""
         return self._app._summary_service.get_cached_summary(cwd, session_id)
 
     def build(self, sessions: list[ClaudeSession]) -> None:  # noqa: PLR0912, PLR0915
@@ -342,7 +339,7 @@ class MenuBuilder:
         sub = build_session_submenu(
             delegate=d,
             summary=self._get_summary(s.cwd, s.session_id),
-            generating=self._summaries_on and self._app._summary_service.is_generating(s.cwd, s.session_id),
+            generating=False,
             actions=actions,
             agents=agents,
         )
@@ -353,18 +350,7 @@ class MenuBuilder:
         model = self._app._usage_service.get_model(s.cwd)
         cached = self._get_summary(s.cwd, s.session_id)
         _max_detail_total = 55
-        if cached:
-            oneliner = cached.replace("\n", " ").strip()
-        elif self._summaries_on:
-            status = self._app._summary_service.get_status(s.cwd, s.session_id)
-            if status == "generating":
-                oneliner = "Generating summary…"
-            elif status == "failed":
-                oneliner = "Summary unavailable"
-            else:
-                oneliner = s.detail_line
-        else:
-            oneliner = s.detail_line
+        oneliner = cached.replace("\n", " ").strip() if cached else s.detail_line
         detail_parts = [p for p in [model, oneliner] if p]
         if detail_parts:
             detail_text = " · ".join(detail_parts)

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -326,11 +326,7 @@ class ClaudeWatchApp:
     def _menu_key(self) -> str:
         parts = [f"scheme:{theme.scheme.name}"]
         for s in self.sessions:
-            cached = (
-                (self._summary_service.get_cached(s.cwd) or "")
-                if features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES)
-                else ""
-            )
+            cached = self._summary_service.get_cached(s.cwd) or ""
             parts.append(f"{s.pid}:{s.status.value}:{s.project}:{s.task_summary}:{s.last_output}:{cached}")
         return "|".join(parts)
 

--- a/claudewatch/ui/preferences/panes/sessions.py
+++ b/claudewatch/ui/preferences/panes/sessions.py
@@ -22,8 +22,6 @@ from AppKit import (
 from Foundation import NSMakeRect
 
 from claudewatch.backend.bookmark.dependencies import get_bookmark_service
-from claudewatch.backend.core import features
-from claudewatch.backend.core.features import FeatureKey
 from claudewatch.backend.history.dependencies import get_history_service
 from claudewatch.backend.summary.dependencies import get_summary_service
 from claudewatch.backend.usage.dependencies import get_usage_service
@@ -148,11 +146,7 @@ def rebuild_rows(delegate: object) -> None:
             if search in proj:
                 filtered.append(e)
                 continue
-            cached = (
-                summary_svc.get_cached(e.get("cwd", ""))
-                if features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES)
-                else None
-            )
+            cached = summary_svc.get_cached(e.get("cwd", ""))
             if cached and search in cached.lower():
                 filtered.append(e)
         entries = filtered
@@ -255,9 +249,7 @@ def _build_row_menu(  # noqa: PLR0913, ARG001
     menu = NSMenu.alloc().init()
 
     # Summary bullets
-    bullets = (
-        summary_svc.get_cached_summary(cwd) if cwd and features.is_enabled(FeatureKey.BACKGROUND_SUMMARIES) else None
-    )
+    bullets = summary_svc.get_cached_summary(cwd) if cwd else None
     if bullets:
         for line in bullets.splitlines():
             stripped = line.strip()

--- a/claudewatch/ui/preferences/panes/settings.py
+++ b/claudewatch/ui/preferences/panes/settings.py
@@ -27,7 +27,6 @@ from claudewatch.ui.theme import theme
 _FEATURE_DETAILS: dict[str, str] = {
     FeatureKey.BOOKMARKS: "Save sessions to resume later from the menu bar.",
     FeatureKey.NOTIFICATIONS: "Get alerts when Claude needs your attention.",
-    FeatureKey.BACKGROUND_SUMMARIES: "Periodically regenerate session summaries in the background.",
     FeatureKey.AUTO_UPDATES: "Check GitHub for new releases periodically.",
     FeatureKey.LAUNCH_AT_LOGIN: "Start ClaudeWatch automatically when you log in.",
     FeatureKey.ACCESSIBILITY: "Color scheme for status dots in the menu bar.",
@@ -36,7 +35,7 @@ _FEATURE_DETAILS: dict[str, str] = {
 
 # Feature groups — defines section order and which features belong to each
 _FEATURE_GROUPS: list[tuple[str, list[str]]] = [
-    ("Sessions", [FeatureKey.BOOKMARKS, FeatureKey.BACKGROUND_SUMMARIES]),
+    ("Sessions", [FeatureKey.BOOKMARKS]),
     ("Notifications", [FeatureKey.NOTIFICATIONS]),
     ("App", [FeatureKey.LAUNCH_AT_LOGIN, FeatureKey.AUTO_UPDATES, FeatureKey.ACCESSIBILITY]),
 ]

--- a/tests/summary/test_summary_service.py
+++ b/tests/summary/test_summary_service.py
@@ -2,76 +2,26 @@
 
 import json
 import os
-import subprocess
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from claudewatch.backend.core.process.service import ProcessService
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.summary.models import SummaryEntry
-from claudewatch.backend.summary.service import SummaryService, _parse_summary_response
+from claudewatch.backend.summary.service import (
+    SummaryService,
+    _find_last_ai_title,
+    _find_last_recap,
+    _truncate_title,
+)
 
 
-class TestParseSummaryResponse:
-    def test_valid_title_and_bullets(self) -> None:
-        raw = "TITLE: Refactoring auth module\n• Updated login flow\n• Fixed token refresh\n• Added tests"
-        title, bullets = _parse_summary_response(raw)
-        assert title == "Refactoring auth module"
-        assert "Updated login flow" in bullets
-        assert "Fixed token refresh" in bullets
-
-    def test_title_clamped_to_30_chars(self) -> None:
-        raw = "TITLE: This is a very long title that should be truncated at word boundary\n• bullet"
-        title, _ = _parse_summary_response(raw)
-        assert len(title) <= 30
-
-    def test_case_insensitive_title(self) -> None:
-        raw = "title: lowercase works\n• bullet"
-        title, _ = _parse_summary_response(raw)
-        assert title == "lowercase works"
-
-    def test_dash_bullets(self) -> None:
-        raw = "TITLE: Test\n- dash bullet one\n- dash bullet two"
-        _, bullets = _parse_summary_response(raw)
-        assert "dash bullet one" in bullets
-        assert "dash bullet two" in bullets
-
-    def test_fallback_first_line_as_title(self) -> None:
-        raw = "Just a plain response\nwith some lines"
-        title, _ = _parse_summary_response(raw)
-        assert title == "Just a plain response"
-
-    def test_fallback_lines_as_bullets(self) -> None:
-        raw = "TITLE: Something\nno bullet markers here\njust plain text\nanother line"
-        _, bullets = _parse_summary_response(raw)
-        assert "no bullet markers here" in bullets
-
-    def test_rejects_prompt_echo(self) -> None:
-        raw = "present-tense verb phrase, max 30 chars\n• bullet"
-        title, bullets = _parse_summary_response(raw)
-        assert title == ""
-        assert bullets == ""
-
-    def test_rejects_no_structure(self) -> None:
-        raw = ""
-        title, bullets = _parse_summary_response(raw)
-        assert title == ""
-        assert bullets == ""
-
-    def test_bullets_only_gets_first_as_title(self) -> None:
-        raw = "• First action taken\n• Second action\n• Third"
-        title, bullets = _parse_summary_response(raw)
-        assert title == "First action taken"
-
-
-def _make_service(tmp_path, projects_dir=None):
+def _make_service(tmp_path):
     """Create a SummaryService wired to tmp_path fixtures."""
     from claudewatch.backend.summary.repository import SummaryRepository
 
     session_log_service = SessionLogService()
-    process_service = ProcessService()
     store_path = str(tmp_path / "summaries.json")
     repo = SummaryRepository(session_log_service, store_path=store_path)
-    return SummaryService(repo, session_log_service, process_service), projects_dir
+    return SummaryService(repo, session_log_service)
 
 
 def _write_jsonl(path, entries):
@@ -80,78 +30,72 @@ def _write_jsonl(path, entries):
             f.write(json.dumps(entry) + "\n")
 
 
-class TestExtractConversationText:
-    """Tests for SummaryService._extract_conversation_text."""
+class TestTruncateTitle:
+    def test_short_title_unchanged(self) -> None:
+        assert _truncate_title("Short") == "Short"
 
-    def test_extracts_user_messages(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [{"type": "user", "message": {"content": "fix the login bug"}, "timestamp": ""}],
-        )
-        svc, _ = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_conversation_text("/Users/dev/myapp")
-        assert "USER: fix the login bug" in result
+    def test_long_title_truncated_at_word_boundary(self) -> None:
+        result = _truncate_title("This is a very long title that should be truncated")
+        assert len(result) <= 30
+        assert not result.endswith(" ")
 
-    def test_extracts_assistant_text(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [
-                {
-                    "type": "assistant",
-                    "message": {"content": [{"type": "text", "text": "I'll help you fix that"}]},
-                    "timestamp": "",
-                },
-            ],
-        )
-        svc, _ = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_conversation_text("/Users/dev/myapp")
-        assert "ASSISTANT: I'll help you fix that" in result
+    def test_title_at_exact_limit(self) -> None:
+        title = "A" * 30
+        assert _truncate_title(title) == title
 
-    def test_respects_max_context_chars(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        entries = [{"type": "user", "message": {"content": "x" * 2000}, "timestamp": ""} for _ in range(10)]
-        _write_jsonl(proj_dir / "session.jsonl", entries)
-        svc, _ = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_conversation_text("/Users/dev/myapp")
-        assert len(result) <= 25000
 
-    def test_returns_empty_for_missing_project(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "nope")):
-            result = svc._extract_conversation_text("/Users/dev/myapp")
-        assert result == ""
+class TestFindLastRecap:
+    def test_returns_recap_content(self) -> None:
+        lines = [
+            json.dumps({"type": "user", "message": {"content": "hi"}}),
+            json.dumps({"type": "system", "subtype": "away_summary", "content": "Did stuff."}),
+        ]
+        assert _find_last_recap(lines) == "Did stuff."
 
-    def test_skips_invalid_json(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        jsonl_file = proj_dir / "session.jsonl"
-        with open(jsonl_file, "w") as f:
-            f.write("not json\n")
-            f.write(json.dumps({"type": "user", "message": {"content": "valid"}, "timestamp": ""}) + "\n")
-        svc, _ = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_conversation_text("/Users/dev/myapp")
-        assert "valid" in result
+    def test_returns_most_recent_when_multiple(self) -> None:
+        lines = [
+            json.dumps({"type": "system", "subtype": "away_summary", "content": "Old."}),
+            json.dumps({"type": "system", "subtype": "away_summary", "content": "New."}),
+        ]
+        assert _find_last_recap(lines) == "New."
 
-    def test_skips_non_dict_messages(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [{"type": "user", "message": "string-not-dict", "timestamp": ""}],
-        )
-        svc, _ = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_conversation_text("/Users/dev/myapp")
-        assert result == ""
+    def test_skips_empty_content(self) -> None:
+        lines = [
+            json.dumps({"type": "system", "subtype": "away_summary", "content": ""}),
+        ]
+        assert _find_last_recap(lines) is None
+
+    def test_skips_other_subtypes(self) -> None:
+        lines = [json.dumps({"type": "system", "subtype": "other", "content": "x"})]
+        assert _find_last_recap(lines) is None
+
+    def test_skips_invalid_json(self) -> None:
+        lines = [
+            "not json",
+            json.dumps({"type": "system", "subtype": "away_summary", "content": "ok"}),
+        ]
+        assert _find_last_recap(lines) == "ok"
+
+
+class TestFindLastAiTitle:
+    def test_returns_ai_title(self) -> None:
+        lines = [json.dumps({"type": "ai-title", "aiTitle": "Refactor auth module"})]
+        assert _find_last_ai_title(lines) == "Refactor auth module"
+
+    def test_returns_most_recent(self) -> None:
+        lines = [
+            json.dumps({"type": "ai-title", "aiTitle": "First"}),
+            json.dumps({"type": "ai-title", "aiTitle": "Second"}),
+        ]
+        assert _find_last_ai_title(lines) == "Second"
+
+    def test_returns_none_when_absent(self) -> None:
+        lines = [json.dumps({"type": "user", "message": {"content": "hi"}})]
+        assert _find_last_ai_title(lines) is None
+
+    def test_skips_empty_ai_title(self) -> None:
+        lines = [json.dumps({"type": "ai-title", "aiTitle": "  "})]
+        assert _find_last_ai_title(lines) is None
 
 
 class TestExtractRecap:
@@ -172,36 +116,10 @@ class TestExtractRecap:
                 },
             ],
         )
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
             result = svc._extract_recap("/Users/dev/myapp")
         assert result == "Fixed auth middleware and added tests."
-
-    def test_returns_most_recent_recap(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [
-                {
-                    "type": "system",
-                    "subtype": "away_summary",
-                    "content": "Old recap.",
-                    "timestamp": "2026-01-01T00:00:00Z",
-                },
-                {"type": "user", "message": {"content": "more work"}, "timestamp": ""},
-                {
-                    "type": "system",
-                    "subtype": "away_summary",
-                    "content": "Newer recap after more work.",
-                    "timestamp": "2026-01-01T01:00:00Z",
-                },
-            ],
-        )
-        svc, _ = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_recap("/Users/dev/myapp")
-        assert result == "Newer recap after more work."
 
     def test_returns_none_when_no_recap(self, tmp_path):
         proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
@@ -210,47 +128,74 @@ class TestExtractRecap:
             proj_dir / "session.jsonl",
             [{"type": "user", "message": {"content": "hello"}, "timestamp": ""}],
         )
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
             result = svc._extract_recap("/Users/dev/myapp")
         assert result is None
 
     def test_returns_none_for_missing_project(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "nope")):
             result = svc._extract_recap("/Users/dev/myapp")
         assert result is None
 
-    def test_ignores_other_system_subtypes(self, tmp_path):
+    def test_full_scan_finds_recap_past_tail(self, tmp_path):
+        """Recap deep in a large file is found via the full-scan fallback."""
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        entries = [
+            {
+                "type": "system",
+                "subtype": "away_summary",
+                "content": "Early recap deep in the file.",
+                "timestamp": "2026-01-01T00:00:00Z",
+            },
+        ]
+        filler = {"type": "user", "message": {"content": "x" * 500}, "timestamp": ""}
+        entries.extend([filler] * 500)
+        _write_jsonl(proj_dir / "session.jsonl", entries)
+
+        svc = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = svc._extract_recap("/Users/dev/myapp")
+        assert result == "Early recap deep in the file."
+
+
+class TestExtractAiTitle:
+    """Tests for SummaryService._extract_ai_title."""
+
+    def test_returns_ai_title_when_present(self, tmp_path):
         proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
         proj_dir.mkdir(parents=True)
         _write_jsonl(
             proj_dir / "session.jsonl",
             [
-                {"type": "system", "subtype": "other_thing", "content": "not a recap", "timestamp": ""},
+                {"type": "ai-title", "aiTitle": "Refactor auth module", "sessionId": "abc"},
+                {"type": "user", "message": {"content": "fix auth"}, "timestamp": ""},
             ],
         )
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_recap("/Users/dev/myapp")
-        assert result is None
+            result = svc._extract_ai_title("/Users/dev/myapp")
+        assert result == "Refactor auth module"
 
-    def test_skips_empty_recap_content(self, tmp_path):
+    def test_returns_none_when_absent(self, tmp_path):
         proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
         proj_dir.mkdir(parents=True)
         _write_jsonl(
             proj_dir / "session.jsonl",
-            [
-                {"type": "system", "subtype": "away_summary", "content": "", "timestamp": ""},
-            ],
+            [{"type": "user", "message": {"content": "hi"}, "timestamp": ""}],
         )
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_recap("/Users/dev/myapp")
+            result = svc._extract_ai_title("/Users/dev/myapp")
         assert result is None
 
-    def test_generate_uses_recap_over_claude_p(self, tmp_path):
-        """generate_and_cache should use native recap instead of spawning claude -p."""
+
+class TestGenerateAndCache:
+    """Tests for SummaryService.generate_and_cache."""
+
+    def test_caches_recap_when_present(self, tmp_path):
         proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
         proj_dir.mkdir(parents=True)
         _write_jsonl(
@@ -265,57 +210,83 @@ class TestExtractRecap:
                 },
             ],
         )
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
             result = svc.generate_and_cache("/Users/dev/myapp")
-            assert result  # got a title back
-            # Full recap should be in the cached summary
+            assert result
             cached = svc.get_cached_summary("/Users/dev/myapp")
             assert cached == "Fixed auth middleware and added integration tests."
 
-    def test_generate_skips_claude_p_when_feature_off(self, tmp_path):
-        """With background_summaries off and no recap, generate_and_cache returns empty without subprocess."""
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [{"type": "user", "message": {"content": "fix auth"}, "timestamp": ""}],
-        )
-        svc, _ = _make_service(tmp_path)
-        with (
-            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=False),
-            patch.object(svc, "_call_claude") as mock_claude,
-        ):
-            result = svc.generate_and_cache("/Users/dev/myapp")
-            mock_claude.assert_not_called()
-        assert result == ""
-
-    def test_generate_uses_recap_even_when_feature_off(self, tmp_path):
-        """Native recaps work regardless of the background_summaries toggle."""
+    def test_uses_ai_title_when_available(self, tmp_path):
         proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
         proj_dir.mkdir(parents=True)
         _write_jsonl(
             proj_dir / "session.jsonl",
             [
-                {"type": "user", "message": {"content": "fix auth"}, "timestamp": ""},
+                {"type": "ai-title", "aiTitle": "Auth refactor", "sessionId": "abc"},
                 {
                     "type": "system",
                     "subtype": "away_summary",
-                    "content": "Fixed auth middleware.",
+                    "content": "A long recap that would otherwise be the title fallback and exceeds 30 chars.",
                     "timestamp": "2026-01-01T00:05:00Z",
                 },
             ],
         )
-        svc, _ = _make_service(tmp_path)
-        with (
-            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=False),
-            patch.object(svc, "_call_claude") as mock_claude,
-        ):
+        svc = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            title = svc.generate_and_cache("/Users/dev/myapp")
+        assert title == "Auth refactor"
+
+    def test_falls_back_to_truncated_recap_without_ai_title(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [
+                {
+                    "type": "system",
+                    "subtype": "away_summary",
+                    "content": "Did some work on the thing.",
+                    "timestamp": "2026-01-01T00:05:00Z",
+                },
+            ],
+        )
+        svc = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            title = svc.generate_and_cache("/Users/dev/myapp")
+        assert title == "Did some work on the thing."
+
+    def test_returns_empty_when_no_recap(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [{"type": "user", "message": {"content": "hi"}, "timestamp": ""}],
+        )
+        svc = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
             result = svc.generate_and_cache("/Users/dev/myapp")
-            mock_claude.assert_not_called()
-        assert result  # recap title returned
+        assert result == ""
+
+    def test_returns_cached_on_second_call(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [
+                {
+                    "type": "system",
+                    "subtype": "away_summary",
+                    "content": "Done.",
+                    "timestamp": "",
+                },
+            ],
+        )
+        svc = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            first = svc.generate_and_cache("/Users/dev/myapp")
+            second = svc.generate_and_cache("/Users/dev/myapp")
+        assert first == second
 
 
 class TestNoRecapSkip:
@@ -328,15 +299,13 @@ class TestNoRecapSkip:
             proj_dir / "session.jsonl",
             [{"type": "user", "message": {"content": "work"}, "timestamp": ""}],
         )
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         with (
             patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=False),
             patch.object(svc, "_extract_recap", return_value=None) as mock_extract,
         ):
             svc.generate_and_cache("/Users/dev/myapp")
             svc.generate_and_cache("/Users/dev/myapp")
-            # First call scans; second call should skip
             assert mock_extract.call_count == 1
 
     def test_rescans_when_mtime_changes(self, tmp_path):
@@ -344,225 +313,20 @@ class TestNoRecapSkip:
         proj_dir.mkdir(parents=True)
         jsonl = proj_dir / "session.jsonl"
         _write_jsonl(jsonl, [{"type": "user", "message": {"content": "work"}, "timestamp": ""}])
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         with (
             patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=False),
             patch.object(svc, "_extract_recap", return_value=None) as mock_extract,
         ):
             svc.generate_and_cache("/Users/dev/myapp")
-            # Bump mtime
             os.utime(jsonl, (9999999999, 9999999999))
             svc.generate_and_cache("/Users/dev/myapp")
             assert mock_extract.call_count == 2
 
 
-class TestFailureTracking:
-    """Tests for the _failures counting and MAX_FAILURES threshold."""
-
-    def test_increments_on_empty_claude_response(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [{"type": "user", "message": {"content": "work"}, "timestamp": ""}],
-        )
-        svc, _ = _make_service(tmp_path)
-        with (
-            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=True),
-            patch.object(svc, "_call_claude", return_value=""),
-        ):
-            svc.generate_and_cache("/Users/dev/myapp")
-            assert svc._failures["/Users/dev/myapp"][0] == 1
-            svc.generate_and_cache("/Users/dev/myapp")
-            assert svc._failures["/Users/dev/myapp"][0] == 2
-
-    def test_resets_failures_on_success(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [{"type": "user", "message": {"content": "work"}, "timestamp": ""}],
-        )
-        svc, _ = _make_service(tmp_path)
-        svc._failures["/Users/dev/myapp"] = (2, 100.0)
-        with (
-            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=True),
-            patch.object(svc, "_call_claude", return_value="TITLE: Done\n• did a thing"),
-        ):
-            svc.generate_and_cache("/Users/dev/myapp")
-        assert "/Users/dev/myapp" not in svc._failures
-
-    def test_gives_up_after_max_failures(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [{"type": "user", "message": {"content": "work"}, "timestamp": ""}],
-        )
-        svc, _ = _make_service(tmp_path)
-        # Seed with MAX_FAILURES threshold already reached at current mtime
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            mtime = svc._repo.get_jsonl_mtime("/Users/dev/myapp")
-        svc._failures["/Users/dev/myapp"] = (5, mtime)
-        with (
-            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=True),
-            patch.object(svc, "_call_claude") as mock_claude,
-        ):
-            result = svc.generate_and_cache("/Users/dev/myapp")
-            mock_claude.assert_not_called()
-        assert result == ""
-
-    def test_retries_after_mtime_advances_past_failure(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [{"type": "user", "message": {"content": "work"}, "timestamp": ""}],
-        )
-        svc, _ = _make_service(tmp_path)
-        # Seed failures at an old mtime — newer mtime should trigger retry
-        svc._failures["/Users/dev/myapp"] = (5, 100.0)
-        with (
-            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-            patch("claudewatch.backend.summary.service.features.is_enabled", return_value=True),
-            patch.object(svc, "_call_claude", return_value="TITLE: Recovered\n• got a response"),
-        ):
-            result = svc.generate_and_cache("/Users/dev/myapp")
-        assert result  # should have tried and succeeded
-        assert "/Users/dev/myapp" not in svc._failures
-
-
-class TestExtractRecapFullScan:
-    """Verify the full-scan fallback catches recaps outside the 200KB tail window."""
-
-    def test_full_scan_finds_recap_past_tail(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        entries = [
-            {
-                "type": "system",
-                "subtype": "away_summary",
-                "content": "Early recap deep in the file.",
-                "timestamp": "2026-01-01T00:00:00Z",
-            },
-        ]
-        # Pad with many user messages to push recap past the 200KB tail window
-        filler = {"type": "user", "message": {"content": "x" * 500}, "timestamp": ""}
-        entries.extend([filler] * 500)  # ~250KB of filler
-        _write_jsonl(proj_dir / "session.jsonl", entries)
-
-        svc, _ = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_recap("/Users/dev/myapp")
-        assert result == "Early recap deep in the file."
-
-
-class TestCallClaude:
-    """Tests for SummaryService._call_claude."""
-
-    def test_returns_empty_when_claude_not_found(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
-        with patch("claudewatch.backend.summary.service.shutil.which", return_value=None):
-            result = svc._call_claude("/Users/dev/myapp")
-        assert result == ""
-
-    def test_returns_empty_when_no_conversation(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
-        with (
-            patch("claudewatch.backend.summary.service.shutil.which", return_value="/usr/bin/claude"),
-            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "nope")),
-        ):
-            result = svc._call_claude("/Users/dev/myapp")
-        assert result == ""
-
-    def test_returns_summary_on_success(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [{"type": "user", "message": {"content": "fix auth"}, "timestamp": ""}],
-        )
-        mock_proc = MagicMock()
-        mock_proc.pid = 99999
-        mock_proc.communicate.return_value = ("Fixed auth middleware\n", "")
-        mock_proc.returncode = 0
-        svc, _ = _make_service(tmp_path)
-        with (
-            patch("claudewatch.backend.summary.service.shutil.which", return_value="/usr/bin/claude"),
-            patch("claudewatch.backend.summary.service.subprocess.Popen", return_value=mock_proc),
-            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-        ):
-            result = svc._call_claude("/Users/dev/myapp")
-        assert result == "Fixed auth middleware"
-
-    def test_registers_and_unregisters_child_pid(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [{"type": "user", "message": {"content": "fix auth"}, "timestamp": ""}],
-        )
-        mock_proc = MagicMock()
-        mock_proc.pid = 99999
-        mock_proc.communicate.return_value = ("summary\n", "")
-        mock_proc.returncode = 0
-        svc, _ = _make_service(tmp_path)
-        with (
-            patch("claudewatch.backend.summary.service.shutil.which", return_value="/usr/bin/claude"),
-            patch("claudewatch.backend.summary.service.subprocess.Popen", return_value=mock_proc),
-            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-        ):
-            svc._call_claude("/Users/dev/myapp")
-        # After call, PID should be unregistered
-        assert 99999 not in svc._process_service.get_child_pids()
-
-    def test_returns_empty_on_timeout(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [{"type": "user", "message": {"content": "fix auth"}, "timestamp": ""}],
-        )
-        mock_proc = MagicMock()
-        mock_proc.pid = 99999
-        mock_proc.communicate.side_effect = subprocess.TimeoutExpired("claude", 15)
-        svc, _ = _make_service(tmp_path)
-        with (
-            patch("claudewatch.backend.summary.service.shutil.which", return_value="/usr/bin/claude"),
-            patch("claudewatch.backend.summary.service.subprocess.Popen", return_value=mock_proc),
-            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-        ):
-            result = svc._call_claude("/Users/dev/myapp")
-        assert result == ""
-
-    def test_returns_empty_on_nonzero_exit(self, tmp_path):
-        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
-        proj_dir.mkdir(parents=True)
-        _write_jsonl(
-            proj_dir / "session.jsonl",
-            [{"type": "user", "message": {"content": "fix auth"}, "timestamp": ""}],
-        )
-        mock_proc = MagicMock()
-        mock_proc.pid = 99999
-        mock_proc.communicate.return_value = ("", "")
-        mock_proc.returncode = 1
-        svc, _ = _make_service(tmp_path)
-        with (
-            patch("claudewatch.backend.summary.service.shutil.which", return_value="/usr/bin/claude"),
-            patch("claudewatch.backend.summary.service.subprocess.Popen", return_value=mock_proc),
-            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
-        ):
-            result = svc._call_claude("/Users/dev/myapp")
-        assert result == ""
-
-
 class TestCacheSummary:
     def test_cache_and_get(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         proj_dir = tmp_path / "projects" / "-test"
         proj_dir.mkdir(parents=True)
         (proj_dir / "s.jsonl").write_text("{}\n")
@@ -573,7 +337,7 @@ class TestCacheSummary:
         assert result == "test summary"
 
     def test_stale_cache_returns_none(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         proj_dir = tmp_path / "projects" / "-test"
         proj_dir.mkdir(parents=True)
         (proj_dir / "s.jsonl").write_text("{}\n")
@@ -585,20 +349,24 @@ class TestCacheSummary:
         assert result is None
 
 
-class TestIsGenerating:
-    def test_false_when_not_generating(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
-        assert svc.is_generating("/test") is False
+class TestGetStatus:
+    def test_pending_when_uncached(self, tmp_path):
+        svc = _make_service(tmp_path)
+        assert svc.get_status("/nope") == "pending"
 
-    def test_true_when_generating(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
-        svc._in_progress.add("/test")
-        assert svc.is_generating("/test") is True
+    def test_cached_when_present(self, tmp_path):
+        svc = _make_service(tmp_path)
+        proj_dir = tmp_path / "projects" / "-test"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "s.jsonl").write_text("{}\n")
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            svc.cache("/test", "x")
+            assert svc.get_status("/test") == "cached"
 
 
 class TestPriorityQueue:
     def test_track_adds_to_priority_queue(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         svc._repo._store_loaded = True
         with (
             patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "nope")),
@@ -608,7 +376,7 @@ class TestPriorityQueue:
         assert ("/new-cwd", "") in svc._priority_queue
 
     def test_track_skips_if_cached(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         proj_dir = tmp_path / "projects" / "-cached"
         proj_dir.mkdir(parents=True)
         (proj_dir / "s.jsonl").write_text("{}\n")
@@ -622,14 +390,14 @@ class TestPriorityQueue:
         assert "/cached" not in svc._priority_queue
 
     def test_pending_count(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         svc._priority_queue.extend([("/a", ""), ("/b", ""), ("/c", "")])
         assert svc.pending_summary_count() == 3
 
 
 class TestInvalidateCache:
     def test_invalidate_removes_entry(self, tmp_path):
-        svc, _ = _make_service(tmp_path)
+        svc = _make_service(tmp_path)
         proj_dir = tmp_path / "projects" / "-test"
         proj_dir.mkdir(parents=True)
         (proj_dir / "s.jsonl").write_text("{}\n")
@@ -639,3 +407,9 @@ class TestInvalidateCache:
             assert svc.get_cached("/test") == "summary"
             svc.invalidate_cache("/test")
             assert svc.get_cached("/test") is None
+
+    def test_invalidate_clears_no_recap_skip(self, tmp_path):
+        svc = _make_service(tmp_path)
+        svc._no_recap_mtimes["/test"] = 123.0
+        svc.invalidate_cache("/test")
+        assert "/test" not in svc._no_recap_mtimes


### PR DESCRIPTION
## Summary

Claude Code now writes both `away_summary` recaps (adopted in #187) and `ai-title` entries to JSONL natively. The paid `claude -p` fallback that existed for sessions without a recap is now redundant on both axes:

- **Title generation** → `ai-title` (free, written automatically)
- **Bullet summary** → `away_summary` recap (already adopted in #187)

This PR rips out the entire `claude -p` machinery and the `BACKGROUND_SUMMARIES` feature flag.

## Changes

**Removed from `backend/summary/service.py`:**
- `_call_claude`, `_run_claude_process`, `_find_claude`, `_extract_conversation_text`, `_parse_summary_response`
- `_REFUSAL_PHRASES`, `_SYSTEM_PROMPT`, `_CONVERSATION_PREFIX`, `_TIMEOUT_SECONDS`, `_MAX_FAILURES`, `_MAX_CONTEXT_CHARS` constants
- Failure-tracking machinery (`_failures`, `_in_progress`, persistent-session reuse, fallback retry counters)
- `process_service` constructor dependency

**Added:**
- `_find_last_ai_title` / `_extract_ai_title` to source titles from the native `ai-title` JSONL entry; falls back to truncated recap when absent

**Removed elsewhere:**
- `BACKGROUND_SUMMARIES` enum value + `model`/`effort` facets (`backend/core/features.py`, `backend/summary/dependencies.py`)
- All UI gating that hid summary surfaces when the toggle was off (#189–#192): `menu_builder.py`, `menubar.py`, `preferences/panes/sessions.py`, `preferences/panes/settings.py`

**Net:** `summary/service.py` drops 590 → 290 lines; tests retargeted to the recap + ai-title surface.

---

**Closed in favor of #201** (rebranched off the harness-default `claude/...` name, re-authored).