### PR TITLE
fix: lock concurrent JSON writes and centralize atomic_json_write helper

### DIFF
--- a/claudewatch/backend/bookmark/repository.py
+++ b/claudewatch/backend/bookmark/repository.py
@@ -2,18 +2,22 @@
 
 import json
 import logging
-import os
+import threading
 from datetime import UTC, datetime
 from typing import TypedDict
 
 from claudewatch.backend.core import features
 from claudewatch.backend.core.dto import BookmarkDTO
 from claudewatch.backend.core.features import FeatureKey
+from claudewatch.backend.core.helpers import atomic_json_write
 from claudewatch.backend.core.paths import PINS_PATH
 
 log = logging.getLogger("claudewatch")
 
 _PATH = PINS_PATH
+
+# Serializes read-modify-write of the bookmarks JSON file across threads.
+_LOCK = threading.Lock()
 
 
 class _BookmarkRecord(TypedDict):
@@ -56,42 +60,42 @@ def _load() -> list[_BookmarkRecord]:
 
 
 def _save(pins: list[_BookmarkRecord]) -> None:
-    tmp = _PATH + ".tmp"
     try:
-        with open(tmp, "w") as f:
-            json.dump(pins, f, indent=2)
-        os.replace(tmp, _PATH)
+        atomic_json_write(_PATH, pins)
     except OSError:
         log.warning("Failed to save pins to %s", _PATH)
 
 
 def add_bookmark(session_id: str, project: str, cwd: str, note: str) -> None:
     """Bookmark a session with a note. Updates if already bookmarked."""
-    bookmarks = _load()
-    ts = datetime.now(tz=UTC).isoformat()
-    for entry in bookmarks:
-        if entry["cwd"] == cwd:
-            entry["session_id"] = session_id
-            entry["note"] = note
-            entry["timestamp"] = ts
-            _save(bookmarks)
-            log.info("bookmark.updated project=%s", project)
-            return
-    bookmarks.append(
-        _BookmarkRecord(
-            session_id=session_id,
-            project=project,
-            cwd=cwd,
-            note=note,
-            timestamp=ts,
+    with _LOCK:
+        bookmarks = _load()
+        ts = datetime.now(tz=UTC).isoformat()
+        for entry in bookmarks:
+            if entry["cwd"] == cwd:
+                entry["session_id"] = session_id
+                entry["note"] = note
+                entry["timestamp"] = ts
+                _save(bookmarks)
+                log.info("bookmark.updated project=%s", project)
+                return
+        bookmarks.append(
+            _BookmarkRecord(
+                session_id=session_id,
+                project=project,
+                cwd=cwd,
+                note=note,
+                timestamp=ts,
+            )
         )
-    )
-    _save(bookmarks)
+        _save(bookmarks)
     log.info("bookmark.created project=%s", project)
 
 
 def get_bookmarks() -> list[BookmarkDTO]:
     """Return all bookmarked sessions as DTOs."""
+    with _LOCK:
+        pins = _load()
     return [
         BookmarkDTO(
             session_id=p.get("session_id", ""),
@@ -100,26 +104,29 @@ def get_bookmarks() -> list[BookmarkDTO]:
             note=p.get("note", ""),
             timestamp=p.get("timestamp", ""),
         )
-        for p in _load()
+        for p in pins
     ]
 
 
 def get_bookmarked_cwds() -> set[str]:
     """Return the set of CWDs that are bookmarked."""
-    return {p["cwd"] for p in _load()}
+    with _LOCK:
+        return {p["cwd"] for p in _load()}
 
 
 def clear_all_bookmarks() -> None:
     """Delete all bookmarks."""
-    _save([])
+    with _LOCK:
+        _save([])
     log.info("bookmark.cleared_all")
 
 
 def remove_bookmark(cwd: str) -> None:
     """Remove a bookmark by CWD."""
-    bookmarks = _load()
-    before = len(bookmarks)
-    bookmarks = [p for p in bookmarks if p["cwd"] != cwd]
-    if len(bookmarks) < before:
-        log.info("bookmark.removed cwd=%s", cwd)
-    _save(bookmarks)
+    with _LOCK:
+        bookmarks = _load()
+        before = len(bookmarks)
+        bookmarks = [p for p in bookmarks if p["cwd"] != cwd]
+        if len(bookmarks) < before:
+            log.info("bookmark.removed cwd=%s", cwd)
+        _save(bookmarks)

--- a/claudewatch/backend/core/helpers.py
+++ b/claudewatch/backend/core/helpers.py
@@ -1,5 +1,7 @@
 import ctypes
+import json
 import logging
+import os
 import threading
 
 from Foundation import NSAppleScript
@@ -7,6 +9,19 @@ from Foundation import NSAppleScript
 log = logging.getLogger("claudewatch")
 
 _APPLESCRIPT_TIMEOUT = 10.0
+
+
+def atomic_json_write(path: str, data: object, *, indent: int | None = 2) -> None:
+    """Write JSON to ``path`` atomically: serialize to ``path + ".tmp"``, then rename.
+
+    A crash mid-write leaves ``path`` either unchanged or fully replaced — never
+    a half-written file. Raises ``OSError`` on filesystem failure; callers wrap
+    with their domain-specific log message.
+    """
+    tmp = f"{path}.tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=indent)
+    os.replace(tmp, path)
 
 
 def is_accessibility_trusted() -> bool:

--- a/claudewatch/backend/history/repository.py
+++ b/claudewatch/backend/history/repository.py
@@ -3,10 +3,12 @@
 import json
 import logging
 import os
+import threading
 from datetime import UTC, datetime
 from typing import TypedDict
 
 from claudewatch.backend.core.dto import HistoryEntryDTO
+from claudewatch.backend.core.helpers import atomic_json_write
 from claudewatch.backend.core.paths import CLAUDE_PROJECTS_DIR, HISTORY_PATH, proj_key_to_cwd
 from claudewatch.backend.core.session_log.jsonl import is_safe_jsonl_path, read_jsonl_tail
 
@@ -14,6 +16,9 @@ log = logging.getLogger("claudewatch")
 
 _PATH = HISTORY_PATH
 _MAX_ENTRIES = 50
+
+# Serializes read-modify-write of the history JSON file across threads.
+_LOCK = threading.Lock()
 
 
 class _HistoryRecord(TypedDict):
@@ -33,7 +38,6 @@ def _load() -> list[_HistoryRecord]:
                 return []
     except (OSError, json.JSONDecodeError):
         return []
-    # Prune to max size
     if len(data) > _MAX_ENTRIES:
         data = data[-_MAX_ENTRIES:]
         _save(data)
@@ -41,41 +45,40 @@ def _load() -> list[_HistoryRecord]:
 
 
 def _save(entries: list[_HistoryRecord]) -> None:
-    tmp = _PATH + ".tmp"
     try:
-        with open(tmp, "w") as f:
-            json.dump(entries, f, indent=2)
-        os.replace(tmp, _PATH)
+        atomic_json_write(_PATH, entries)
     except OSError:
         log.warning("Failed to save history to %s", _PATH)
 
 
 def record_session(session_id: str, project: str, cwd: str, model: str, host_app: str) -> None:
     """Record a session when it ends. Deduplicates by CWD (keeps latest)."""
-    entries = _load()
-    ts = datetime.now(tz=UTC).isoformat()
-    entries = [e for e in entries if e["cwd"] != cwd]
-    entries.append(
-        _HistoryRecord(
-            session_id=session_id,
-            project=project,
-            cwd=cwd,
-            model=model,
-            host_app=host_app,
-            ended_at=ts,
+    with _LOCK:
+        entries = _load()
+        ts = datetime.now(tz=UTC).isoformat()
+        entries = [e for e in entries if e["cwd"] != cwd]
+        entries.append(
+            _HistoryRecord(
+                session_id=session_id,
+                project=project,
+                cwd=cwd,
+                model=model,
+                host_app=host_app,
+                ended_at=ts,
+            )
         )
-    )
-    if len(entries) > _MAX_ENTRIES:
-        entries = entries[-_MAX_ENTRIES:]
-    _save(entries)
+        if len(entries) > _MAX_ENTRIES:
+            entries = entries[-_MAX_ENTRIES:]
+        _save(entries)
     log.info("history.recorded project=%s", project)
 
 
 def get_history() -> list[HistoryEntryDTO]:
     """Return session history, newest first. Seeds from JSONL on first call."""
-    entries = _load()
-    if not entries:
-        entries = _seed_from_jsonl()
+    with _LOCK:
+        entries = _load()
+        if not entries:
+            entries = _seed_from_jsonl()
     return [
         HistoryEntryDTO(
             session_id=e.get("session_id", ""),
@@ -145,6 +148,7 @@ def _seed_from_jsonl() -> list[_HistoryRecord]:
 
 def remove_history_entry(cwd: str) -> None:
     """Remove a history entry by CWD."""
-    entries = _load()
-    entries = [e for e in entries if e["cwd"] != cwd]
-    _save(entries)
+    with _LOCK:
+        entries = _load()
+        entries = [e for e in entries if e["cwd"] != cwd]
+        _save(entries)

--- a/claudewatch/backend/security/repository.py
+++ b/claudewatch/backend/security/repository.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import time
 
+from claudewatch.backend.core.helpers import atomic_json_write
 from claudewatch.backend.core.paths import CLAUDE_PROJECTS_DIR, proj_key_to_cwd
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.core.settings import get_setting, set_setting
@@ -18,14 +19,6 @@ log = logging.getLogger("claudewatch")
 _CLAUDE_DIR = os.path.expanduser("~/.claude")
 _BASELINE_KEY = "security.last_config_snapshot"
 _WHATIS_SETTINGS_KEY = "security.whatis_cache"
-
-
-def _atomic_json_write(path: str, data: dict[str, object]) -> None:
-    """Write JSON atomically via tmp file + rename."""
-    tmp = path + ".tmp"
-    with open(tmp, "w") as f:
-        json.dump(data, f, indent=2)
-    os.replace(tmp, path)
 
 
 class SecurityRepository:
@@ -159,7 +152,7 @@ class SecurityRepository:
         data["permissions"] = perms
 
         try:
-            _atomic_json_write(settings_path, data)
+            atomic_json_write(settings_path, data)
             log.info("security: removed permission rule '%s' from %s", rule[:50], settings_path)
             self.invalidate_project_cache()
             return True
@@ -183,7 +176,7 @@ class SecurityRepository:
         data["permissions"] = perms
 
         try:
-            _atomic_json_write(settings_path, data)
+            atomic_json_write(settings_path, data)
             log.info("security: cleared all permissions from %s", settings_path)
             self.invalidate_project_cache()
             return True
@@ -229,7 +222,7 @@ class SecurityRepository:
             perms["allow"] = safe_rules
             data["permissions"] = perms
             try:
-                _atomic_json_write(settings_path, data)
+                atomic_json_write(settings_path, data)
                 log.info("security: removed %d dangerous permissions from %s", removed, settings_path)
                 self.invalidate_project_cache()
             except OSError:
@@ -252,7 +245,7 @@ class SecurityRepository:
             if isinstance(plugins, dict) and plugin_name in plugins:
                 del plugins[plugin_name]
                 data["plugins"] = plugins
-                _atomic_json_write(installed_path, data)
+                atomic_json_write(installed_path, data)
                 success = True
         except (OSError, json.JSONDecodeError):
             log.warning("security: failed to update installed_plugins.json")
@@ -265,7 +258,7 @@ class SecurityRepository:
             if isinstance(enabled, dict) and plugin_name in enabled:
                 del enabled[plugin_name]
                 data["enabledPlugins"] = enabled
-                _atomic_json_write(settings_path, data)
+                atomic_json_write(settings_path, data)
         except (OSError, json.JSONDecodeError):
             log.warning("security: failed to update settings.json")
 

--- a/claudewatch/backend/summary/repository.py
+++ b/claudewatch/backend/summary/repository.py
@@ -8,6 +8,7 @@ import os
 import threading
 import time
 
+from claudewatch.backend.core.helpers import atomic_json_write
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.summary.models import SummaryEntry
 
@@ -63,15 +64,12 @@ class SummaryRepository:
 
     def _save_store(self) -> None:
         """Atomically write the store to disk."""
-        tmp = self._store_path + ".tmp"
+        serialized = {
+            k: {"title": v.title, "summary": v.summary, "mtime": v.mtime, "jsonl_size": v.jsonl_size}
+            for k, v in self._store.items()
+        }
         try:
-            serialized = {
-                k: {"title": v.title, "summary": v.summary, "mtime": v.mtime, "jsonl_size": v.jsonl_size}
-                for k, v in self._store.items()
-            }
-            with open(tmp, "w") as f:
-                json.dump(serialized, f, indent=2)
-            os.replace(tmp, self._store_path)
+            atomic_json_write(self._store_path, serialized)
         except OSError:
             log.warning("Failed to save summaries to %s", self._store_path)
 

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -1,9 +1,18 @@
-"""Tests for claudewatch.backend.core.helpers — escape_applescript, run_applescript, is_accessibility_trusted."""
+"""Tests for claudewatch.backend.core.helpers — escape_applescript, run_applescript, is_accessibility_trusted, atomic_json_write."""
 
+import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
-from claudewatch.backend.core.helpers import escape_applescript, is_accessibility_trusted, run_applescript
+import pytest
+
+from claudewatch.backend.core.helpers import (
+    atomic_json_write,
+    escape_applescript,
+    is_accessibility_trusted,
+    run_applescript,
+)
 
 
 class TestRunApplescript:
@@ -123,3 +132,60 @@ class TestIsAccessibilityTrusted:
             mock_ctypes.cdll.LoadLibrary.side_effect = OSError("not found")
 
             assert is_accessibility_trusted() is False
+
+
+class TestAtomicJsonWrite:
+    """atomic_json_write writes via tmp + os.replace."""
+
+    def test_writes_dict(self, tmp_path) -> None:
+        path = str(tmp_path / "out.json")
+        atomic_json_write(path, {"a": 1, "b": [2, 3]})
+        with open(path) as f:
+            assert json.load(f) == {"a": 1, "b": [2, 3]}
+
+    def test_writes_list(self, tmp_path) -> None:
+        path = str(tmp_path / "out.json")
+        atomic_json_write(path, [{"x": 1}, {"x": 2}])
+        with open(path) as f:
+            assert json.load(f) == [{"x": 1}, {"x": 2}]
+
+    def test_overwrites_existing(self, tmp_path) -> None:
+        path = str(tmp_path / "out.json")
+        with open(path, "w") as f:
+            json.dump({"old": True}, f)
+        atomic_json_write(path, {"new": True})
+        with open(path) as f:
+            assert json.load(f) == {"new": True}
+
+    def test_no_tmp_file_remains_on_success(self, tmp_path) -> None:
+        path = str(tmp_path / "out.json")
+        atomic_json_write(path, {"ok": 1})
+        assert not os.path.exists(f"{path}.tmp")
+
+    def test_indent_default_is_two(self, tmp_path) -> None:
+        path = str(tmp_path / "out.json")
+        atomic_json_write(path, {"a": 1})
+        with open(path) as f:
+            text = f.read()
+        assert '  "a"' in text  # 2-space indent
+
+    def test_indent_none_writes_compact(self, tmp_path) -> None:
+        path = str(tmp_path / "out.json")
+        atomic_json_write(path, {"a": 1, "b": 2}, indent=None)
+        with open(path) as f:
+            text = f.read()
+        assert "\n" not in text
+
+    def test_raises_oserror_for_bad_target_dir(self, tmp_path) -> None:
+        bad_path = str(tmp_path / "does_not_exist" / "out.json")
+        with pytest.raises(FileNotFoundError):
+            atomic_json_write(bad_path, {"a": 1})
+
+    def test_target_unchanged_when_serialization_fails(self, tmp_path) -> None:
+        """Non-JSON-serializable input raises before os.replace runs; target file stays as it was."""
+        path = str(tmp_path / "out.json")
+        atomic_json_write(path, {"original": True})
+        with pytest.raises(TypeError):
+            atomic_json_write(path, {"bad": object()})
+        with open(path) as f:
+            assert json.load(f) == {"original": True}


### PR DESCRIPTION
## Summary

Two related fixes for the safe-writes pattern flagged by the recent audit.

**1. Module-level locks in `history/` and `bookmark/` repositories.** Both expose module-level `_save()` functions called from public mutators (`record_session`, `add_bookmark`, etc.). With no lock, two threads doing read-modify-write concurrently can lose data — the atomic `tmp + os.replace` prevents corruption but not last-write-wins. Each module now holds a `threading.Lock()` and wraps its public mutators with it.

**2. Promote `_atomic_json_write` to `core/helpers.py`.** The pattern was duplicated 4× (security had a private helper, summary/history/bookmark each had inline `tmp + os.replace` blocks). Now lives once as `atomic_json_write` in `backend/core/helpers.py`. Raises `OSError` so callers can attach a domain-specific log message. Net: ~40 lines deduplicated.

## Why now

The architecture audit identified the unguarded module-level `_save()` calls as a real concurrency risk in domains called from both UI clicks (main thread) and background scans (detection thread). Tmp+rename gives atomicity but not isolation; the lock closes the gap.

## Changes

- **New:** `atomic_json_write(path, data, *, indent=2)` in `backend/core/helpers.py`
- **`security/repository.py`:** delete private `_atomic_json_write`, use shared helper (5 call sites)
- **`summary/repository.py`:** swap inline tmp+rename for shared helper (existing `_store_lock` retained)
- **`history/repository.py`:** add module-level `_LOCK = threading.Lock()`, wrap `record_session`, `get_history`, `remove_history_entry`; use shared helper
- **`bookmark/repository.py`:** add module-level `_LOCK = threading.Lock()`, wrap `add_bookmark`, `get_bookmarks`, `get_bookmarked_cwds`, `clear_all_bookmarks`, `remove_bookmark`; use shared helper
- **`tests/core/test_helpers.py`:** 8 new tests for `atomic_json_write` — happy path, list/dict input, overwrite, indent options, no-tmp-residue on success, target-unchanged when serialization fails

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [ ] CI lint + macOS test (gated on `ready to merge` label)
- [ ] Smoke-test on macOS: bookmark add/remove from menu still works; history records new sessions; security pane removes/clears permissions correctly