### PR TITLE
fix: expose public mark_shown on OnboardingService

### DIFF
--- a/claudewatch/backend/onboarding/service.py
+++ b/claudewatch/backend/onboarding/service.py
@@ -55,7 +55,7 @@ class OnboardingService(BaseService):
             return list(tips)
         return []
 
-    def _mark_shown(self, tip_id: str) -> None:
+    def mark_shown(self, tip_id: str) -> None:
         """Persist *tip_id* as shown so it is never delivered again."""
         self._shown_this_session.add(tip_id)
         shown = self._shown_tips()
@@ -81,7 +81,7 @@ class OnboardingService(BaseService):
         if not tip:
             return False
 
-        self._mark_shown(tip_id)
+        self.mark_shown(tip_id)
         self._notification_service.send(tip["title"], "ClaudeWatch", tip["message"])
         log.info("onboarding.tip_shown tip=%s", tip_id)
         return True

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -592,11 +592,11 @@ class ClaudeWatchApp:
         show_preferences()
 
     def _open_guide(self, _: NSMenuItem) -> None:
-        self._onboarding_service._mark_shown("guide_nudge")
+        self._onboarding_service.mark_shown("guide_nudge")
         show_preferences(pane="guide")
 
     def _dismiss_guide(self, _: NSMenuItem) -> None:
-        self._onboarding_service._mark_shown("guide_nudge")
+        self._onboarding_service.mark_shown("guide_nudge")
         self._last_menu_key = ""  # force menu rebuild
 
     def _open_github(self, _: NSMenuItem) -> None:

--- a/tests/onboarding/test_onboarding.py
+++ b/tests/onboarding/test_onboarding.py
@@ -60,6 +60,46 @@ class TestTipTracking:
             assert not svc.is_tip_shown("welcome")
 
 
+class TestMarkShown:
+    """Public mark_shown — used by UI for tips that aren't notification-delivered (e.g. menu nudges)."""
+
+    def test_persists_tip_id(self):
+        svc = _make_service()
+        mock_set = MagicMock()
+        with (
+            patch(f"{_MOD}.get_setting", return_value=[]),
+            patch(f"{_MOD}.set_setting", mock_set),
+        ):
+            svc.mark_shown("guide_nudge")
+        mock_set.assert_called_once_with("onboarding_tips_shown", ["guide_nudge"])
+
+    def test_idempotent_skips_duplicate_persist(self):
+        svc = _make_service()
+        mock_set = MagicMock()
+        with (
+            patch(f"{_MOD}.get_setting", return_value=["guide_nudge"]),
+            patch(f"{_MOD}.set_setting", mock_set),
+        ):
+            svc.mark_shown("guide_nudge")
+        mock_set.assert_not_called()
+
+    def test_preserves_existing_shown_tips(self):
+        svc = _make_service()
+        mock_set = MagicMock()
+        with (
+            patch(f"{_MOD}.get_setting", return_value=["welcome", "attention"]),
+            patch(f"{_MOD}.set_setting", mock_set),
+        ):
+            svc.mark_shown("guide_nudge")
+        mock_set.assert_called_once_with("onboarding_tips_shown", ["welcome", "attention", "guide_nudge"])
+
+    def test_in_memory_fallback_blocks_resends(self):
+        svc = _make_service()
+        with patch(f"{_MOD}.set_setting"), patch(f"{_MOD}.get_setting", return_value=[]):
+            svc.mark_shown("guide_nudge")
+        assert svc.is_tip_shown("guide_nudge")
+
+
 class TestShowTip:
     """Tip delivery via NotificationService.send()."""
 


### PR DESCRIPTION
## Summary

Closes the last item from the recent architectural audit: `menubar.py:595,599` was reaching into `_onboarding_service._mark_shown("guide_nudge")` — a cross-module call into a private method, which `.claude/rules/architecture.md` forbids ("Never access private methods (`_method`) across module boundaries").

The method is genuinely a public API: not every shown tip gets delivered as a notification — some are inline menu items dismissed on click (the getting-started nudge being the example) — so callers legitimately need to mark a tip handled without going through `show_tip`.

## Changes

- **`backend/onboarding/service.py`:** rename `_mark_shown` → `mark_shown`. Internal call from `show_tip` follows the rename.
- **`ui/menubar.py`:** `_open_guide` and `_dismiss_guide` now call the public method.
- **`tests/onboarding/test_onboarding.py`:** 4 new direct tests for `mark_shown` — persistence, idempotency, preservation of existing entries, in-memory fallback.

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [ ] CI lint + macOS test (gated on `ready to merge` label)
- [ ] Smoke-test on macOS: clicking "View Guide" or "Don't show again" in the menu makes the nudge stay dismissed across app restarts