### PR TITLE
fix: clamp notification content to tool name + project per privacy rule

### DIFF
--- a/claudewatch/backend/notifications/service.py
+++ b/claudewatch/backend/notifications/service.py
@@ -139,21 +139,17 @@ class NotificationService(BaseService):
         self.last_notification_time = now
 
         for s in new_attention:
+            # Privacy: notifications carry only the tool name + project name.
+            # prompt_text from detection is shaped "ToolName: <input snippet>" — drop the snippet.
+            tool_name = s.prompt_text.split(":", 1)[0].strip() if s.prompt_text else ""
             title = "Claude needs attention"
             subtitle = s.project
-            if s.prompt_text:
-                message = s.prompt_text
-            elif s.task_summary:
-                message = s.task_summary
-            elif s.last_output:
-                message = s.last_output
-            else:
-                message = "Waiting for input"
+            message = f"{tool_name} approval needed" if tool_name else "Waiting for input"
 
             log.info(
-                "notification.sent project=%s action=%s host=%s pid=%d",
+                "notification.sent project=%s tool=%s host=%s pid=%d",
                 s.project,
-                s.prompt_text or "permission",
+                tool_name or "permission",
                 s.host_app.value,
                 s.pid,
             )

--- a/tests/notifications/test_notifications.py
+++ b/tests/notifications/test_notifications.py
@@ -195,6 +195,84 @@ class TestNotifyIfNeeded:
         user_info = mock_notif.setUserInfo_.call_args[0][0]
         assert user_info["pid"] == 500
 
+    def test_message_never_includes_command_input(self):
+        """Privacy rule: notification body must contain only tool name + project, never input."""
+        svc = NotificationService()
+        svc.last_notification_time = 0.0
+        mock_cls, mock_notif = _mock_notification_class()
+        svc._center = _mock_center()
+        with (
+            patch(f"{_MOD}.features.is_enabled", return_value=True),
+            patch(f"{_MOD}.NSUserNotification", mock_cls),
+        ):
+            s = _make_session(
+                pid=600,
+                project="myproject",
+                status=SessionStatus.ATTENTION,
+                prompt_text="Bash: rm -rf /private/secret-dir",
+            )
+            svc.notify_if_needed([s])
+        message = mock_notif.setInformativeText_.call_args[0][0]
+        assert "rm -rf" not in message
+        assert "/private" not in message
+        assert message == "Bash approval needed"
+
+    def test_message_falls_back_to_waiting_when_no_tool(self):
+        svc = NotificationService()
+        svc.last_notification_time = 0.0
+        mock_cls, mock_notif = _mock_notification_class()
+        svc._center = _mock_center()
+        with (
+            patch(f"{_MOD}.features.is_enabled", return_value=True),
+            patch(f"{_MOD}.NSUserNotification", mock_cls),
+        ):
+            s = _make_session(pid=601, status=SessionStatus.ATTENTION, prompt_text="")
+            svc.notify_if_needed([s])
+        assert mock_notif.setInformativeText_.call_args[0][0] == "Waiting for input"
+
+    def test_message_does_not_leak_task_summary_or_last_output(self):
+        """Even if task_summary/last_output have content, they must not appear in the notification."""
+        svc = NotificationService()
+        svc.last_notification_time = 0.0
+        mock_cls, mock_notif = _mock_notification_class()
+        svc._center = _mock_center()
+        with (
+            patch(f"{_MOD}.features.is_enabled", return_value=True),
+            patch(f"{_MOD}.NSUserNotification", mock_cls),
+        ):
+            s = _make_session(
+                pid=602,
+                status=SessionStatus.ATTENTION,
+                prompt_text="",
+                last_output="leaked terminal buffer content",
+            )
+            svc.notify_if_needed([s])
+        message = mock_notif.setInformativeText_.call_args[0][0]
+        assert "leaked" not in message
+        assert "terminal buffer" not in message
+
+    def test_log_records_tool_name_not_command(self, caplog):
+        """Audit log must not contain user prompts / command bodies."""
+        svc = NotificationService()
+        svc.last_notification_time = 0.0
+        mock_cls, _ = _mock_notification_class()
+        svc._center = _mock_center()
+        with (
+            patch(f"{_MOD}.features.is_enabled", return_value=True),
+            patch(f"{_MOD}.NSUserNotification", mock_cls),
+            caplog.at_level("INFO", logger="claudewatch"),
+        ):
+            s = _make_session(
+                pid=603,
+                project="proj",
+                status=SessionStatus.ATTENTION,
+                prompt_text="Bash: cat /etc/passwd",
+            )
+            svc.notify_if_needed([s])
+        joined = " ".join(r.message for r in caplog.records)
+        assert "cat /etc/passwd" not in joined
+        assert "tool=Bash" in joined
+
     def test_notifications_disabled_skips(self):
         svc = NotificationService()
         mock_center = _mock_center()


### PR DESCRIPTION
## Summary

`.claude/rules/privacy.md` is explicit: *"Notifications must only contain tool names and project names. Never raw terminal buffer data."* The notification path was reading `s.prompt_text`, `s.task_summary`, or `s.last_output` into the body — all three can carry tool input or raw terminal content:

- `prompt_text` is shaped `"ToolName: <command-or-path-snippet>"` by `_format_tool_use` in detection — leaks command text and file paths.
- `task_summary` and `last_output` carry raw terminal buffer content directly.

## Fix

- Extract just the tool name from `prompt_text` (`split(":", 1)[0]`).
- Notification body becomes `"{ToolName} approval needed"`, or `"Waiting for input"` when no tool name is available.
- Drop the `task_summary` / `last_output` fallbacks entirely.
- Same redaction applied to the audit log line — previously logged `s.prompt_text` (full snippet); now logs only the tool name.

## Changes

- **`backend/notifications/service.py:141-159`** — replace prompt_text/task_summary/last_output cascade with tool-name-only message + log line.
- **`tests/notifications/test_notifications.py`** — 4 new tests:
  - `test_message_never_includes_command_input` — verifies `Bash: rm -rf /...` never reaches the notification body.
  - `test_message_falls_back_to_waiting_when_no_tool` — empty prompt_text → "Waiting for input".
  - `test_message_does_not_leak_task_summary_or_last_output` — those fields are never read.
  - `test_log_records_tool_name_not_command` — audit log carries `tool=Bash`, not the command.

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [ ] CI lint + macOS test (gated on `ready to merge` label)
- [ ] Smoke-test on macOS: trigger an ATTENTION session via Bash tool approval, confirm notification reads `"Bash approval needed"` and not the command text.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5WTPdcBtUKkEUMCeYuQGg)_