### PR TITLE
perf: cache bookmark + history reads so menu builds do no JSON I/O

### DIFF
--- a/claudewatch/backend/bookmark/service.py
+++ b/claudewatch/backend/bookmark/service.py
@@ -1,29 +1,57 @@
 """BookmarkService — facade over the bookmarks repository for UI consumption."""
 
+import threading
+
 from claudewatch.backend.bookmark import repository as bookmarks_repo
 from claudewatch.backend.core.dto import BookmarkDTO
 from claudewatch.backend.core.service import BaseService
 
 
 class BookmarkService(BaseService):
-    """Bookmark/unbookmark sessions and return DTOs for the UI layer."""
+    """Bookmark/unbookmark sessions and return DTOs for the UI layer.
+
+    Holds an in-memory cache of the bookmark list so menu builds (main thread)
+    don't trigger JSON file reads. Cache is lazy-loaded on first read and
+    invalidated by every mutation.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._cache: list[BookmarkDTO] | None = None
+        self._cache_lock = threading.Lock()
 
     def add(self, session_id: str, project: str, cwd: str, note: str) -> None:
         """Bookmark a session with a note. Updates if already bookmarked."""
         bookmarks_repo.add_bookmark(session_id, project, cwd, note)
+        self._invalidate()
 
     def remove(self, cwd: str) -> None:
         """Remove a bookmark by CWD."""
         bookmarks_repo.remove_bookmark(cwd)
+        self._invalidate()
 
     def get_all(self) -> list[BookmarkDTO]:
         """Return all bookmarked sessions as DTOs."""
-        return bookmarks_repo.get_bookmarks()
+        with self._cache_lock:
+            if self._cache is None:
+                self._cache = bookmarks_repo.get_bookmarks()
+            return list(self._cache)
 
     def get_bookmarked_cwds(self) -> set[str]:
         """Return the set of CWDs that are currently bookmarked."""
-        return bookmarks_repo.get_bookmarked_cwds()
+        return {b.cwd for b in self.get_all()}
 
     def clear_all(self) -> None:
         """Delete all bookmarks."""
         bookmarks_repo.clear_all_bookmarks()
+        self._invalidate()
+
+    def warm(self) -> None:
+        """Pre-populate the cache. Call from a background thread so the first
+        main-thread read of bookmark data doesn't block on disk I/O."""
+        with self._cache_lock:
+            self._cache = bookmarks_repo.get_bookmarks()
+
+    def _invalidate(self) -> None:
+        with self._cache_lock:
+            self._cache = None

--- a/claudewatch/backend/history/service.py
+++ b/claudewatch/backend/history/service.py
@@ -1,21 +1,48 @@
 """HistoryService — facade over the history repository for UI consumption."""
 
+import threading
+
 from claudewatch.backend.core.dto import HistoryEntryDTO
 from claudewatch.backend.core.service import BaseService
 from claudewatch.backend.history import repository as history_repo
 
 
 class HistoryService(BaseService):
-    """Record, list, and remove session history entries as DTOs."""
+    """Record, list, and remove session history entries as DTOs.
+
+    Holds an in-memory cache of the history list so menu builds (main thread)
+    don't trigger JSON file reads. Cache is lazy-loaded on first read and
+    invalidated by every mutation.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._cache: list[HistoryEntryDTO] | None = None
+        self._cache_lock = threading.Lock()
 
     def record(self, session_id: str, project: str, cwd: str, model: str, host_app: str) -> None:
         """Record a session when it ends."""
         history_repo.record_session(session_id, project, cwd, model, host_app)
+        self._invalidate()
 
     def get_all(self) -> list[HistoryEntryDTO]:
         """Return all history entries as DTOs, newest first."""
-        return history_repo.get_history()
+        with self._cache_lock:
+            if self._cache is None:
+                self._cache = history_repo.get_history()
+            return list(self._cache)
 
     def remove(self, cwd: str) -> None:
         """Remove a history entry by CWD."""
         history_repo.remove_history_entry(cwd)
+        self._invalidate()
+
+    def warm(self) -> None:
+        """Pre-populate the cache. Call from a background thread so the first
+        main-thread read of history data doesn't block on disk I/O."""
+        with self._cache_lock:
+            self._cache = history_repo.get_history()
+
+    def _invalidate(self) -> None:
+        with self._cache_lock:
+            self._cache = None

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -139,6 +139,9 @@ class ClaudeWatchApp:
         # Kick off background update check
         _safe_bg(self._update_service.check)
         _safe_bg(self._security_service.warm_command_cache)
+        # Pre-populate caches off the main thread so menu builds do no JSON I/O.
+        _safe_bg(self._bookmark_service.warm)
+        _safe_bg(self._history_service.warm)
 
     def run(self) -> None:
         """Start the app: create status bar item, timer, and run the event loop."""

--- a/tests/bookmark/test_bookmark_service.py
+++ b/tests/bookmark/test_bookmark_service.py
@@ -66,11 +66,75 @@ class TestBookmarkService:
         assert result[0].timestamp == ""
 
     @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
-    def test_get_bookmarked_cwds_delegates_to_repo(self, mock_repo):
-        mock_repo.get_bookmarked_cwds.return_value = {"/tmp/a", "/tmp/b"}
-        result = self.svc.get_bookmarked_cwds()
-        assert result == {"/tmp/a", "/tmp/b"}
-        mock_repo.get_bookmarked_cwds.assert_called_once()
+    def test_get_bookmarked_cwds_derives_from_get_all(self, mock_repo):
+        mock_repo.get_bookmarks.return_value = [
+            BookmarkDTO(session_id="s1", project="p", cwd="/tmp/a", note="", timestamp=""),
+            BookmarkDTO(session_id="s2", project="p", cwd="/tmp/b", note="", timestamp=""),
+        ]
+        assert self.svc.get_bookmarked_cwds() == {"/tmp/a", "/tmp/b"}
+
+
+class TestBookmarkServiceCache:
+    """Cache isolates the menu build (main thread) from JSON file reads."""
+
+    def setup_method(self) -> None:
+        self.svc = BookmarkService()
+
+    @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
+    def test_get_all_caches_after_first_call(self, mock_repo):
+        mock_repo.get_bookmarks.return_value = []
+        self.svc.get_all()
+        self.svc.get_all()
+        self.svc.get_all()
+        assert mock_repo.get_bookmarks.call_count == 1
+
+    @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
+    def test_get_bookmarked_cwds_uses_cache(self, mock_repo):
+        mock_repo.get_bookmarks.return_value = []
+        self.svc.get_all()
+        self.svc.get_bookmarked_cwds()
+        assert mock_repo.get_bookmarks.call_count == 1
+
+    @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
+    def test_add_invalidates_cache(self, mock_repo):
+        mock_repo.get_bookmarks.return_value = []
+        self.svc.get_all()
+        self.svc.add("s", "p", "/tmp/cwd", "note")
+        self.svc.get_all()
+        assert mock_repo.get_bookmarks.call_count == 2
+
+    @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
+    def test_remove_invalidates_cache(self, mock_repo):
+        mock_repo.get_bookmarks.return_value = []
+        self.svc.get_all()
+        self.svc.remove("/tmp/cwd")
+        self.svc.get_all()
+        assert mock_repo.get_bookmarks.call_count == 2
+
+    @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
+    def test_clear_all_invalidates_cache(self, mock_repo):
+        mock_repo.get_bookmarks.return_value = []
+        self.svc.get_all()
+        self.svc.clear_all()
+        self.svc.get_all()
+        assert mock_repo.get_bookmarks.call_count == 2
+
+    @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
+    def test_warm_populates_cache(self, mock_repo):
+        mock_repo.get_bookmarks.return_value = []
+        self.svc.warm()
+        self.svc.get_all()
+        assert mock_repo.get_bookmarks.call_count == 1
+
+    @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
+    def test_get_all_returns_independent_list(self, mock_repo):
+        """Mutating the returned list must not poison the cache."""
+        mock_repo.get_bookmarks.return_value = [
+            BookmarkDTO(session_id="s1", project="p", cwd="/tmp/a", note="", timestamp=""),
+        ]
+        result = self.svc.get_all()
+        result.clear()
+        assert len(self.svc.get_all()) == 1
 
     @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
     def test_get_all_returns_frozen_dtos(self, mock_repo):

--- a/tests/history/test_history_service.py
+++ b/tests/history/test_history_service.py
@@ -69,6 +69,46 @@ class TestHistoryService:
         mock_repo.remove_history_entry.assert_called_once_with("/tmp/cwd")
 
     @patch("claudewatch.backend.history.service.history_repo")
+    def test_get_all_caches_after_first_call(self, mock_repo):
+        mock_repo.get_history.return_value = []
+        self.svc.get_all()
+        self.svc.get_all()
+        self.svc.get_all()
+        assert mock_repo.get_history.call_count == 1
+
+    @patch("claudewatch.backend.history.service.history_repo")
+    def test_record_invalidates_cache(self, mock_repo):
+        mock_repo.get_history.return_value = []
+        self.svc.get_all()
+        self.svc.record("sid", "proj", "/tmp/c", "model", "Terminal")
+        self.svc.get_all()
+        assert mock_repo.get_history.call_count == 2
+
+    @patch("claudewatch.backend.history.service.history_repo")
+    def test_remove_invalidates_cache(self, mock_repo):
+        mock_repo.get_history.return_value = []
+        self.svc.get_all()
+        self.svc.remove("/tmp/c")
+        self.svc.get_all()
+        assert mock_repo.get_history.call_count == 2
+
+    @patch("claudewatch.backend.history.service.history_repo")
+    def test_warm_populates_cache(self, mock_repo):
+        mock_repo.get_history.return_value = []
+        self.svc.warm()
+        self.svc.get_all()
+        assert mock_repo.get_history.call_count == 1
+
+    @patch("claudewatch.backend.history.service.history_repo")
+    def test_get_all_returns_independent_list(self, mock_repo):
+        mock_repo.get_history.return_value = [
+            HistoryEntryDTO(session_id="s1", project="p", cwd="/tmp/a", model="m", host_app="Terminal", ended_at=""),
+        ]
+        result = self.svc.get_all()
+        result.clear()
+        assert len(self.svc.get_all()) == 1
+
+    @patch("claudewatch.backend.history.service.history_repo")
     def test_get_all_returns_frozen_dtos(self, mock_repo):
         mock_repo.get_history.return_value = [
             HistoryEntryDTO(


### PR DESCRIPTION
## Summary

`.claude/rules/architecture.md` Threading Rules: *"Never generate summaries or do I/O during menu build — only read from caches."*

`MenuBuilder.build()` was violating this — `bookmark_service.get_all()`, `bookmark_service.get_bookmarked_cwds()`, and `history_service.get_all()` each trigger a fresh `_load()` → JSON file read on the main thread per rebuild. The audit flagged it as a HIGH-severity rule violation.

## Fix

- **`BookmarkService`** and **`HistoryService`** each gain an in-memory `_cache` (lock-protected, lazy-loaded). Cleared by every mutation (`add`/`remove`/`clear`/`record`). New `warm()` method pre-populates from a background thread.
- **`ClaudeWatchApp.__init__`** now warms both caches via `_safe_bg(...)` alongside the existing security/whatis warm, so the first menu build also hits cache (no main-thread blocking on startup).
- **`get_bookmarked_cwds()`** derives from the cached `get_all()` list rather than triggering a separate repo call.

## Changes

| File | What |
|------|------|
| `backend/bookmark/service.py` | Cache + lock + invalidation + `warm()` |
| `backend/history/service.py` | Cache + lock + invalidation + `warm()` |
| `ui/menubar.py` | Two `_safe_bg(svc.warm)` calls in `__init__` |
| `tests/bookmark/test_bookmark_service.py` | 7 new cache tests + 1 updated derivation test |
| `tests/history/test_history_service.py` | 5 new cache tests |

## Scope notes

- **Usage service is unchanged.** It already has `_token_cache` keyed by JSONL mtime that absorbs the dominant cost. The remaining `find_most_recent` + `getmtime` call is cheap and only fires when sessions are present.
- **`_menu_key()` over-rebuilding** (where `last_output` triggers rebuilds on every JSONL write) is real but a separate trade-off — fixing it would mean accepting stale UI for active sessions. Left for a future PR.

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [ ] CI lint + macOS test (gated on `ready to merge` label)
- [ ] Smoke-test on macOS: bookmark a session, verify it appears in menu without delay; remove it, verify it disappears; verify history pane still updates after `record_session`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5WTPdcBtUKkEUMCeYuQGg)_