### PR TITLE
fix: analytics retention sweep + wire schema-version mismatch logging

### DIFF
--- a/claudewatch/backend/analytics/models.py
+++ b/claudewatch/backend/analytics/models.py
@@ -225,6 +225,16 @@ class AnalyticsStore:
             if row is None:
                 s.add(SchemaVersionRow(version=_SCHEMA_VERSION))
                 s.commit()
+                return
+            if row.version != _SCHEMA_VERSION:
+                # No automatic migration plumbing yet — log loudly so the
+                # mismatch is visible in the audit log when it eventually happens.
+                log.warning(
+                    "analytics: schema version mismatch — db=%d, code=%d. "
+                    "Queries depending on newer columns may fail; delete the DB to recreate.",
+                    row.version,
+                    _SCHEMA_VERSION,
+                )
 
     @property
     def engine(self) -> Engine:

--- a/claudewatch/backend/analytics/repository.py
+++ b/claudewatch/backend/analytics/repository.py
@@ -678,6 +678,51 @@ class AgentScanner:
         return "stale"
 
 
+class Maintenance:
+    """Retention sweep for analytics tables."""
+
+    def __init__(self, session_factory: sessionmaker[Session]) -> None:
+        self._session_factory = session_factory
+
+    def prune_older_than(self, cutoff_epoch: float) -> dict[str, int]:
+        """Delete time-series rows whose ts_epoch / last_epoch is older than ``cutoff_epoch``.
+
+        Sessions are pruned by ``last_epoch`` (last activity). Agents whose session no
+        longer exists become orphans and are pruned too. Returns ``{table: rows_deleted}``.
+        """
+        deleted: dict[str, int] = {}
+        with self._session_factory() as s:
+            for row_cls, label in (
+                (EventRow, "events"),
+                (ToolRow, "tools"),
+                (FileRow, "files"),
+                (TokenRow, "tokens"),
+                (PullRequestRow, "pull_requests"),
+            ):
+                count = s.query(row_cls).filter(row_cls.ts_epoch < cutoff_epoch).delete()
+                if count:
+                    deleted[label] = count
+
+            session_count = (
+                s.query(SessionRow)
+                .filter(SessionRow.last_epoch.is_not(None), SessionRow.last_epoch < cutoff_epoch)
+                .delete()
+            )
+            if session_count:
+                deleted["sessions"] = session_count
+
+            agent_count = (
+                s.query(AgentRow)
+                .filter(~AgentRow.session_id.in_(select(SessionRow.session_id)))
+                .delete(synchronize_session=False)
+            )
+            if agent_count:
+                deleted["agents"] = agent_count
+
+            s.commit()
+        return deleted
+
+
 class Queries:
     """All read-only analytics queries via SQLAlchemy ORM."""
 

--- a/claudewatch/backend/analytics/service.py
+++ b/claudewatch/backend/analytics/service.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Protocol
 
 from claudewatch.backend.analytics.models import AgentInfo, AnalyticsStore
-from claudewatch.backend.analytics.repository import AgentScanner, Ingest, Queries
+from claudewatch.backend.analytics.repository import AgentScanner, Ingest, Maintenance, Queries
 from claudewatch.backend.core.paths import cwd_to_proj_key
 from claudewatch.backend.core.service import BaseService
 
 log = logging.getLogger("claudewatch")
+
+_DEFAULT_RETENTION_DAYS = 180
 
 
 class _Enrichable(Protocol):
@@ -27,7 +30,16 @@ class AnalyticsService(BaseService):
         self._ingest = Ingest(self._store.session)
         self._scanner = AgentScanner(self._store.session, projects_dir)
         self._queries = Queries(self._store.session)
+        self._maintenance = Maintenance(self._store.session)
         self._projects_dir = projects_dir
+
+    def prune_old_data(self, days: int = _DEFAULT_RETENTION_DAYS) -> dict[str, int]:
+        """Delete analytics rows older than ``days``. Returns ``{table: rows_deleted}``."""
+        cutoff = time.time() - days * 86400
+        deleted = self._maintenance.prune_older_than(cutoff)
+        if deleted:
+            log.info("analytics.pruned days=%d %s", days, deleted)
+        return deleted
 
     # --- ETL (background thread) ---
 

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -142,6 +142,8 @@ class ClaudeWatchApp:
         # Pre-populate caches off the main thread so menu builds do no JSON I/O.
         _safe_bg(self._bookmark_service.warm)
         _safe_bg(self._history_service.warm)
+        # Prune old analytics rows once per launch — keeps the SQLite DB bounded.
+        _safe_bg(self._analytics_service.prune_old_data)
 
     def run(self) -> None:
         """Start the app: create status bar item, timer, and run the event loop."""

--- a/tests/analytics/test_maintenance.py
+++ b/tests/analytics/test_maintenance.py
@@ -73,9 +73,7 @@ class TestMaintenance:
         with store.session() as s:
             assert s.query(EventRow).count() == 1
 
-    def test_prunes_across_all_time_series_tables(
-        self, store: AnalyticsStore, maintenance: Maintenance
-    ) -> None:
+    def test_prunes_across_all_time_series_tables(self, store: AnalyticsStore, maintenance: Maintenance) -> None:
         now = time.time()
         old = now - 365 * 86400
         with store.session() as s:
@@ -106,9 +104,7 @@ class TestMaintenance:
         with store.session() as s:
             assert s.query(EventRow).count() == 1
 
-    def test_prunes_old_sessions_by_last_epoch(
-        self, store: AnalyticsStore, maintenance: Maintenance
-    ) -> None:
+    def test_prunes_old_sessions_by_last_epoch(self, store: AnalyticsStore, maintenance: Maintenance) -> None:
         now = time.time()
         _seed_session(store, session_id="old", last_epoch=now - 365 * 86400)
         _seed_session(store, session_id="recent", last_epoch=now - 1 * 86400)
@@ -118,9 +114,7 @@ class TestMaintenance:
             remaining = {row.session_id for row in s.query(SessionRow).all()}
         assert remaining == {"recent"}
 
-    def test_keeps_sessions_with_null_last_epoch(
-        self, store: AnalyticsStore, maintenance: Maintenance
-    ) -> None:
+    def test_keeps_sessions_with_null_last_epoch(self, store: AnalyticsStore, maintenance: Maintenance) -> None:
         _seed_session(store, session_id="never_active", last_epoch=None)
         maintenance.prune_older_than(time.time() - 180 * 86400)
         with store.session() as s:
@@ -137,9 +131,7 @@ class TestMaintenance:
             remaining = {row.agent_id for row in s.query(AgentRow).all()}
         assert remaining == {"a-alive"}
 
-    def test_returns_empty_dict_when_nothing_to_prune(
-        self, store: AnalyticsStore, maintenance: Maintenance
-    ) -> None:
+    def test_returns_empty_dict_when_nothing_to_prune(self, store: AnalyticsStore, maintenance: Maintenance) -> None:
         deleted = maintenance.prune_older_than(time.time() - 180 * 86400)
         assert deleted == {}
 

--- a/tests/analytics/test_maintenance.py
+++ b/tests/analytics/test_maintenance.py
@@ -1,0 +1,152 @@
+"""Tests for Maintenance — analytics retention sweep."""
+
+import os
+import time
+
+import pytest
+
+from claudewatch.backend.analytics.models import (
+    AgentRow,
+    AnalyticsStore,
+    EventRow,
+    FileRow,
+    PullRequestRow,
+    SessionRow,
+    TokenRow,
+    ToolRow,
+)
+from claudewatch.backend.analytics.repository import Maintenance
+
+
+@pytest.fixture
+def store(tmp_path: str) -> AnalyticsStore:
+    return AnalyticsStore(os.path.join(tmp_path, "test.db"))
+
+
+@pytest.fixture
+def maintenance(store: AnalyticsStore) -> Maintenance:
+    return Maintenance(store.session)
+
+
+def _seed_event(store: AnalyticsStore, *, ts_epoch: float, session_id: str = "s1") -> None:
+    with store.session() as s:
+        s.add(
+            EventRow(
+                session_id=session_id,
+                uuid=f"e-{ts_epoch}",
+                entry_type="user",
+                timestamp="x",
+                ts_epoch=ts_epoch,
+                proj_key="pk",
+            )
+        )
+        s.commit()
+
+
+def _seed_session(store: AnalyticsStore, *, session_id: str, last_epoch: float | None) -> None:
+    with store.session() as s:
+        s.add(SessionRow(session_id=session_id, proj_key="pk", last_epoch=last_epoch))
+        s.commit()
+
+
+def _seed_agent(store: AnalyticsStore, *, agent_id: str, session_id: str) -> None:
+    with store.session() as s:
+        s.add(
+            AgentRow(
+                agent_id=agent_id,
+                session_id=session_id,
+                agent_type="t",
+                description="",
+                proj_key="pk",
+            )
+        )
+        s.commit()
+
+
+class TestMaintenance:
+    def test_prunes_old_event_rows(self, store: AnalyticsStore, maintenance: Maintenance) -> None:
+        now = time.time()
+        _seed_event(store, ts_epoch=now - 365 * 86400)  # 1 year old
+        _seed_event(store, ts_epoch=now - 1 * 86400)  # 1 day old
+        deleted = maintenance.prune_older_than(now - 180 * 86400)
+        assert deleted.get("events") == 1
+        with store.session() as s:
+            assert s.query(EventRow).count() == 1
+
+    def test_prunes_across_all_time_series_tables(
+        self, store: AnalyticsStore, maintenance: Maintenance
+    ) -> None:
+        now = time.time()
+        old = now - 365 * 86400
+        with store.session() as s:
+            s.add(EventRow(session_id="s", entry_type="t", timestamp="x", ts_epoch=old, proj_key="pk"))
+            s.add(ToolRow(session_id="s", name="Bash", timestamp="x", ts_epoch=old, proj_key="pk"))
+            s.add(FileRow(session_id="s", path="/p", access_type="read", timestamp="x", ts_epoch=old, proj_key="pk"))
+            s.add(TokenRow(session_id="s", model="m", timestamp="x", ts_epoch=old, proj_key="pk"))
+            s.add(
+                PullRequestRow(
+                    session_id="s", number=1, url="u", repository="r", timestamp="x", ts_epoch=old, proj_key="pk"
+                )
+            )
+            s.commit()
+        deleted = maintenance.prune_older_than(now - 180 * 86400)
+        assert deleted == {
+            "events": 1,
+            "tools": 1,
+            "files": 1,
+            "tokens": 1,
+            "pull_requests": 1,
+        }
+
+    def test_keeps_recent_rows(self, store: AnalyticsStore, maintenance: Maintenance) -> None:
+        now = time.time()
+        _seed_event(store, ts_epoch=now - 1 * 86400)
+        deleted = maintenance.prune_older_than(now - 180 * 86400)
+        assert "events" not in deleted
+        with store.session() as s:
+            assert s.query(EventRow).count() == 1
+
+    def test_prunes_old_sessions_by_last_epoch(
+        self, store: AnalyticsStore, maintenance: Maintenance
+    ) -> None:
+        now = time.time()
+        _seed_session(store, session_id="old", last_epoch=now - 365 * 86400)
+        _seed_session(store, session_id="recent", last_epoch=now - 1 * 86400)
+        deleted = maintenance.prune_older_than(now - 180 * 86400)
+        assert deleted.get("sessions") == 1
+        with store.session() as s:
+            remaining = {row.session_id for row in s.query(SessionRow).all()}
+        assert remaining == {"recent"}
+
+    def test_keeps_sessions_with_null_last_epoch(
+        self, store: AnalyticsStore, maintenance: Maintenance
+    ) -> None:
+        _seed_session(store, session_id="never_active", last_epoch=None)
+        maintenance.prune_older_than(time.time() - 180 * 86400)
+        with store.session() as s:
+            assert s.query(SessionRow).count() == 1
+
+    def test_prunes_orphan_agents(self, store: AnalyticsStore, maintenance: Maintenance) -> None:
+        now = time.time()
+        _seed_session(store, session_id="alive", last_epoch=now - 1 * 86400)
+        _seed_agent(store, agent_id="a-alive", session_id="alive")
+        _seed_agent(store, agent_id="a-orphan", session_id="dead")  # session never seeded
+        deleted = maintenance.prune_older_than(now - 180 * 86400)
+        assert deleted.get("agents") == 1
+        with store.session() as s:
+            remaining = {row.agent_id for row in s.query(AgentRow).all()}
+        assert remaining == {"a-alive"}
+
+    def test_returns_empty_dict_when_nothing_to_prune(
+        self, store: AnalyticsStore, maintenance: Maintenance
+    ) -> None:
+        deleted = maintenance.prune_older_than(time.time() - 180 * 86400)
+        assert deleted == {}
+
+    def test_idempotent_when_called_twice(self, store: AnalyticsStore, maintenance: Maintenance) -> None:
+        now = time.time()
+        _seed_event(store, ts_epoch=now - 365 * 86400)
+        first = maintenance.prune_older_than(now - 180 * 86400)
+        second = maintenance.prune_older_than(now - 180 * 86400)
+        assert first.get("events") == 1
+        assert "events" not in second

--- a/tests/analytics/test_store.py
+++ b/tests/analytics/test_store.py
@@ -65,6 +65,28 @@ class TestAnalyticsStore:
             assert row.version == 1
         store.close()
 
+    def test_schema_version_mismatch_logs_warning(self, db_path: str, caplog) -> None:
+        store = AnalyticsStore(db_path)
+        with store.session() as s:
+            s.query(SchemaVersionRow).delete()
+            s.add(SchemaVersionRow(version=42))
+            s.commit()
+        store.close()
+        with caplog.at_level("WARNING", logger="claudewatch"):
+            store2 = AnalyticsStore(db_path)
+        store2.close()
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("schema version mismatch" in r.message for r in warnings)
+        assert any("db=42" in r.message for r in warnings)
+
+    def test_schema_version_match_no_warning(self, db_path: str, caplog) -> None:
+        AnalyticsStore(db_path).close()
+        with caplog.at_level("WARNING", logger="claudewatch"):
+            store2 = AnalyticsStore(db_path)
+        store2.close()
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert not any("schema version mismatch" in r.message for r in warnings)
+
     def test_engine_property(self, db_path: str) -> None:
         store = AnalyticsStore(db_path)
         assert isinstance(store.engine, Engine)


### PR DESCRIPTION
## Summary

Two related data-layer fixes flagged by the principal-engineer audit.

### 1. Analytics retention sweep

SQLite analytics tables had no cap. After a year of active use the time-series tables (events, tools, files, tokens, pull_requests) grow unbounded — the audit estimated hundreds of thousands of rows for a typical user.

- **New `Maintenance` class** (`analytics/repository.py`) with `prune_older_than(cutoff_epoch)`:
  - Deletes time-series rows where `ts_epoch < cutoff` from all five tables
  - Drops `SessionRow` records by `last_epoch`
  - Sweeps orphan `AgentRow` entries whose session no longer exists
  - Returns `{table: rows_deleted}` for log observability
- **`AnalyticsService.prune_old_data(days=180)`** wraps it
- **`ClaudeWatchApp.__init__`** fires it once per launch on a daemon thread (alongside the existing warm hooks), so the DB stays bounded without user intervention

### 2. SchemaVersionRow wired

`_init_version` previously inserted the version row but never **read** it. A future schema bump would silently leave old DBs at version 1, and the next query against a missing column would crash cryptically. Now mismatch logs at WARNING so the audit log makes the situation visible. Migration plumbing itself is left for a future PR — first we need to actually *see* the mismatch.

## Changes

| File | What |
|------|------|
| `backend/analytics/repository.py` | New `Maintenance` class |
| `backend/analytics/service.py` | `prune_old_data(days)`, wires `Maintenance` |
| `backend/analytics/models.py` | `_init_version` now logs mismatch warning |
| `ui/menubar.py` | One-line `_safe_bg(self._analytics_service.prune_old_data)` at startup |
| `tests/analytics/test_maintenance.py` | 8 new tests |
| `tests/analytics/test_store.py` | 2 new schema-version tests |

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] `pytest tests/analytics/test_maintenance.py tests/analytics/test_store.py` — 19/19 pass
- [ ] CI lint + macOS test (gated on `ready to merge` label)
- [ ] After a 180+ day-old DB starts up, verify the audit log shows `analytics.pruned` with deletion counts

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5WTPdcBtUKkEUMCeYuQGg)_