### PR TITLE
refactor: AgentInfoDTO + centralize JSONL discriminator constants

### DIFF
--- a/claudewatch/backend/activity/service.py
+++ b/claudewatch/backend/activity/service.py
@@ -7,14 +7,7 @@ import os
 
 from claudewatch.backend.core.dto import ActivityEventDTO
 from claudewatch.backend.core.service import BaseService
-from claudewatch.backend.core.session_log.schema import (
-    BLOCK_TEXT,
-    BLOCK_TOOL_USE,
-    SUBTYPE_AWAY_SUMMARY,
-    TYPE_ASSISTANT,
-    TYPE_SYSTEM,
-    TYPE_USER,
-)
+from claudewatch.backend.core.session_log.schema import BlockType, EntryType, Subtype
 from claudewatch.backend.core.session_log.service import SessionLogService
 
 
@@ -49,7 +42,7 @@ class ActivityService(BaseService):
             ts = d.get("timestamp", "")
 
             # Recaps live on the entry itself (d.content), not in message
-            if dtype == TYPE_SYSTEM and d.get("subtype") == SUBTYPE_AWAY_SUMMARY:
+            if dtype == EntryType.SYSTEM and d.get("subtype") == Subtype.AWAY_SUMMARY:
                 content = d.get("content", "")
                 if isinstance(content, str) and content.strip():
                     entries.append(
@@ -66,7 +59,7 @@ class ActivityService(BaseService):
             if not isinstance(msg, dict):
                 continue
 
-            if dtype == TYPE_USER:
+            if dtype == EntryType.USER:
                 content = msg.get("content", "")
                 if isinstance(content, str) and content.strip():
                     entries.append(
@@ -78,8 +71,8 @@ class ActivityService(BaseService):
                         )
                     )
 
-            elif dtype in (TYPE_ASSISTANT, "progress"):
-                if dtype == "progress":
+            elif dtype in (EntryType.ASSISTANT, EntryType.PROGRESS):
+                if dtype == EntryType.PROGRESS:
                     msg = d.get("data", {}).get("message", {})
                     if not isinstance(msg, dict):
                         continue
@@ -89,10 +82,10 @@ class ActivityService(BaseService):
                 for block in content:
                     if not isinstance(block, dict):
                         continue
-                    bt = block.get("type", "")
-                    if bt == BLOCK_TOOL_USE:
+                    block_type = block.get("type", "")
+                    if block_type == BlockType.TOOL_USE:
                         entries.append(_parse_tool_use_dto(block, ts))
-                    elif bt == BLOCK_TEXT:
+                    elif block_type == BlockType.TEXT:
                         text = block.get("text", "").strip()
                         if text:
                             entries.append(

--- a/claudewatch/backend/activity/service.py
+++ b/claudewatch/backend/activity/service.py
@@ -7,6 +7,14 @@ import os
 
 from claudewatch.backend.core.dto import ActivityEventDTO
 from claudewatch.backend.core.service import BaseService
+from claudewatch.backend.core.session_log.schema import (
+    BLOCK_TEXT,
+    BLOCK_TOOL_USE,
+    SUBTYPE_AWAY_SUMMARY,
+    TYPE_ASSISTANT,
+    TYPE_SYSTEM,
+    TYPE_USER,
+)
 from claudewatch.backend.core.session_log.service import SessionLogService
 
 
@@ -41,7 +49,7 @@ class ActivityService(BaseService):
             ts = d.get("timestamp", "")
 
             # Recaps live on the entry itself (d.content), not in message
-            if dtype == "system" and d.get("subtype") == "away_summary":
+            if dtype == TYPE_SYSTEM and d.get("subtype") == SUBTYPE_AWAY_SUMMARY:
                 content = d.get("content", "")
                 if isinstance(content, str) and content.strip():
                     entries.append(
@@ -58,7 +66,7 @@ class ActivityService(BaseService):
             if not isinstance(msg, dict):
                 continue
 
-            if dtype == "user":
+            if dtype == TYPE_USER:
                 content = msg.get("content", "")
                 if isinstance(content, str) and content.strip():
                     entries.append(
@@ -70,7 +78,7 @@ class ActivityService(BaseService):
                         )
                     )
 
-            elif dtype in ("assistant", "progress"):
+            elif dtype in (TYPE_ASSISTANT, "progress"):
                 if dtype == "progress":
                     msg = d.get("data", {}).get("message", {})
                     if not isinstance(msg, dict):
@@ -82,9 +90,9 @@ class ActivityService(BaseService):
                     if not isinstance(block, dict):
                         continue
                     bt = block.get("type", "")
-                    if bt == "tool_use":
+                    if bt == BLOCK_TOOL_USE:
                         entries.append(_parse_tool_use_dto(block, ts))
-                    elif bt == "text":
+                    elif bt == BLOCK_TEXT:
                         text = block.get("text", "").strip()
                         if text:
                             entries.append(

--- a/claudewatch/backend/analytics/models.py
+++ b/claudewatch/backend/analytics/models.py
@@ -347,5 +347,3 @@ class BranchActivity:
     session_count: int
     event_count: int
     last_active: str
-
-

--- a/claudewatch/backend/analytics/models.py
+++ b/claudewatch/backend/analytics/models.py
@@ -349,15 +349,3 @@ class BranchActivity:
     last_active: str
 
 
-@dataclass(frozen=True)
-class AgentInfo:
-    agent_id: str
-    session_id: str
-    parent_agent_id: str
-    agent_type: str
-    description: str
-    status: AgentStatus | str
-    started_at: str
-    ended_at: str
-    entry_count: int
-    proj_key: str

--- a/claudewatch/backend/analytics/repository.py
+++ b/claudewatch/backend/analytics/repository.py
@@ -39,7 +39,7 @@ from claudewatch.backend.analytics.models import (
 )
 from claudewatch.backend.core.dto import AgentInfoDTO
 from claudewatch.backend.core.paths import is_safe_projects_path
-from claudewatch.backend.core.session_log.schema import BLOCK_TOOL_USE
+from claudewatch.backend.core.session_log.schema import BlockType, EntryType
 
 log = logging.getLogger("claudewatch")
 
@@ -212,7 +212,7 @@ class Ingest:
         s.add(evt)
         s.flush()
 
-        if entry_type == "assistant":
+        if entry_type == EntryType.ASSISTANT:
             self._extract_tools(s, message, evt.id, session_id, proj_key, ts, ts_epoch)
             self._extract_tokens(s, message, evt.id, session_id, proj_key, ts, ts_epoch)
 
@@ -232,7 +232,7 @@ class Ingest:
         if not isinstance(content, list):
             return
         for block in content:
-            if not isinstance(block, dict) or block.get("type") != BLOCK_TOOL_USE:
+            if not isinstance(block, dict) or block.get("type") != BlockType.TOOL_USE:
                 continue
             tool_name = block.get("name", "")
             if not tool_name:
@@ -344,7 +344,7 @@ class Ingest:
             self._find_prs(s, content, session_id, proj_key, ts, ts_epoch)
         elif isinstance(content, list):
             for block in content:
-                if isinstance(block, dict) and block.get("type") == "text":
+                if isinstance(block, dict) and block.get("type") == BlockType.TEXT:
                     text = block.get("text", "")
                     if text:
                         self._find_prs(s, text, session_id, proj_key, ts, ts_epoch)
@@ -390,8 +390,8 @@ class Ingest:
                 func.max(EventRow.timestamp).label("last_ts"),
                 func.min(EventRow.ts_epoch).label("first_epoch"),
                 func.max(EventRow.ts_epoch).label("last_epoch"),
-                func.sum(func.iif(EventRow.entry_type == "user", 1, 0)).label("user_msgs"),
-                func.sum(func.iif(EventRow.entry_type == "assistant", 1, 0)).label("asst_msgs"),
+                func.sum(func.iif(EventRow.entry_type == EntryType.USER, 1, 0)).label("user_msgs"),
+                func.sum(func.iif(EventRow.entry_type == EntryType.ASSISTANT, 1, 0)).label("asst_msgs"),
             ).where(EventRow.session_id == session_id)
         ).first()
         if not row or row.first_ts is None:

--- a/claudewatch/backend/analytics/repository.py
+++ b/claudewatch/backend/analytics/repository.py
@@ -16,7 +16,6 @@ from sqlalchemy.orm import Session, sessionmaker
 from claudewatch.backend.analytics.models import (
     ACCESS_TYPE,
     FILE_TOOLS,
-    AgentInfo,
     AgentRow,
     BranchActivity,
     CheckpointRow,
@@ -38,7 +37,9 @@ from claudewatch.backend.analytics.models import (
     ToolSequence,
     ToolUsage,
 )
+from claudewatch.backend.core.dto import AgentInfoDTO
 from claudewatch.backend.core.paths import is_safe_projects_path
+from claudewatch.backend.core.session_log.schema import BLOCK_TOOL_USE
 
 log = logging.getLogger("claudewatch")
 
@@ -231,7 +232,7 @@ class Ingest:
         if not isinstance(content, list):
             return
         for block in content:
-            if not isinstance(block, dict) or block.get("type") != "tool_use":
+            if not isinstance(block, dict) or block.get("type") != BLOCK_TOOL_USE:
                 continue
             tool_name = block.get("name", "")
             if not tool_name:
@@ -596,7 +597,7 @@ class AgentScanner:
                 or 0
             )
 
-    def agents_for_session(self, session_id: str) -> list[AgentInfo]:
+    def agents_for_session(self, session_id: str) -> list[AgentInfoDTO]:
         """Query agent info from DB for a given session."""
         with self._session_factory() as s:
             rows = (
@@ -605,7 +606,7 @@ class AgentScanner:
                 .all()
             )
             return [
-                AgentInfo(
+                AgentInfoDTO(
                     agent_id=r.agent_id,
                     session_id=r.session_id,
                     parent_agent_id=r.parent_agent_id or "",

--- a/claudewatch/backend/analytics/service.py
+++ b/claudewatch/backend/analytics/service.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 from typing import Protocol
 
-from claudewatch.backend.analytics.models import AgentInfo, AnalyticsStore
+from claudewatch.backend.analytics.models import AnalyticsStore
 from claudewatch.backend.analytics.repository import AgentScanner, Ingest, Queries
+from claudewatch.backend.core.dto import AgentInfoDTO
 from claudewatch.backend.core.paths import cwd_to_proj_key
 from claudewatch.backend.core.service import BaseService
 
@@ -58,7 +59,7 @@ class AnalyticsService(BaseService):
 
     # --- Agent details (main thread, for menu submenu) ---
 
-    def agents_for_session(self, session_id: str) -> list[AgentInfo]:
+    def agents_for_session(self, session_id: str) -> list[AgentInfoDTO]:
         return self._scanner.agents_for_session(session_id)
 
     # --- Queries ---

--- a/claudewatch/backend/core/dto.py
+++ b/claudewatch/backend/core/dto.py
@@ -78,3 +78,19 @@ class ChangelogEntryDTO(BaseDTO):
 
     tag: str
     body: str
+
+
+@dataclass(frozen=True)
+class AgentInfoDTO(BaseDTO):
+    """Subagent record returned by AnalyticsService."""
+
+    agent_id: str
+    session_id: str
+    parent_agent_id: str
+    agent_type: str
+    description: str
+    status: str
+    started_at: str
+    ended_at: str
+    entry_count: int
+    proj_key: str

--- a/claudewatch/backend/core/session_log/jsonl.py
+++ b/claudewatch/backend/core/session_log/jsonl.py
@@ -4,7 +4,7 @@ import json
 import os
 
 from claudewatch.backend.core.paths import CLAUDE_PROJECTS_DIR, cwd_to_proj_key
-from claudewatch.backend.core.session_log.schema import FIELD_AI_TITLE, TYPE_AI_TITLE
+from claudewatch.backend.core.session_log.schema import FIELD_AI_TITLE, EntryType
 
 
 def list_jsonls_in_cwd(cwd: str) -> list[str]:
@@ -90,7 +90,7 @@ def read_ai_title(path: str, tail_bytes: int = 10240) -> str:
     tail = read_jsonl_tail(path, tail_bytes=tail_bytes)
     if not tail:
         return ""
-    needle = f'"{TYPE_AI_TITLE}"'
+    needle = f'"{EntryType.AI_TITLE}"'
     for line in reversed(tail.splitlines()):
         if needle not in line:
             continue
@@ -98,7 +98,7 @@ def read_ai_title(path: str, tail_bytes: int = 10240) -> str:
             d = json.loads(line)
         except (json.JSONDecodeError, ValueError):
             continue
-        if d.get("type") == TYPE_AI_TITLE:
+        if d.get("type") == EntryType.AI_TITLE:
             title = d.get(FIELD_AI_TITLE, "")
             if isinstance(title, str) and title:
                 return title

--- a/claudewatch/backend/core/session_log/schema.py
+++ b/claudewatch/backend/core/session_log/schema.py
@@ -1,0 +1,26 @@
+"""Centralized field-name constants for Claude Code's JSONL session-log shape.
+
+Claude Code's JSONL schema evolves: PR #187 added ``away_summary`` recap entries,
+PR #201 added ``ai-title`` entries. Centralizing the strings that identify each
+entry shape (the discriminator values, not generic structural keys like ``type``)
+reduces the blast radius of the next format change to this single file.
+
+If Claude Code renames any of these tokens, update the value here and every
+consumer keeps parsing.
+"""
+
+# Top-level JSONL entry-type values
+TYPE_USER = "user"
+TYPE_ASSISTANT = "assistant"
+TYPE_SYSTEM = "system"
+TYPE_AI_TITLE = "ai-title"
+
+# `system` subtype values
+SUBTYPE_AWAY_SUMMARY = "away_summary"
+
+# Field name for the `ai-title` entry's title payload
+FIELD_AI_TITLE = "aiTitle"
+
+# Content-block ``type`` values inside an assistant message
+BLOCK_TOOL_USE = "tool_use"
+BLOCK_TEXT = "text"

--- a/claudewatch/backend/core/session_log/schema.py
+++ b/claudewatch/backend/core/session_log/schema.py
@@ -5,22 +5,37 @@ PR #201 added ``ai-title`` entries. Centralizing the strings that identify each
 entry shape (the discriminator values, not generic structural keys like ``type``)
 reduces the blast radius of the next format change to this single file.
 
-If Claude Code renames any of these tokens, update the value here and every
-consumer keeps parsing.
+These are ``StrEnum`` so members compare equal to raw JSON strings —
+``EntryType.USER == "user"`` is ``True`` and ``d["type"] == EntryType.USER``
+works without ``.value``. If Claude Code renames any of these tokens, update
+the value here and every consumer keeps parsing.
 """
 
-# Top-level JSONL entry-type values
-TYPE_USER = "user"
-TYPE_ASSISTANT = "assistant"
-TYPE_SYSTEM = "system"
-TYPE_AI_TITLE = "ai-title"
+from enum import StrEnum
 
-# `system` subtype values
-SUBTYPE_AWAY_SUMMARY = "away_summary"
 
-# Field name for the `ai-title` entry's title payload
+class EntryType(StrEnum):
+    """Top-level ``type`` values on a JSONL line."""
+
+    USER = "user"
+    ASSISTANT = "assistant"
+    SYSTEM = "system"
+    AI_TITLE = "ai-title"
+    PROGRESS = "progress"
+
+
+class Subtype(StrEnum):
+    """``system`` entry subtypes."""
+
+    AWAY_SUMMARY = "away_summary"
+
+
+class BlockType(StrEnum):
+    """Content-block ``type`` values inside an assistant message."""
+
+    TOOL_USE = "tool_use"
+    TEXT = "text"
+
+
+# Single-value field name — no enum needed.
 FIELD_AI_TITLE = "aiTitle"
-
-# Content-block ``type`` values inside an assistant message
-BLOCK_TOOL_USE = "tool_use"
-BLOCK_TEXT = "text"

--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -13,6 +13,7 @@ from claudewatch.backend.core.models import (
 from claudewatch.backend.core.process.models import ProcessInfo
 from claudewatch.backend.core.process.service import ProcessService
 from claudewatch.backend.core.service import BaseService
+from claudewatch.backend.core.session_log.schema import BLOCK_TOOL_USE, TYPE_ASSISTANT, TYPE_USER
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.detection.constants import HOST_PROCESS_NAMES, IDLE_INDICATOR
 from claudewatch.backend.detection.models import PendingToolResult, TerminalMatch, ToolUseInfo
@@ -249,7 +250,7 @@ class DetectionService(BaseService):
                 if dtype in ("system", "last-prompt", "pr-link", "queue-operation", "file-history-snapshot"):
                     continue
 
-                if dtype == "user":
+                if dtype == TYPE_USER:
                     content = d.get("message", {}).get("content", [])
                     if isinstance(content, list):
                         has_tool_result = any(isinstance(b, dict) and b.get("type") == "tool_result" for b in content)
@@ -258,9 +259,9 @@ class DetectionService(BaseService):
                             continue
                     return _empty
 
-                if dtype == "assistant":
+                if dtype == TYPE_ASSISTANT:
                     content = d.get("message", {}).get("content", [])
-                    tool_uses = [b for b in content if isinstance(b, dict) and b.get("type") == "tool_use"]
+                    tool_uses = [b for b in content if isinstance(b, dict) and b.get("type") == BLOCK_TOOL_USE]
                     if tool_uses:
                         if seen_tool_result:
                             return _empty
@@ -270,11 +271,11 @@ class DetectionService(BaseService):
 
                 if dtype == "progress":
                     msg = d["data"]["message"]
-                    if msg.get("type") == "user":
+                    if msg.get("type") == TYPE_USER:
                         return _empty
-                    if msg.get("type") == "assistant":
+                    if msg.get("type") == TYPE_ASSISTANT:
                         content = msg.get("message", {}).get("content", [])
-                        tool_uses = [b for b in content if isinstance(b, dict) and b.get("type") == "tool_use"]
+                        tool_uses = [b for b in content if isinstance(b, dict) and b.get("type") == BLOCK_TOOL_USE]
                         if tool_uses:
                             if seen_tool_result:
                                 return _empty

--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -13,7 +13,7 @@ from claudewatch.backend.core.models import (
 from claudewatch.backend.core.process.models import ProcessInfo
 from claudewatch.backend.core.process.service import ProcessService
 from claudewatch.backend.core.service import BaseService
-from claudewatch.backend.core.session_log.schema import BLOCK_TOOL_USE, TYPE_ASSISTANT, TYPE_SYSTEM, TYPE_USER
+from claudewatch.backend.core.session_log.schema import BlockType, EntryType
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.detection.constants import HOST_PROCESS_NAMES, IDLE_INDICATOR
 from claudewatch.backend.detection.models import PendingToolResult, TerminalMatch, ToolUseInfo
@@ -252,10 +252,10 @@ class DetectionService(BaseService):
             except (json.JSONDecodeError, ValueError):
                 continue
             dtype = d.get("type", "")
-            if dtype in (TYPE_USER, TYPE_ASSISTANT):
+            if dtype in (EntryType.USER, EntryType.ASSISTANT):
                 last_type = dtype
 
-        if last_type == TYPE_ASSISTANT:
+        if last_type == EntryType.ASSISTANT:
             return SessionStatus.IDLE
         return SessionStatus.WORKING
 
@@ -281,10 +281,10 @@ class DetectionService(BaseService):
                 d = json.loads(line)
                 dtype = d.get("type")
 
-                if dtype in (TYPE_SYSTEM, "last-prompt", "pr-link", "queue-operation", "file-history-snapshot"):
+                if dtype in (EntryType.SYSTEM, "last-prompt", "pr-link", "queue-operation", "file-history-snapshot"):
                     continue
 
-                if dtype == TYPE_USER:
+                if dtype == EntryType.USER:
                     content = d.get("message", {}).get("content", [])
                     if isinstance(content, list):
                         has_tool_result = any(isinstance(b, dict) and b.get("type") == "tool_result" for b in content)
@@ -293,9 +293,9 @@ class DetectionService(BaseService):
                             continue
                     return _empty
 
-                if dtype == TYPE_ASSISTANT:
+                if dtype == EntryType.ASSISTANT:
                     content = d.get("message", {}).get("content", [])
-                    tool_uses = [b for b in content if isinstance(b, dict) and b.get("type") == BLOCK_TOOL_USE]
+                    tool_uses = [b for b in content if isinstance(b, dict) and b.get("type") == BlockType.TOOL_USE]
                     if tool_uses:
                         if seen_tool_result:
                             return _empty
@@ -303,13 +303,13 @@ class DetectionService(BaseService):
                         return PendingToolResult(has_pending=True, one_line=info.one_line, context=info.context)
                     return _empty
 
-                if dtype == "progress":
+                if dtype == EntryType.PROGRESS:
                     msg = d["data"]["message"]
-                    if msg.get("type") == TYPE_USER:
+                    if msg.get("type") == EntryType.USER:
                         return _empty
-                    if msg.get("type") == TYPE_ASSISTANT:
+                    if msg.get("type") == EntryType.ASSISTANT:
                         content = msg.get("message", {}).get("content", [])
-                        tool_uses = [b for b in content if isinstance(b, dict) and b.get("type") == BLOCK_TOOL_USE]
+                        tool_uses = [b for b in content if isinstance(b, dict) and b.get("type") == BlockType.TOOL_USE]
                         if tool_uses:
                             if seen_tool_result:
                                 return _empty

--- a/claudewatch/backend/graph/repository.py
+++ b/claudewatch/backend/graph/repository.py
@@ -14,7 +14,7 @@ import uuid
 import kuzu
 
 from claudewatch.backend.core.paths import is_safe_projects_path
-from claudewatch.backend.core.session_log.schema import BLOCK_TOOL_USE
+from claudewatch.backend.core.session_log.schema import BlockType, EntryType
 from claudewatch.backend.graph.models import (
     ActionStep,
     BehaviorResult,
@@ -270,7 +270,7 @@ class SessionETL:
 
         ts = entry.get("timestamp", "")
 
-        if entry_type == "assistant":
+        if entry_type == EntryType.ASSISTANT:
             model = message.get("model", "")
             if model and model != "<synthetic>":
                 self._update_session_model(session_id, model)
@@ -285,7 +285,7 @@ class SessionETL:
                 for block in content:
                     if not isinstance(block, dict):
                         continue
-                    if block.get("type") == BLOCK_TOOL_USE:
+                    if block.get("type") == BlockType.TOOL_USE:
                         action_id = self._process_tool(
                             block,
                             session_id,
@@ -296,7 +296,7 @@ class SessionETL:
                             self._create_next(prev_action_id, action_id)
                         if action_id:
                             prev_action_id = action_id
-                    elif block.get("type") == "text":
+                    elif block.get("type") == BlockType.TEXT:
                         self._extract_prs(block.get("text", ""), session_id, ts)
 
         # Check for agent spawns in the entry

--- a/claudewatch/backend/graph/repository.py
+++ b/claudewatch/backend/graph/repository.py
@@ -14,6 +14,7 @@ import uuid
 import kuzu
 
 from claudewatch.backend.core.paths import is_safe_projects_path
+from claudewatch.backend.core.session_log.schema import BLOCK_TOOL_USE
 from claudewatch.backend.graph.models import (
     ActionStep,
     BehaviorResult,
@@ -284,7 +285,7 @@ class SessionETL:
                 for block in content:
                     if not isinstance(block, dict):
                         continue
-                    if block.get("type") == "tool_use":
+                    if block.get("type") == BLOCK_TOOL_USE:
                         action_id = self._process_tool(
                             block,
                             session_id,

--- a/claudewatch/backend/security/repository.py
+++ b/claudewatch/backend/security/repository.py
@@ -10,6 +10,7 @@ import time
 
 from claudewatch.backend.core.helpers import atomic_json_write
 from claudewatch.backend.core.paths import CLAUDE_PROJECTS_DIR, proj_key_to_cwd
+from claudewatch.backend.core.session_log.schema import BLOCK_TOOL_USE
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.core.settings import get_setting, set_setting
 from claudewatch.backend.security.models import ConfigSnapshot, is_dangerous_permission
@@ -319,7 +320,7 @@ class SecurityRepository:
                 continue
 
             for block in content:
-                if not isinstance(block, dict) or block.get("type") != "tool_use":
+                if not isinstance(block, dict) or block.get("type") != BLOCK_TOOL_USE:
                     continue
                 if block.get("name") != "Bash":
                     continue

--- a/claudewatch/backend/security/repository.py
+++ b/claudewatch/backend/security/repository.py
@@ -10,7 +10,7 @@ import time
 
 from claudewatch.backend.core.helpers import atomic_json_write
 from claudewatch.backend.core.paths import CLAUDE_PROJECTS_DIR, proj_key_to_cwd
-from claudewatch.backend.core.session_log.schema import BLOCK_TOOL_USE
+from claudewatch.backend.core.session_log.schema import BlockType
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.core.settings import get_setting, set_setting
 from claudewatch.backend.security.models import ConfigSnapshot, is_dangerous_permission
@@ -320,7 +320,7 @@ class SecurityRepository:
                 continue
 
             for block in content:
-                if not isinstance(block, dict) or block.get("type") != BLOCK_TOOL_USE:
+                if not isinstance(block, dict) or block.get("type") != BlockType.TOOL_USE:
                     continue
                 if block.get("name") != "Bash":
                     continue

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -17,6 +17,12 @@ import threading
 import time
 
 from claudewatch.backend.core.service import BaseService
+from claudewatch.backend.core.session_log.schema import (
+    FIELD_AI_TITLE,
+    SUBTYPE_AWAY_SUMMARY,
+    TYPE_AI_TITLE,
+    TYPE_SYSTEM,
+)
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.summary.repository import SummaryRepository
 
@@ -46,7 +52,7 @@ def _find_last_recap(lines: list[str]) -> str | None:
             d = json.loads(line)
         except (json.JSONDecodeError, ValueError):
             continue
-        if d.get("type") == "system" and d.get("subtype") == "away_summary":
+        if d.get("type") == TYPE_SYSTEM and d.get("subtype") == SUBTYPE_AWAY_SUMMARY:
             content = d.get("content", "")
             if isinstance(content, str) and content.strip():
                 recap = content.strip()
@@ -61,8 +67,8 @@ def _find_last_ai_title(lines: list[str]) -> str | None:
             d = json.loads(line)
         except (json.JSONDecodeError, ValueError):
             continue
-        if d.get("type") == "ai-title":
-            value = d.get("aiTitle", "")
+        if d.get("type") == TYPE_AI_TITLE:
+            value = d.get(FIELD_AI_TITLE, "")
             if isinstance(value, str) and value.strip():
                 title = value.strip()
     return title

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -17,12 +17,7 @@ import threading
 import time
 
 from claudewatch.backend.core.service import BaseService
-from claudewatch.backend.core.session_log.schema import (
-    FIELD_AI_TITLE,
-    SUBTYPE_AWAY_SUMMARY,
-    TYPE_AI_TITLE,
-    TYPE_SYSTEM,
-)
+from claudewatch.backend.core.session_log.schema import FIELD_AI_TITLE, EntryType, Subtype
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.summary.repository import SummaryRepository
 
@@ -52,7 +47,7 @@ def _find_last_recap(lines: list[str]) -> str | None:
             d = json.loads(line)
         except (json.JSONDecodeError, ValueError):
             continue
-        if d.get("type") == TYPE_SYSTEM and d.get("subtype") == SUBTYPE_AWAY_SUMMARY:
+        if d.get("type") == EntryType.SYSTEM and d.get("subtype") == Subtype.AWAY_SUMMARY:
             content = d.get("content", "")
             if isinstance(content, str) and content.strip():
                 recap = content.strip()
@@ -67,7 +62,7 @@ def _find_last_ai_title(lines: list[str]) -> str | None:
             d = json.loads(line)
         except (json.JSONDecodeError, ValueError):
             continue
-        if d.get("type") == TYPE_AI_TITLE:
+        if d.get("type") == EntryType.AI_TITLE:
             value = d.get(FIELD_AI_TITLE, "")
             if isinstance(value, str) and value.strip():
                 title = value.strip()

--- a/claudewatch/ui/menu/session_submenu.py
+++ b/claudewatch/ui/menu/session_submenu.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from claudewatch.backend.analytics.models import AgentInfo
+    from claudewatch.backend.core.dto import AgentInfoDTO
 
 from AppKit import NSMenu, NSMenuItem
 
@@ -41,7 +41,7 @@ def build_session_submenu(
     summary: str | None,
     generating: bool = False,
     actions: SessionActions | None = None,
-    agents: list[AgentInfo] | None = None,
+    agents: list[AgentInfoDTO] | None = None,
 ) -> NSMenu:
     """Build a session submenu with Summary, Usage, and contextual actions."""
     sub = NSMenu.alloc().init()
@@ -98,7 +98,7 @@ def build_session_submenu(
     return sub
 
 
-def build_agents_submenu(agents: list[AgentInfo], delegate: object) -> NSMenuItem:
+def build_agents_submenu(agents: list[AgentInfoDTO], delegate: object) -> NSMenuItem:
     """Build an Agents (N) submenu showing type and status for each agent."""
     d = delegate
     agents_item = make_menu_item(f"Agents ({len(agents)})", None, d)

--- a/tests/analytics/test_scanner.py
+++ b/tests/analytics/test_scanner.py
@@ -5,8 +5,9 @@ import os
 
 import pytest
 
-from claudewatch.backend.analytics.models import AgentInfo, AnalyticsStore
+from claudewatch.backend.analytics.models import AnalyticsStore
 from claudewatch.backend.analytics.repository import AgentScanner
+from claudewatch.backend.core.dto import AgentInfoDTO
 
 
 @pytest.fixture
@@ -138,7 +139,7 @@ class TestAgentScanner:
         scanner = AgentScanner(store.session, projects_dir)
         scanner.scan_all()
         agents = scanner.agents_for_session("sess-1")
-        assert isinstance(agents[0], AgentInfo)
+        assert isinstance(agents[0], AgentInfoDTO)
         assert agents[0].description == "hi"
 
     def test_empty_projects_dir(self, store: AnalyticsStore, tmp_path: str) -> None:

--- a/tests/analytics/test_service.py
+++ b/tests/analytics/test_service.py
@@ -5,8 +5,8 @@ import os
 
 import pytest
 
-from claudewatch.backend.analytics.models import AgentInfo
 from claudewatch.backend.analytics.service import AnalyticsService
+from claudewatch.backend.core.dto import AgentInfoDTO
 
 
 def _write_jsonl(path: str, entries: list[dict]) -> None:
@@ -86,7 +86,7 @@ class TestAnalyticsService:
         service.full_scan()
         agents = service.agents_for_session("sess-1")
         assert len(agents) == 1
-        assert isinstance(agents[0], AgentInfo)
+        assert isinstance(agents[0], AgentInfoDTO)
 
     def test_enrich_sessions(self, service: AnalyticsService, projects_dir: str) -> None:
         agent_dir = os.path.join(projects_dir, "-Users-dev-app", "sess-1", "agent-x")


### PR DESCRIPTION
## Summary

Two changes flagged by the principal-engineer audit, in the same domain — reducing implicit knowledge of internal types and Claude-specific shapes that leaks across module boundaries.

### 1. `AgentInfoDTO` — UI no longer imports from `analytics/models.py`

`ui/menu/session_submenu.py:14` was importing `AgentInfo` directly from `analytics/models.py`, violating the architecture rule that cross-layer types live in `core/dto.py` and inherit `BaseDTO`. Now lives once as `AgentInfoDTO` in `core/dto.py`. Status simplified from `AgentStatus | str` to plain `str` since no caller used the enum form.

### 2. Centralized JSONL discriminator constants in `core/session_log/schema.py`

Claude Code's JSONL shape evolved twice recently (PR #187 added `away_summary`, PR #201 added `ai-title`). Each adaptation was a multi-file hunt for hardcoded string literals. Centralizing the **discriminator values** turns the next format change into a single-file diff:

```
TYPE_USER, TYPE_ASSISTANT, TYPE_SYSTEM, TYPE_AI_TITLE
SUBTYPE_AWAY_SUMMARY
BLOCK_TOOL_USE, BLOCK_TEXT
FIELD_AI_TITLE
```

Generic structural fields (`message`, `content`, `timestamp`) are intentionally **not** centralized — those are stable JSONL meta-shape, not the audit concern.

## Changes

- **New:** `backend/core/dto.py` adds `AgentInfoDTO`
- **New:** `backend/core/session_log/schema.py` (constants)
- **`backend/analytics/models.py`** — `AgentInfo` deleted
- **`backend/analytics/repository.py`** — returns `AgentInfoDTO`; uses `BLOCK_TOOL_USE`
- **`backend/analytics/service.py`** — returns `AgentInfoDTO`
- **`backend/summary/service.py`** — uses `TYPE_SYSTEM`, `SUBTYPE_AWAY_SUMMARY`, `TYPE_AI_TITLE`, `FIELD_AI_TITLE`
- **`backend/activity/service.py`** — uses `TYPE_USER`, `TYPE_ASSISTANT`, `TYPE_SYSTEM`, `SUBTYPE_AWAY_SUMMARY`, `BLOCK_TOOL_USE`, `BLOCK_TEXT`
- **`backend/detection/service.py`** — uses `TYPE_USER`, `TYPE_ASSISTANT`, `BLOCK_TOOL_USE`
- **`backend/graph/repository.py`** — uses `BLOCK_TOOL_USE`
- **`backend/security/repository.py`** — uses `BLOCK_TOOL_USE`
- **`ui/menu/session_submenu.py`** — `AgentInfoDTO` via `core/dto`
- **Tests:** `test_service.py` + `test_scanner.py` import paths updated

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] `pytest tests/analytics/` — 70/70 pass
- [ ] CI lint + macOS test (gated on `ready to merge` label)
- [ ] Smoke-test on macOS: open a session submenu, verify the Agents (N) submenu still renders correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5WTPdcBtUKkEUMCeYuQGg)_