### PR TITLE
chore: PR template + run lint on every PR (not just labeled ones)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,24 @@
 ## Summary
 
-<!-- What and why, 1-3 bullets. -->
+<!-- 1–3 sentences. What changed and why. Link to the audit / issue if relevant. -->
+
+## Changes
+
+<!--
+Bulleted list of the actual edits. Group by file or by concern, whichever
+reads cleaner.
+-->
+
+## Test plan
+
+- [ ] `ruff check .` clean
+- [ ] `python3 scripts/audit_imports.py --check` clean
+- [ ] Targeted tests pass locally: `uv run pytest <paths>`
+- [ ] CI lint + macOS test (gated on `ready to merge` label)
+- [ ] Smoke-test on macOS:
+  <!-- Specific UI flow to exercise: which menu, which pane, which click. -->
+
+<!--
+Domain rule reminder (CLAUDE.md): one branch per domain. If this PR
+spans more than one logical concern, split it before merging.
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [labeled, synchronize]
+    types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
     inputs:
       pr:
@@ -18,9 +18,9 @@ permissions: {}
 
 jobs:
   lint:
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'ready to merge')
+    # Runs on every PR event (and workflow_dispatch). ruff + audit_imports are
+    # cheap, so contributors get fast feedback without needing the
+    # `ready to merge` label.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,6 +39,11 @@ jobs:
         run: python3 scripts/audit_imports.py --check
 
   test:
+    # macOS-14 minutes are expensive — gate on the `ready to merge` label so
+    # the full test suite only runs on PRs that are actually about to land.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'ready to merge')
     runs-on: macos-14
     needs: lint
     permissions:


### PR DESCRIPTION
## Summary

Two contributor-experience fixes flagged by the principal-engineer audit.

### 1. Lint runs on every PR

Previously the entire CI suite (lint, test, security) was gated by the `ready to merge` label, so contributors saw zero CI feedback until a maintainer manually labeled the PR. Now `lint` (`ruff check`, `ruff format --check`, `audit_imports.py`) runs on every PR event — `opened`, `reopened`, `synchronize`, `labeled`. It takes ~30 seconds on Ubuntu so the cost is negligible.

The expensive `test` job (macOS-14, full PyObjC + 70% coverage gate) keeps its label gate, and `security` does too. Net effect:

- **Contributors** get fast lint signal automatically.
- **macOS minutes** are still reserved for ready-to-land PRs.

### 2. PR template

New `.github/pull_request_template.md` with three sections (Summary, Changes, Test plan) matching the format the recent merged PRs already use, plus the one-branch-per-domain reminder from CLAUDE.md.

## Changes

| File | What |
|------|------|
| `.github/workflows/ci.yml` | Trigger types include `opened, reopened`; `lint` job loses its label gate; `test` and `security` jobs keep theirs (now spelled out explicitly) |
| `.github/pull_request_template.md` | Replaces the 1-line stub with a proper template |

## Test plan

- [x] Workflow YAML renders (no syntax errors visible to my eyes)
- [ ] First CI run on this PR will demonstrate the new behavior — `lint` should fire automatically, `test` and `security` should be skipped until the `ready to merge` label is added
- [ ] After labeling, `test` and `security` should run as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5WTPdcBtUKkEUMCeYuQGg)_