### PR TITLE
fix: shared-CWD sessions read sibling JSONL, never reach ATTENTION

### DIFF
--- a/claudewatch/backend/core/session_log/jsonl.py
+++ b/claudewatch/backend/core/session_log/jsonl.py
@@ -1,8 +1,32 @@
 """Shared JSONL file discovery and reading for Claude Code session logs."""
 
+import json
 import os
 
 from claudewatch.backend.core.paths import CLAUDE_PROJECTS_DIR, cwd_to_proj_key
+
+
+def list_jsonls_in_cwd(cwd: str) -> list[str]:
+    """List all JSONL paths in a CWD's project dir, sorted by mtime descending.
+
+    Filters out symlink-traversal paths. Returns empty list on error.
+    """
+    proj_key = cwd_to_proj_key(cwd)
+    proj_dir = os.path.join(CLAUDE_PROJECTS_DIR, proj_key)
+    if not os.path.isdir(proj_dir):
+        return []
+
+    try:
+        candidates = [os.path.join(proj_dir, f) for f in os.listdir(proj_dir) if f.endswith(".jsonl")]
+        jsonls = sorted(
+            (p for p in candidates if is_safe_jsonl_path(p)),
+            key=os.path.getmtime,
+            reverse=True,
+        )
+    except OSError:
+        return []
+
+    return jsonls
 
 
 def find_most_recent_jsonl(cwd: str) -> str | None:
@@ -10,27 +34,8 @@ def find_most_recent_jsonl(cwd: str) -> str | None:
 
     Returns the full path, or None if not found or symlink traversal detected.
     """
-    proj_key = cwd_to_proj_key(cwd)
-    proj_dir = os.path.join(CLAUDE_PROJECTS_DIR, proj_key)
-    if not os.path.isdir(proj_dir):
-        return None
-
-    try:
-        jsonls = sorted(
-            [os.path.join(proj_dir, f) for f in os.listdir(proj_dir) if f.endswith(".jsonl")],
-            key=os.path.getmtime,
-            reverse=True,
-        )
-    except OSError:
-        return None
-
-    if not jsonls:
-        return None
-
-    if not is_safe_jsonl_path(jsonls[0]):
-        return None
-
-    return jsonls[0]
+    jsonls = list_jsonls_in_cwd(cwd)
+    return jsonls[0] if jsonls else None
 
 
 def is_safe_jsonl_path(path: str) -> bool:
@@ -73,3 +78,26 @@ def read_jsonl_full(path: str) -> list[str]:
 def get_session_id_from_path(path: str) -> str:
     """Extract the session ID (UUID) from a JSONL filename."""
     return os.path.basename(path).removesuffix(".jsonl")
+
+
+def read_ai_title(path: str, tail_bytes: int = 10240) -> str:
+    """Return the latest aiTitle recorded in the JSONL, or "" if none.
+
+    Claude Code writes `{"type":"ai-title","aiTitle":"..."}` periodically.
+    We scan the tail in reverse so we pick up the most recent title.
+    """
+    tail = read_jsonl_tail(path, tail_bytes=tail_bytes)
+    if not tail:
+        return ""
+    for line in reversed(tail.splitlines()):
+        if '"ai-title"' not in line:
+            continue
+        try:
+            d = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if d.get("type") == "ai-title":
+            title = d.get("aiTitle", "")
+            if isinstance(title, str) and title:
+                return title
+    return ""

--- a/claudewatch/backend/core/session_log/service.py
+++ b/claudewatch/backend/core/session_log/service.py
@@ -14,6 +14,14 @@ class SessionLogService(BaseService):
         """
         return jsonl.find_most_recent_jsonl(cwd)
 
+    def list_in_cwd(self, cwd: str) -> list[str]:
+        """List all JSONL paths in a CWD's project dir, mtime descending."""
+        return jsonl.list_jsonls_in_cwd(cwd)
+
+    def read_ai_title(self, path: str) -> str:
+        """Return the latest aiTitle recorded in a JSONL, or "" if none."""
+        return jsonl.read_ai_title(path)
+
     def is_safe_path(self, path: str) -> bool:
         """Check that a JSONL path resolves to within CLAUDE_PROJECTS_DIR."""
         return jsonl.is_safe_jsonl_path(path)

--- a/claudewatch/backend/detection/constants.py
+++ b/claudewatch/backend/detection/constants.py
@@ -1,16 +1,5 @@
 from claudewatch.backend.core.models import HostApp
 
-# Permission prompt markers in the terminal buffer
-PROMPT_KEYWORDS = [
-    "do you want to proceed",
-    "yes, allow",
-    "esc to cancel",
-    "allow once",
-    "allow always",
-    "yes, proceed",
-    "approve this action",
-]
-
 # Claude Code sets ✳ in the title when idle (not actively streaming)
 IDLE_INDICATOR = "✳"
 

--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -24,6 +24,7 @@ _MAX_SESSIONS = 50
 _TEXT_MAX_LEN = 80
 _WIN_SPLIT_FIELDS = 3
 _TERMINAL_CACHE_TTL = 3  # seconds between AppleScript refreshes
+_AI_TITLE_CACHE_TTL = 3  # seconds between per-CWD ai-title scans
 _JSONL_STREAMING_THRESHOLD = 5  # JSONL modified within this → actively streaming
 _JSONL_IDLE_THRESHOLD = 60  # JSONL not modified within this → definitely idle
 
@@ -50,6 +51,9 @@ class DetectionService(BaseService):
         self._host_app_cache: dict[int, HostApp] = {}
         self._terminal_cache: dict[str, tuple[str, int]] | None = None
         self._terminal_cache_time: float = 0
+        # cwd → ({ai_title: jsonl_path}, timestamp). Lets each session in a shared
+        # CWD read its own JSONL instead of the most-recent one for the project.
+        self._ai_title_cache: dict[str, tuple[dict[str, str], float]] = {}
 
     # -- Process info helpers -----------------------------------------------
 
@@ -188,6 +192,36 @@ class DetectionService(BaseService):
         for s in ide_sessions:
             s.tab_index = tty_to_index.get(s.tty)
 
+    # -- Per-session JSONL matching ----------------------------------------
+
+    def _get_ai_title_map(self, cwd: str) -> dict[str, str]:
+        """Return {aiTitle: jsonl_path} for all JSONLs in a CWD.
+
+        Multiple Claude sessions can share a CWD; each writes its own JSONL.
+        Matching a session's window title against this map lets us read the
+        JSONL that actually belongs to that session — not just the most-recent
+        one for the project.
+
+        Cached per cwd with _AI_TITLE_CACHE_TTL.
+        """
+        now = time.time()
+        cached = self._ai_title_cache.get(cwd)
+        if cached is not None and now - cached[1] < _AI_TITLE_CACHE_TTL:
+            return cached[0]
+
+        mapping: dict[str, str] = {}
+        for path in self._session_log_service.list_in_cwd(cwd):
+            title = self._session_log_service.read_ai_title(path)
+            if not title:
+                continue
+            # If two JSONLs share an ai-title (rare, e.g. after a session
+            # restart), the more-recently-modified one wins because list_in_cwd
+            # returns mtime-desc and we keep the first writer.
+            mapping.setdefault(title, path)
+
+        self._ai_title_cache[cwd] = (mapping, now)
+        return mapping
+
     # -- JSONL status helpers -----------------------------------------------
 
     def _read_jsonl_tail(self, jsonl_path: str | None) -> tuple[str, float]:
@@ -307,6 +341,7 @@ class DetectionService(BaseService):
         log.debug("detect: found %d claude processes", len(pids))
         if not pids:
             self._host_app_cache.clear()
+            self._ai_title_cache.clear()
             return []
 
         all_ps = self._batch_ps_info(pids)
@@ -318,9 +353,18 @@ class DetectionService(BaseService):
         for stale in list(self._host_app_cache.keys()):
             if stale not in live_pids:
                 del self._host_app_cache[stale]
+        live_cwds = set(cwds.values())
+        for stale_cwd in list(self._ai_title_cache.keys()):
+            if stale_cwd not in live_cwds:
+                del self._ai_title_cache[stale_cwd]
 
-        # Cache JSONL path per CWD — avoids repeated directory scans
-        jsonl_path_cache: dict[str, str | None] = {}
+        # Per-CWD fallback (most-recent JSONL) when ai-title matching can't
+        # disambiguate a session. Built lazily.
+        cwd_fallback_jsonl: dict[str, str | None] = {}
+        # Per-session JSONL path — keyed by PID. With shared-CWD setups the
+        # most-recent file in the project dir often belongs to a sibling
+        # session, so we match on aiTitle from the window title instead.
+        session_jsonl: dict[int, str | None] = {}
 
         sessions = []
         for pid in pids:
@@ -367,8 +411,11 @@ class DetectionService(BaseService):
 
             status = _determine_status(window_title)
 
-            if cwd not in jsonl_path_cache:
-                jsonl_path_cache[cwd] = self._session_log_service.find_most_recent(cwd)
+            if cwd not in cwd_fallback_jsonl:
+                cwd_fallback_jsonl[cwd] = self._session_log_service.find_most_recent(cwd)
+            fallback = cwd_fallback_jsonl[cwd]
+            jpath = _match_jsonl_by_title(window_title, self._get_ai_title_map(cwd), fallback)
+            session_jsonl[pid] = jpath
 
             sessions.append(
                 ClaudeSession(
@@ -380,22 +427,24 @@ class DetectionService(BaseService):
                     window_title=window_title,
                     window_id=window_id,
                     status=status,
-                    session_id=self._get_session_id(cwd, jsonl_path_cache[cwd]),
+                    session_id=self._get_session_id(cwd, jpath),
                 )
             )
 
         self._get_ide_tab_indices(sessions, all_ps)
 
-        # JSONL-based status refinement.
-        # The window title is the real-time signal. If it shows a working indicator
-        # (braille spinner), Claude is actively streaming — trust it over JSONL.
-        # For IDE sessions (no title indicators), JSONL is the only signal.
-        cwd_status_cache: dict[str, tuple[PendingToolResult, SessionStatus]] = {}
+        # JSONL-based status refinement. Each session reads its own JSONL
+        # (matched by aiTitle); two sessions in the same CWD won't share state.
+        # The window title is the real-time signal — if it shows a working
+        # indicator (braille spinner) we trust it over JSONL. For IDE sessions
+        # (no title indicators) JSONL is the only signal.
+        path_status_cache: dict[str, tuple[PendingToolResult, SessionStatus]] = {}
         for s in sessions:
             if not s.cwd:
                 continue
-            if s.cwd not in cwd_status_cache:
-                jpath = jsonl_path_cache.get(s.cwd)
+            jpath = session_jsonl.get(s.pid)
+            cache_key = jpath or ""
+            if cache_key not in path_status_cache:
                 tail, age = self._read_jsonl_tail(jpath)
                 if 0 <= age < _JSONL_STREAMING_THRESHOLD:
                     # JSONL modified < 5s ago — Claude is actively streaming
@@ -411,9 +460,9 @@ class DetectionService(BaseService):
                         jsonl_status = SessionStatus.IDLE
                     else:
                         jsonl_status = self._check_jsonl_for_idle(tail)
-                cwd_status_cache[s.cwd] = (tool_result, jsonl_status)
+                path_status_cache[cache_key] = (tool_result, jsonl_status)
 
-            tool_result, jsonl_status = cwd_status_cache[s.cwd]
+            tool_result, jsonl_status = path_status_cache[cache_key]
             title_confirms_working = _has_working_indicator(s.window_title)
             title_confirms_idle = IDLE_INDICATOR in s.window_title
 
@@ -425,10 +474,8 @@ class DetectionService(BaseService):
                 s.prompt_context = tool_result.context
             elif not tool_result.has_pending and not title_confirms_working and not title_confirms_idle:
                 # Title has no indicator (IDE session or unknown host) — use JSONL status.
-                # Note: JSONL status is shared across all sessions with the same CWD, so
-                # we only apply it when the title gives no signal.
                 s.status = jsonl_status
-            # else: title confirms IDLE or WORKING — trust it over the shared-CWD JSONL
+            # else: title confirms IDLE or WORKING — trust it
 
         return sessions
 
@@ -452,6 +499,29 @@ def _format_tool_use(tool: dict) -> ToolUseInfo:
     if len(one_line) > _TEXT_MAX_LEN:
         one_line = one_line[:77] + "..."
     return ToolUseInfo(one_line=one_line, context="\n".join(context_parts))
+
+
+def _match_jsonl_by_title(
+    window_title: str,
+    ai_title_map: dict[str, str],
+    fallback: str | None,
+) -> str | None:
+    """Find the JSONL whose aiTitle appears as a substring of the window title.
+
+    Used to disambiguate multiple Claude sessions sharing a CWD. Longest match
+    wins so a substring title doesn't shadow a more specific one. Returns
+    `fallback` if nothing matches — which preserves prior behavior for
+    brand-new sessions (no ai-title yet) and IDE sessions (no terminal title).
+    """
+    if not window_title or not ai_title_map:
+        return fallback
+    best_title = ""
+    best_path = fallback
+    for title, path in ai_title_map.items():
+        if title and title in window_title and len(title) > len(best_title):
+            best_title = title
+            best_path = path
+    return best_path
 
 
 def _has_working_indicator(window_title: str) -> bool:

--- a/tests/core/test_jsonl_reader.py
+++ b/tests/core/test_jsonl_reader.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 from claudewatch.backend.core.session_log.jsonl import (
     find_most_recent_jsonl,
     get_session_id_from_path,
+    list_jsonls_in_cwd,
+    read_ai_title,
     read_jsonl_full,
     read_jsonl_tail,
 )
@@ -107,3 +109,71 @@ class TestGetSessionIdFromPath:
 
     def test_handles_bare_filename(self):
         assert get_session_id_from_path("session.jsonl") == "session"
+
+
+class TestListJsonlsInCwd:
+    """Tests for list_jsonls_in_cwd."""
+
+    def test_returns_empty_for_missing_dir(self, tmp_path):
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "nope")):
+            assert list_jsonls_in_cwd("/Users/dev/myapp") == []
+
+    def test_returns_mtime_descending(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        old = proj_dir / "old.jsonl"
+        old.write_text("{}\n")
+        os.utime(old, (1000, 1000))
+        new = proj_dir / "new.jsonl"
+        new.write_text("{}\n")
+        os.utime(new, (2000, 2000))
+
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = list_jsonls_in_cwd("/Users/dev/myapp")
+        assert [os.path.basename(p) for p in result] == ["new.jsonl", "old.jsonl"]
+
+    def test_filters_symlink_traversal(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        evil = outside / "evil.jsonl"
+        evil.write_text("{}\n")
+        (proj_dir / "linked.jsonl").symlink_to(evil)
+        safe = proj_dir / "safe.jsonl"
+        safe.write_text("{}\n")
+
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = list_jsonls_in_cwd("/Users/dev/myapp")
+        assert [os.path.basename(p) for p in result] == ["safe.jsonl"]
+
+
+class TestReadAiTitle:
+    """Tests for read_ai_title."""
+
+    def test_returns_empty_when_no_ai_title(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        f.write_text('{"type": "assistant", "message": {"content": []}}\n')
+        assert read_ai_title(str(f)) == ""
+
+    def test_returns_ai_title(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        f.write_text('{"type": "ai-title", "aiTitle": "Fix detection logic"}\n')
+        assert read_ai_title(str(f)) == "Fix detection logic"
+
+    def test_returns_latest_when_multiple(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        f.write_text(
+            '{"type": "ai-title", "aiTitle": "First title"}\n'
+            '{"type": "assistant", "message": {"content": []}}\n'
+            '{"type": "ai-title", "aiTitle": "Updated title"}\n'
+        )
+        assert read_ai_title(str(f)) == "Updated title"
+
+    def test_returns_empty_for_missing_file(self):
+        assert read_ai_title("/nonexistent/x.jsonl") == ""
+
+    def test_skips_malformed_json(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        f.write_text('not-json-at-all\n{"type": "ai-title", "aiTitle": "Valid title"}\n')
+        assert read_ai_title(str(f)) == "Valid title"

--- a/tests/core/test_session_log_service.py
+++ b/tests/core/test_session_log_service.py
@@ -80,6 +80,29 @@ class TestReadFull:
         assert result == []
 
 
+class TestListInCwd:
+    """Tests for SessionLogService.list_in_cwd."""
+
+    def test_delegates_to_list_jsonls_in_cwd(self):
+        svc = SessionLogService()
+        paths = ["/proj/-Users-dev/a.jsonl", "/proj/-Users-dev/b.jsonl"]
+        with patch(f"{MODULE}.list_jsonls_in_cwd", return_value=paths) as mock:
+            result = svc.list_in_cwd("/Users/dev/myapp")
+        mock.assert_called_once_with("/Users/dev/myapp")
+        assert result == paths
+
+
+class TestReadAiTitle:
+    """Tests for SessionLogService.read_ai_title."""
+
+    def test_delegates_to_read_ai_title(self):
+        svc = SessionLogService()
+        with patch(f"{MODULE}.read_ai_title", return_value="Review PR #42") as mock:
+            result = svc.read_ai_title("/path/to/x.jsonl")
+        mock.assert_called_once_with("/path/to/x.jsonl")
+        assert result == "Review PR #42"
+
+
 class TestGetSessionId:
     """Tests for SessionLogService.get_session_id."""
 

--- a/tests/detection/test_attention_status.py
+++ b/tests/detection/test_attention_status.py
@@ -12,7 +12,7 @@ import os
 import time
 
 from claudewatch.backend.core.models import SessionStatus
-from claudewatch.backend.detection.service import DetectionService
+from claudewatch.backend.detection.service import DetectionService, _match_jsonl_by_title
 
 _STALE_AGE = 10  # seconds — old enough that the pending check runs
 
@@ -302,3 +302,41 @@ class TestStatusPriority:
         tail = _read_tail(jsonl_path)
         status = service._check_jsonl_for_idle(tail)
         assert status == SessionStatus.IDLE
+
+
+class TestMatchJsonlByTitle:
+    """Tests for _match_jsonl_by_title — picks the right JSONL in shared-CWD setups."""
+
+    def test_substring_match_returns_path(self):
+        mapping = {"Review backend API pull request #593": "/proj/a.jsonl"}
+        title = "360privacy — ✳ Review backend API pull request #593 — node ◂ claude — 177×47"
+        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == "/proj/a.jsonl"
+
+    def test_longest_match_wins(self):
+        mapping = {
+            "Review PR": "/proj/short.jsonl",
+            "Review PR #593 backend": "/proj/long.jsonl",
+        }
+        title = "myapp — ✳ Review PR #593 backend — node ◂ claude — 80×24"
+        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == "/proj/long.jsonl"
+
+    def test_no_match_returns_fallback(self):
+        mapping = {"Some other title": "/proj/other.jsonl"}
+        title = "myapp — ✳ Brand new session — claude"
+        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == "/fallback.jsonl"
+
+    def test_empty_map_returns_fallback(self):
+        assert _match_jsonl_by_title("any title", {}, "/fallback.jsonl") == "/fallback.jsonl"
+
+    def test_empty_title_returns_fallback(self):
+        mapping = {"Some title": "/proj/a.jsonl"}
+        assert _match_jsonl_by_title("", mapping, "/fallback.jsonl") == "/fallback.jsonl"
+
+    def test_empty_title_value_skipped(self):
+        # An empty aiTitle would substring-match every title — must be ignored.
+        mapping = {"": "/proj/empty.jsonl", "Real title": "/proj/real.jsonl"}
+        title = "myapp — ✳ Real title — claude"
+        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == "/proj/real.jsonl"
+
+    def test_returns_fallback_when_fallback_is_none(self):
+        assert _match_jsonl_by_title("x", {}, None) is None

--- a/tests/detection/test_detect_integration.py
+++ b/tests/detection/test_detect_integration.py
@@ -319,6 +319,106 @@ class TestDetectPendingTool:
                 p.stop()
 
 
+class TestDetectSharedCwdAttention:
+    """Regression: shared-CWD ATTENTION must use each session's own JSONL.
+
+    Bug: find_most_recent(cwd) returns the most recently modified JSONL in the
+    project dir. When sibling sessions are actively streaming, the idle session
+    waiting for tool approval reads the wrong file and never reaches ATTENTION.
+    Fix matches each session to its own JSONL via the aiTitle in the window title.
+    """
+
+    def test_idle_session_with_pending_tool_gets_attention(self, tmp_path):
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+
+        # Session A: actively streaming, fresh JSONL. Looks like the most-recent.
+        _write_jsonl(
+            os.path.join(proj_dir, "active.jsonl"),
+            [
+                {"type": "ai-title", "aiTitle": "Refactor billing module"},
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}},
+            ],
+        )
+        # Session B: idle, JSONL has unresolved tool_use, older mtime.
+        _write_jsonl(
+            os.path.join(proj_dir, "pending.jsonl"),
+            [
+                {"type": "ai-title", "aiTitle": "Review backend API PR 593"},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "tool_use", "name": "Write", "input": {"file_path": "/x/ONBOARDING.md"}}]
+                    },
+                },
+            ],
+            age_seconds=30,
+        )
+        # Session C: idle, no pending tool, oldest mtime.
+        _write_jsonl(
+            os.path.join(proj_dir, "old.jsonl"),
+            [
+                {"type": "ai-title", "aiTitle": "Diagnose API 422"},
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": "done"}]}},
+            ],
+            age_seconds=300,
+        )
+
+        svc = _build_service(
+            str(tmp_path),
+            [100, 200, 300],
+            pid_info={
+                100: ProcessInfo(tty="ttys001", ppid=1, comm="claude"),
+                200: ProcessInfo(tty="ttys002", ppid=1, comm="claude"),
+                300: ProcessInfo(tty="ttys003", ppid=1, comm="claude"),
+            },
+            pid_cwds={100: cwd, 200: cwd, 300: cwd},
+            terminal_titles={
+                "/dev/ttys001": ("myapp — ⠂ Refactor billing module — node ◂ claude", 1),
+                "/dev/ttys002": ("myapp — ✳ Review backend API PR 593 — node ◂ claude", 2),
+                "/dev/ttys003": ("myapp — ✳ Diagnose API 422 — node ◂ claude", 3),
+            },
+        )
+        try:
+            sessions = svc.detect()
+            by_pid = {s.pid: s for s in sessions}
+            assert by_pid[100].status == SessionStatus.WORKING
+            assert by_pid[200].status == SessionStatus.ATTENTION
+            assert "Write" in by_pid[200].prompt_text
+            assert by_pid[300].status == SessionStatus.IDLE
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
+    def test_brand_new_session_no_ai_title_falls_back(self, tmp_path):
+        """Session with no aiTitle in window title falls back to most-recent JSONL."""
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+        _write_jsonl(
+            os.path.join(proj_dir, "s1.jsonl"),
+            [
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}]},
+                },
+            ],
+            age_seconds=30,
+        )
+        svc = _build_service(
+            str(tmp_path),
+            [100],
+            pid_info={100: ProcessInfo(tty="ttys001", ppid=1, comm="claude")},
+            pid_cwds={100: cwd},
+            terminal_titles={"/dev/ttys001": ("myapp — ✳ claude", 1)},
+        )
+        try:
+            sessions = svc.detect()
+            assert sessions[0].status == SessionStatus.ATTENTION
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
+
 class TestDetectIdeSession:
     """IDE sessions have no title indicator — JSONL is the only signal."""
 


### PR DESCRIPTION
`find_most_recent(cwd)` returns a single JSONL for the whole project dir. With multiple Claude sessions in the same CWD, the idle session waiting for tool approval ends up reading the active sibling's JSONL — which has no pending `tool_use` — and never reaches ATTENTION.

Each session writes an `ai-title` entry to its own JSONL and that title appears in its terminal window title. Match on substring (longest wins) to pick the right JSONL per session, with most-recent as fallback for brand-new sessions that don't have an aiTitle yet.

Also drops the long-dead `PROMPT_KEYWORDS` list left over from when buffer scanning was a thing.