### PR TITLE
fix: readable model labels and disambiguate duplicates in Sessions pane

### DIFF
--- a/claudewatch/backend/usage/service.py
+++ b/claudewatch/backend/usage/service.py
@@ -9,13 +9,14 @@ from claudewatch.backend.core.dto import TokenUsageDTO
 from claudewatch.backend.core.service import BaseService
 from claudewatch.backend.core.session_log.service import SessionLogService
 
-# Model display names — keep factual
+# Model display names — keep factual. Use readable family + version so rows
+# show "opus 4.6" rather than the ambiguous "o4.6" which reads as a typo.
 MODEL_DISPLAY_NAMES: dict[str, str] = {
-    "claude-opus-4-6": "o4.6",
-    "claude-sonnet-4-6": "s4.6",
-    "claude-haiku-4-5": "h4.5",
-    "claude-sonnet-4-5-20250514": "s4.5",
-    "claude-opus-4-20250512": "o4",
+    "claude-opus-4-6": "opus 4.6",
+    "claude-sonnet-4-6": "sonnet 4.6",
+    "claude-haiku-4-5": "haiku 4.5",
+    "claude-sonnet-4-5-20250514": "sonnet 4.5",
+    "claude-opus-4-20250512": "opus 4",
 }
 
 _MAX_TOKEN_CACHE = 200

--- a/claudewatch/ui/preferences/panes/sessions.py
+++ b/claudewatch/ui/preferences/panes/sessions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime, timedelta
 
 import objc
@@ -168,14 +169,74 @@ def rebuild_rows(delegate: object) -> None:
         empty_label.setFrame_(NSMakeRect(0, total_h // 2, w, 18))
         inner.addSubview_(empty_label)
     else:
+        project_labels = disambiguate_projects(entries)
         y = total_h
         for entry in entries:
             y -= _ROW_H
-            _add_row(inner, delegate, entry, 0, y, w, _ROW_H, pinned_cwds, usage_svc, summary_svc)
+            display_project = project_labels.get(entry.get("cwd", ""), entry.get("project", "unknown"))
+            _add_row(
+                inner,
+                delegate,
+                entry,
+                0,
+                y,
+                w,
+                _ROW_H,
+                pinned_cwds,
+                usage_svc,
+                summary_svc,
+                display_project,
+            )
 
     scroll.setDocumentView_(inner)
     inner.scrollPoint_((0, total_h))  # scroll to top (newest first)
     delegate._history_inner = inner
+
+
+def disambiguate_projects(entries: list[dict]) -> dict[str, str]:
+    """Build a cwd -> display-name map that disambiguates duplicate basenames.
+
+    When two history entries share the same ``project`` basename (e.g. multiple
+    repos with an ``api`` subdirectory), prepend the parent directory so each
+    row carries enough context to be identifiable. Unique basenames are kept
+    as-is.
+    """
+    by_name: dict[str, list[str]] = {}
+    for entry in entries:
+        name = entry.get("project", "")
+        cwd = entry.get("cwd", "")
+        if not cwd:
+            continue
+        by_name.setdefault(name, []).append(cwd)
+
+    labels: dict[str, str] = {}
+    for name, cwds in by_name.items():
+        if len(cwds) <= 1:
+            for cwd in cwds:
+                labels[cwd] = name or "unknown"
+            continue
+        for cwd in cwds:
+            parent = os.path.basename(os.path.dirname(cwd))
+            labels[cwd] = f"{parent}/{name}" if parent else (name or "unknown")
+    return labels
+
+
+def _resolve_model_label(model_raw: str, cwd: str, usage_svc: object) -> str:
+    """Map a raw model id to its display name, falling back to live JSONL lookup.
+
+    History rows occasionally have an empty ``model`` field — sessions seeded
+    before any assistant message was written, or older entries missing the
+    field. When that happens, ask the usage service for the latest model
+    recorded on disk so the row still shows something useful.
+    """
+    if model_raw:
+        return MODEL_DISPLAY_NAMES.get(model_raw, model_raw)
+    if not cwd:
+        return ""
+    try:
+        return usage_svc.get_model(cwd)  # type: ignore[attr-defined]
+    except (OSError, AttributeError):
+        return ""
 
 
 def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001
@@ -189,32 +250,34 @@ def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001
     pinned_cwds: set[str],
     usage_svc: object,
     summary_svc: object,
+    display_project: str = "",
 ) -> None:
     """Build a single history row using the SessionRow composite."""
 
-    project = entry.get("project", "unknown")
+    raw_project = entry.get("project", "unknown")
+    project = display_project or raw_project
     cwd = entry.get("cwd", "")
     session_id = entry.get("session_id", "")
     model_raw = entry.get("model", "")
-    model = MODEL_DISPLAY_NAMES.get(model_raw, model_raw)
+    model = _resolve_model_label(model_raw, cwd, usage_svc)
     ended_at = entry.get("ended_at", "")
     is_pinned = cwd in pinned_cwds
 
-    # Build context menu
-    row_menu = _build_row_menu(delegate, entry, is_pinned, cwd, session_id, project, summary_svc)
+    # Build context menu — use raw project as the stable identity for action payloads.
+    row_menu = _build_row_menu(delegate, entry, is_pinned, cwd, session_id, raw_project, summary_svc)
 
     # Gather display data
     token_data = usage_svc.get_tokens(cwd)
     token_compact = format_tokens_compact(token_data)
     cached_title = summary_svc.get_cached(cwd) if cwd else ""
 
-    # Bookmark callback wiring
+    # Bookmark callback wiring — payload carries the raw project as identity.
     if is_pinned:
         bookmark_action = objc.selector(delegate.unbookmarkSession_, signature=b"v@:@")
         bookmark_rep = cwd
     else:
         bookmark_action = objc.selector(delegate.bookmarkSession_, signature=b"v@:@")
-        bookmark_rep = f"{session_id}|{project}|{cwd}"
+        bookmark_rep = f"{session_id}|{raw_project}|{cwd}"
 
     row = build_session_row(
         project=project,

--- a/tests/ui/test_panes.py
+++ b/tests/ui/test_panes.py
@@ -181,3 +181,124 @@ class TestSessionsPane:
         pane = SessionsPane(_make_delegate(), 490, 620)
         view = pane.build()
         assert isinstance(view, NSView)
+
+    @patch("claudewatch.ui.preferences.panes.sessions.get_usage_service")
+    @patch("claudewatch.ui.preferences.panes.sessions.get_summary_service")
+    @patch("claudewatch.ui.preferences.panes.sessions.get_bookmark_service")
+    @patch("claudewatch.ui.preferences.panes.sessions.get_history_service")
+    def test_renders_with_duplicate_project_names(
+        self,
+        mock_history: MagicMock,
+        mock_bookmark: MagicMock,
+        mock_summary: MagicMock,
+        mock_usage: MagicMock,
+    ) -> None:
+        from claudewatch.backend.core.dto import HistoryEntryDTO, TokenUsageDTO
+        from claudewatch.ui.preferences.panes.sessions import SessionsPane
+
+        mock_history.return_value.get_all.return_value = [
+            HistoryEntryDTO(
+                session_id="s1",
+                project="api",
+                cwd="/Users/dev/backend/api",
+                model="claude-opus-4-6",
+                host_app="Terminal",
+                ended_at="2026-05-20T12:00:00",
+            ),
+            HistoryEntryDTO(
+                session_id="s2",
+                project="api",
+                cwd="/Users/dev/frontend/api",
+                model="",
+                host_app="Terminal",
+                ended_at="2026-05-20T13:00:00",
+            ),
+        ]
+        mock_bookmark.return_value.get_bookmarked_cwds.return_value = set()
+        mock_summary.return_value.get_cached.return_value = ""
+        mock_summary.return_value.get_cached_summary.return_value = ""
+        mock_usage.return_value.get_tokens.return_value = TokenUsageDTO(0, 0, 0, 0)
+        mock_usage.return_value.get_model.return_value = "sonnet 4.6"
+
+        pane = SessionsPane(_make_delegate(), 490, 620)
+        view = pane.build()
+        assert isinstance(view, NSView)
+
+
+class TestDisambiguateProjects:
+    def test_unique_names_kept_as_is(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import disambiguate_projects
+
+        entries = [
+            {"project": "myapp", "cwd": "/Users/dev/myapp"},
+            {"project": "tools", "cwd": "/Users/dev/tools"},
+        ]
+        labels = disambiguate_projects(entries)
+        assert labels["/Users/dev/myapp"] == "myapp"
+        assert labels["/Users/dev/tools"] == "tools"
+
+    def test_duplicate_names_prepend_parent(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import disambiguate_projects
+
+        entries = [
+            {"project": "api", "cwd": "/Users/dev/backend/api"},
+            {"project": "api", "cwd": "/Users/dev/frontend/api"},
+            {"project": "webtools", "cwd": "/Users/dev/webtools"},
+        ]
+        labels = disambiguate_projects(entries)
+        assert labels["/Users/dev/backend/api"] == "backend/api"
+        assert labels["/Users/dev/frontend/api"] == "frontend/api"
+        assert labels["/Users/dev/webtools"] == "webtools"
+
+    def test_missing_cwd_is_skipped(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import disambiguate_projects
+
+        entries = [
+            {"project": "api", "cwd": ""},
+            {"project": "api", "cwd": "/Users/dev/api"},
+        ]
+        labels = disambiguate_projects(entries)
+        assert labels == {"/Users/dev/api": "api"}
+
+    def test_empty_input(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import disambiguate_projects
+
+        assert disambiguate_projects([]) == {}
+
+
+class TestResolveModelLabel:
+    def test_known_model_id_maps_to_display_name(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import _resolve_model_label
+
+        svc = MagicMock()
+        assert _resolve_model_label("claude-opus-4-6", "/tmp/proj", svc) == "opus 4.6"
+        svc.get_model.assert_not_called()
+
+    def test_unknown_model_id_falls_through(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import _resolve_model_label
+
+        svc = MagicMock()
+        assert _resolve_model_label("claude-future-99", "/tmp/proj", svc) == "claude-future-99"
+        svc.get_model.assert_not_called()
+
+    def test_empty_model_falls_back_to_usage_service(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import _resolve_model_label
+
+        svc = MagicMock()
+        svc.get_model.return_value = "sonnet 4.6"
+        assert _resolve_model_label("", "/tmp/proj", svc) == "sonnet 4.6"
+        svc.get_model.assert_called_once_with("/tmp/proj")
+
+    def test_empty_model_and_no_cwd_returns_empty(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import _resolve_model_label
+
+        svc = MagicMock()
+        assert _resolve_model_label("", "", svc) == ""
+        svc.get_model.assert_not_called()
+
+    def test_usage_service_failure_returns_empty(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import _resolve_model_label
+
+        svc = MagicMock()
+        svc.get_model.side_effect = OSError("disk error")
+        assert _resolve_model_label("", "/tmp/proj", svc) == ""

--- a/tests/usage/test_usage.py
+++ b/tests/usage/test_usage.py
@@ -23,9 +23,16 @@ class TestModelDisplayNames:
     """MODEL_DISPLAY_NAMES mapping tests."""
 
     def test_known_models_have_display_names(self):
-        assert MODEL_DISPLAY_NAMES["claude-opus-4-6"] == "o4.6"
-        assert MODEL_DISPLAY_NAMES["claude-sonnet-4-6"] == "s4.6"
-        assert MODEL_DISPLAY_NAMES["claude-haiku-4-5"] == "h4.5"
+        assert MODEL_DISPLAY_NAMES["claude-opus-4-6"] == "opus 4.6"
+        assert MODEL_DISPLAY_NAMES["claude-sonnet-4-6"] == "sonnet 4.6"
+        assert MODEL_DISPLAY_NAMES["claude-haiku-4-5"] == "haiku 4.5"
+
+    def test_display_names_are_human_readable(self):
+        # Each display name should start with a real word, not a single letter.
+        # This guards against regressing to cryptic forms like "o4.6".
+        for display in MODEL_DISPLAY_NAMES.values():
+            family = display.split()[0]
+            assert len(family) > 1, f"display name {display!r} starts with a single letter"
 
 
 class TestUsageServiceGetModel:
@@ -42,7 +49,7 @@ class TestUsageServiceGetModel:
     def test_returns_display_name_for_known_model(self):
         tail = json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}}) + "\n"
         svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
-        assert svc.get_model("/Users/dev/myapp") == "o4.6"
+        assert svc.get_model("/Users/dev/myapp") == "opus 4.6"
 
     def test_returns_raw_model_for_unknown(self):
         tail = json.dumps({"type": "assistant", "message": {"model": "claude-future-99"}}) + "\n"
@@ -57,12 +64,12 @@ class TestUsageServiceGetModel:
             + "\n"
         )
         svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
-        assert svc.get_model("/Users/dev/myapp") == "o4.6"
+        assert svc.get_model("/Users/dev/myapp") == "opus 4.6"
 
     def test_handles_invalid_json_lines(self):
         tail = "not json\n" + json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}}) + "\n"
         svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
-        assert svc.get_model("/Users/dev/myapp") == "o4.6"
+        assert svc.get_model("/Users/dev/myapp") == "opus 4.6"
 
     def test_handles_non_dict_message(self):
         tail = json.dumps({"type": "assistant", "message": "string"}) + "\n"


### PR DESCRIPTION
Three rendering bugs in the Sessions preferences pane:

- Model labels rendered as `o4.6` / `s4.6` / `h4.5` — readable as truncations. Now `opus 4.6` / `sonnet 4.6` / `haiku 4.5`.
- Rows whose history entry had an empty `model` field showed nothing for the model badge. Now falls back to `UsageService.get_model(cwd)` which reads the latest assistant message off the JSONL.
- Multiple bookmarks ending in the same basename (e.g. `backend/api` and `frontend/api`) collapsed to identical "api" rows. Now prepends the parent dir only when basenames collide; unique names stay bare.