### PR TITLE
test: sanitize detection fixtures, drop real project/session strings

### DIFF
--- a/tests/detection/test_attention_status.py
+++ b/tests/detection/test_attention_status.py
@@ -308,8 +308,8 @@ class TestMatchJsonlByTitle:
     """Tests for _match_jsonl_by_title — picks the right JSONL in shared-CWD setups."""
 
     def test_substring_match_returns_path(self):
-        mapping = {"Review backend API pull request #593": "/proj/a.jsonl"}
-        title = "360privacy — ✳ Review backend API pull request #593 — node ◂ claude — 177×47"
+        mapping = {"Wire up search filter": "/proj/a.jsonl"}
+        title = "myapp — ✳ Wire up search filter — node ◂ claude — 177×47"
         assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == "/proj/a.jsonl"
 
     def test_longest_match_wins(self):

--- a/tests/detection/test_detect_integration.py
+++ b/tests/detection/test_detect_integration.py
@@ -336,7 +336,7 @@ class TestDetectSharedCwdAttention:
         _write_jsonl(
             os.path.join(proj_dir, "active.jsonl"),
             [
-                {"type": "ai-title", "aiTitle": "Refactor billing module"},
+                {"type": "ai-title", "aiTitle": "Wire up search filter"},
                 {"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}},
             ],
         )
@@ -344,11 +344,11 @@ class TestDetectSharedCwdAttention:
         _write_jsonl(
             os.path.join(proj_dir, "pending.jsonl"),
             [
-                {"type": "ai-title", "aiTitle": "Review backend API PR 593"},
+                {"type": "ai-title", "aiTitle": "Investigate stale cache"},
                 {
                     "type": "assistant",
                     "message": {
-                        "content": [{"type": "tool_use", "name": "Write", "input": {"file_path": "/x/ONBOARDING.md"}}]
+                        "content": [{"type": "tool_use", "name": "Write", "input": {"file_path": "/x/README.md"}}]
                     },
                 },
             ],
@@ -358,7 +358,7 @@ class TestDetectSharedCwdAttention:
         _write_jsonl(
             os.path.join(proj_dir, "old.jsonl"),
             [
-                {"type": "ai-title", "aiTitle": "Diagnose API 422"},
+                {"type": "ai-title", "aiTitle": "Tidy log formatting"},
                 {"type": "assistant", "message": {"content": [{"type": "text", "text": "done"}]}},
             ],
             age_seconds=300,
@@ -374,9 +374,9 @@ class TestDetectSharedCwdAttention:
             },
             pid_cwds={100: cwd, 200: cwd, 300: cwd},
             terminal_titles={
-                "/dev/ttys001": ("myapp — ⠂ Refactor billing module — node ◂ claude", 1),
-                "/dev/ttys002": ("myapp — ✳ Review backend API PR 593 — node ◂ claude", 2),
-                "/dev/ttys003": ("myapp — ✳ Diagnose API 422 — node ◂ claude", 3),
+                "/dev/ttys001": ("myapp — ⠂ Wire up search filter — node ◂ claude", 1),
+                "/dev/ttys002": ("myapp — ✳ Investigate stale cache — node ◂ claude", 2),
+                "/dev/ttys003": ("myapp — ✳ Tidy log formatting — node ◂ claude", 3),
             },
         )
         try:


### PR DESCRIPTION
Test fixtures introduced in #208 included real project basenames and session titles. Swapped for generic placeholders. No behavior change.