### PR TITLE
fix: clean up stale model names in Recent and Sessions views

### DIFF
--- a/claudewatch/backend/history/repository.py
+++ b/claudewatch/backend/history/repository.py
@@ -20,6 +20,23 @@ _MAX_ENTRIES = 50
 # Serializes read-modify-write of the history JSON file across threads.
 _LOCK = threading.Lock()
 
+# Stale model values from earlier versions that stored display names directly,
+# or from JSONL placeholders. Mapped back to a raw model id (or "" when no
+# canonical id exists) so the display layer renders one consistent format.
+_STALE_MODEL_MAP: dict[str, str] = {
+    "o4.6": "claude-opus-4-6",
+    "opus 4.6": "claude-opus-4-6",
+    "s4.6": "claude-sonnet-4-6",
+    "sonnet 4.6": "claude-sonnet-4-6",
+    "h4.5": "claude-haiku-4-5",
+    "haiku 4.5": "claude-haiku-4-5",
+    "s4.5": "claude-sonnet-4-5-20250514",
+    "sonnet 4.5": "claude-sonnet-4-5-20250514",
+    "o4": "claude-opus-4-20250512",
+    "opus 4": "claude-opus-4-20250512",
+    "<synthetic>": "",
+}
+
 
 class _HistoryRecord(TypedDict):
     session_id: str
@@ -30,6 +47,11 @@ class _HistoryRecord(TypedDict):
     ended_at: str
 
 
+def _normalize_model(value: str) -> str:
+    """Translate stale display-name or placeholder values back to raw ids."""
+    return _STALE_MODEL_MAP.get(value, value)
+
+
 def _load() -> list[_HistoryRecord]:
     try:
         with open(_PATH) as f:
@@ -38,8 +60,17 @@ def _load() -> list[_HistoryRecord]:
                 return []
     except (OSError, json.JSONDecodeError):
         return []
+    mutated = False
     if len(data) > _MAX_ENTRIES:
         data = data[-_MAX_ENTRIES:]
+        mutated = True
+    for entry in data:
+        original = entry.get("model", "")
+        normalized = _normalize_model(original)
+        if normalized != original:
+            entry["model"] = normalized
+            mutated = True
+    if mutated:
         _save(data)
     return data
 
@@ -74,10 +105,15 @@ def record_session(session_id: str, project: str, cwd: str, model: str, host_app
 
 
 def get_history() -> list[HistoryEntryDTO]:
-    """Return session history, newest first. Seeds from JSONL on first call."""
+    """Return session history, newest first. Seeds from JSONL on first call.
+
+    Only seeds when the history file does not yet exist on disk. Once the file
+    exists, an empty list is treated as "user cleared their history" and is
+    left empty — otherwise deleted entries would reappear from ~/.claude/.
+    """
     with _LOCK:
         entries = _load()
-        if not entries:
+        if not entries and not os.path.exists(_PATH):
             entries = _seed_from_jsonl()
     return [
         HistoryEntryDTO(
@@ -119,7 +155,7 @@ def _seed_from_jsonl() -> list[_HistoryRecord]:
                 try:
                     d = json.loads(line)
                     m = d.get("message", {}).get("model", "")
-                    if m:
+                    if m and m != "<synthetic>":
                         model = m
                 except (json.JSONDecodeError, AttributeError):
                     pass

--- a/claudewatch/backend/usage/service.py
+++ b/claudewatch/backend/usage/service.py
@@ -4,20 +4,40 @@ from __future__ import annotations
 
 import json
 import os
+import re
 
 from claudewatch.backend.core.dto import TokenUsageDTO
 from claudewatch.backend.core.service import BaseService
 from claudewatch.backend.core.session_log.service import SessionLogService
 
-# Model display names — keep factual. Use readable family + version so rows
-# show "opus 4.6" rather than the ambiguous "o4.6" which reads as a typo.
-MODEL_DISPLAY_NAMES: dict[str, str] = {
-    "claude-opus-4-6": "opus 4.6",
-    "claude-sonnet-4-6": "sonnet 4.6",
-    "claude-haiku-4-5": "haiku 4.5",
-    "claude-sonnet-4-5-20250514": "sonnet 4.5",
-    "claude-opus-4-20250512": "opus 4",
-}
+# Parses a raw Claude model id into family + major[.minor]. Trailing 8+ digit
+# release dates are ignored so 'claude-haiku-4-5-20251001' collapses to the
+# same label as 'claude-haiku-4-5'. The minor segment is capped at six digits
+# so it never swallows a date suffix that follows a model with no minor
+# component (e.g. 'claude-opus-4-20250512' → family 4, no minor, date dropped).
+_MODEL_RE = re.compile(r"^claude-(opus|sonnet|haiku)-(\d+)(?:-(\d{1,6}))?(?:-\d{8,})?$")
+
+
+def model_display_name(raw_id: str) -> str:
+    """Render a Claude model id as a short human label.
+
+    Examples:
+        'claude-opus-4-7'            -> 'opus 4.7'
+        'claude-haiku-4-5-20251001'  -> 'haiku 4.5'
+        'claude-opus-4-20250512'     -> 'opus 4'
+
+    Any id that doesn't match the expected pattern is returned unchanged —
+    callers display the raw value as a last-resort fallback rather than
+    inventing a label.
+    """
+    if not raw_id:
+        return raw_id
+    match = _MODEL_RE.match(raw_id)
+    if not match:
+        return raw_id
+    family, major, minor = match.group(1), match.group(2), match.group(3)
+    return f"{family} {major}.{minor}" if minor else f"{family} {major}"
+
 
 _MAX_TOKEN_CACHE = 200
 
@@ -79,10 +99,12 @@ class UsageService(BaseService):
         self._token_cache: dict[str, tuple[TokenUsageDTO, float]] = {}
 
     def get_model(self, cwd: str) -> str:
-        """Get the model name for the most recent session at a CWD.
+        """Get the raw model id for the most recent session at a CWD.
 
         Reads the last assistant message from the JSONL to find the model.
-        Returns a display name like 'opus 4.6' or empty string if unavailable.
+        Returns the raw id (e.g. 'claude-opus-4-6') so callers store a stable
+        identifier; display name mapping via model_display_name is done at
+        render time. Returns empty string if unavailable or synthetic.
         """
         path = self._session_log_service.find_most_recent(cwd)
         if not path:
@@ -99,12 +121,12 @@ class UsageService(BaseService):
                 msg = d.get("message", {})
                 if isinstance(msg, dict):
                     model = msg.get("model", "")
-                    if model:
+                    if model and model != "<synthetic>":
                         last_model = model
             except (json.JSONDecodeError, AttributeError):
                 continue
 
-        return MODEL_DISPLAY_NAMES.get(last_model, last_model)
+        return last_model
 
     def get_tokens(self, cwd: str) -> TokenUsageDTO:
         """Get token usage breakdown for the most recent session at a CWD.

--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -17,7 +17,7 @@ from claudewatch.backend.core import features
 from claudewatch.backend.core.features import FeatureKey
 from claudewatch.backend.core.models import ClaudeSession, SessionStatus
 from claudewatch.backend.core.paths import is_homebrew_install
-from claudewatch.backend.usage.service import MODEL_DISPLAY_NAMES, format_tokens_breakdown
+from claudewatch.backend.usage.service import format_tokens_breakdown, model_display_name
 from claudewatch.ui.icons import (
     get_app_icon,
     get_status_colors,
@@ -235,7 +235,7 @@ class MenuBuilder:
             recent_menu_item.setImage_(sf_icon("clock.arrow.circlepath"))
             recent_submenu = NSMenu.alloc().init()
             for entry in recent_entries:
-                model = MODEL_DISPLAY_NAMES.get(entry.model, entry.model)
+                model = model_display_name(entry.model)
 
                 detail_parts = [p for p in [entry.ended_at[:10] if entry.ended_at else "", model] if p]
                 label = entry.project

--- a/claudewatch/ui/preferences/panes/insights.py
+++ b/claudewatch/ui/preferences/panes/insights.py
@@ -9,7 +9,7 @@ from AppKit import NSScrollView, NSView
 from Foundation import NSMakeRect
 
 from claudewatch.backend.analytics.dependencies import get_analytics_service
-from claudewatch.backend.usage.service import MODEL_DISPLAY_NAMES
+from claudewatch.backend.usage.service import model_display_name
 from claudewatch.ui.components.tokens import Font, Spacing
 from claudewatch.ui.components.widgets.cards import card
 from claudewatch.ui.components.widgets.labels import label, secondary_label
@@ -130,7 +130,7 @@ class InsightsPane(BasePane):
             my = models_h - _card_pad
             for model_entry in models:
                 my -= _row_h
-                display = MODEL_DISPLAY_NAMES.get(model_entry.name, model_entry.name)
+                display = model_display_name(model_entry.name)
                 model_label = label(display, size=Font.SECONDARY)
                 model_label.setFrame_(NSMakeRect(_card_pad, my, 200, 18))
                 models_content.addSubview_(model_label)

--- a/claudewatch/ui/preferences/panes/sessions.py
+++ b/claudewatch/ui/preferences/panes/sessions.py
@@ -26,7 +26,7 @@ from claudewatch.backend.bookmark.dependencies import get_bookmark_service
 from claudewatch.backend.history.dependencies import get_history_service
 from claudewatch.backend.summary.dependencies import get_summary_service
 from claudewatch.backend.usage.dependencies import get_usage_service
-from claudewatch.backend.usage.service import MODEL_DISPLAY_NAMES, format_tokens_compact
+from claudewatch.backend.usage.service import format_tokens_compact, model_display_name
 from claudewatch.ui.components.composites.session_row import build_session_row
 from claudewatch.ui.components.tokens import Font, Spacing
 from claudewatch.ui.components.widgets.labels import secondary_label
@@ -230,13 +230,14 @@ def _resolve_model_label(model_raw: str, cwd: str, usage_svc: object) -> str:
     recorded on disk so the row still shows something useful.
     """
     if model_raw:
-        return MODEL_DISPLAY_NAMES.get(model_raw, model_raw)
+        return model_display_name(model_raw)
     if not cwd:
         return ""
     try:
-        return usage_svc.get_model(cwd)  # type: ignore[attr-defined]
+        fallback = usage_svc.get_model(cwd)  # type: ignore[attr-defined]
     except (OSError, AttributeError):
         return ""
+    return model_display_name(fallback)
 
 
 def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001

--- a/tests/history/test_history.py
+++ b/tests/history/test_history.py
@@ -13,14 +13,14 @@ class TestRecordSession:
     def test_records_new_session(self, tmp_path):
         fake_path = str(tmp_path / "history.json")
         with patch.object(history, "_PATH", fake_path):
-            history.record_session("sess-1", "myproject", "/tmp/myproject", "o4.6", "Terminal")
+            history.record_session("sess-1", "myproject", "/tmp/myproject", "claude-opus-4-6", "Terminal")
             entries = history._load()
 
         assert len(entries) == 1
         assert entries[0]["session_id"] == "sess-1"
         assert entries[0]["project"] == "myproject"
         assert entries[0]["cwd"] == "/tmp/myproject"
-        assert entries[0]["model"] == "o4.6"
+        assert entries[0]["model"] == "claude-opus-4-6"
         assert entries[0]["host_app"] == "Terminal"
         assert "ended_at" in entries[0]
 
@@ -247,3 +247,142 @@ class TestLoadEdgeCases:
             result = history._load()
 
         assert len(result) == 50
+
+
+class TestModelNormalization:
+    """_load migrates stale display-name model values back to raw ids."""
+
+    def test_old_short_display_name_normalized(self, tmp_path):
+        fake_path = str(tmp_path / "history.json")
+        with open(fake_path, "w") as f:
+            json.dump([{"cwd": "/a", "session_id": "s1", "model": "o4.6"}], f)
+
+        with patch.object(history, "_PATH", fake_path):
+            result = history._load()
+
+        assert result[0]["model"] == "claude-opus-4-6"
+
+    def test_new_long_display_name_normalized(self, tmp_path):
+        fake_path = str(tmp_path / "history.json")
+        with open(fake_path, "w") as f:
+            json.dump([{"cwd": "/a", "session_id": "s1", "model": "opus 4.6"}], f)
+
+        with patch.object(history, "_PATH", fake_path):
+            result = history._load()
+
+        assert result[0]["model"] == "claude-opus-4-6"
+
+    def test_synthetic_placeholder_cleared(self, tmp_path):
+        fake_path = str(tmp_path / "history.json")
+        with open(fake_path, "w") as f:
+            json.dump([{"cwd": "/a", "session_id": "s1", "model": "<synthetic>"}], f)
+
+        with patch.object(history, "_PATH", fake_path):
+            result = history._load()
+
+        assert result[0]["model"] == ""
+
+    def test_raw_id_untouched(self, tmp_path):
+        fake_path = str(tmp_path / "history.json")
+        with open(fake_path, "w") as f:
+            json.dump([{"cwd": "/a", "session_id": "s1", "model": "claude-opus-4-7"}], f)
+
+        with patch.object(history, "_PATH", fake_path):
+            result = history._load()
+
+        assert result[0]["model"] == "claude-opus-4-7"
+
+    def test_normalization_persisted(self, tmp_path):
+        # Stale values should be rewritten back to disk so future reads are clean.
+        fake_path = str(tmp_path / "history.json")
+        with open(fake_path, "w") as f:
+            json.dump([{"cwd": "/a", "session_id": "s1", "model": "o4.6"}], f)
+
+        with patch.object(history, "_PATH", fake_path):
+            history._load()
+
+        with open(fake_path) as f:
+            on_disk = json.load(f)
+        assert on_disk[0]["model"] == "claude-opus-4-6"
+
+
+class TestNoReseedOnEmpty:
+    """get_history must NOT reseed if the file exists but the list is empty."""
+
+    def test_no_reseed_when_file_exists_empty(self, tmp_path):
+        fake_path = str(tmp_path / "history.json")
+        with open(fake_path, "w") as f:
+            json.dump([], f)  # user cleared their history
+
+        proj_base = tmp_path / "projects"
+        proj_dir = proj_base / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "session.jsonl").write_text("{}\n")
+
+        with (
+            patch.object(history, "_PATH", fake_path),
+            patch("claudewatch.backend.history.repository.CLAUDE_PROJECTS_DIR", str(proj_base)),
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(proj_base)),
+        ):
+            result = history.get_history()
+
+        assert result == []
+
+    def test_seeds_when_file_missing(self, tmp_path):
+        # Inverse: first-ever launch should still seed from JSONL.
+        fake_path = str(tmp_path / "history.json")
+        proj_base = tmp_path / "projects"
+        proj_dir = proj_base / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        with open(proj_dir / "session.jsonl", "w") as f:
+            f.write(json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}}) + "\n")
+
+        with (
+            patch.object(history, "_PATH", fake_path),
+            patch("claudewatch.backend.history.repository.CLAUDE_PROJECTS_DIR", str(proj_base)),
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(proj_base)),
+        ):
+            result = history.get_history()
+
+        assert len(result) >= 1
+
+
+class TestSeedFiltersSynthetic:
+    """_seed_from_jsonl must not store '<synthetic>' as a model value."""
+
+    def test_synthetic_in_tail_treated_as_empty(self, tmp_path):
+        proj_base = tmp_path / "projects"
+        proj_dir = proj_base / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        jsonl = proj_dir / "session.jsonl"
+        with open(jsonl, "w") as f:
+            f.write(json.dumps({"type": "assistant", "message": {"model": "<synthetic>"}}) + "\n")
+
+        fake_path = str(tmp_path / "history.json")
+        with (
+            patch.object(history, "_PATH", fake_path),
+            patch("claudewatch.backend.history.repository.CLAUDE_PROJECTS_DIR", str(proj_base)),
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(proj_base)),
+        ):
+            result = history._seed_from_jsonl()
+
+        assert result[0]["model"] == ""
+
+    def test_real_model_preferred_over_synthetic(self, tmp_path):
+        proj_base = tmp_path / "projects"
+        proj_dir = proj_base / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        jsonl = proj_dir / "session.jsonl"
+        with open(jsonl, "w") as f:
+            f.write(json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}}) + "\n")
+            f.write(json.dumps({"type": "assistant", "message": {"model": "<synthetic>"}}) + "\n")
+
+        fake_path = str(tmp_path / "history.json")
+        with (
+            patch.object(history, "_PATH", fake_path),
+            patch("claudewatch.backend.history.repository.CLAUDE_PROJECTS_DIR", str(proj_base)),
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(proj_base)),
+        ):
+            result = history._seed_from_jsonl()
+
+        assert result[0]["model"] == "claude-opus-4-6"

--- a/tests/ui/test_panes.py
+++ b/tests/ui/test_panes.py
@@ -218,7 +218,7 @@ class TestSessionsPane:
         mock_summary.return_value.get_cached.return_value = ""
         mock_summary.return_value.get_cached_summary.return_value = ""
         mock_usage.return_value.get_tokens.return_value = TokenUsageDTO(0, 0, 0, 0)
-        mock_usage.return_value.get_model.return_value = "sonnet 4.6"
+        mock_usage.return_value.get_model.return_value = "claude-sonnet-4-6"
 
         pane = SessionsPane(_make_delegate(), 490, 620)
         view = pane.build()
@@ -285,9 +285,16 @@ class TestResolveModelLabel:
         from claudewatch.ui.preferences.panes.sessions import _resolve_model_label
 
         svc = MagicMock()
-        svc.get_model.return_value = "sonnet 4.6"
+        svc.get_model.return_value = "claude-sonnet-4-6"
         assert _resolve_model_label("", "/tmp/proj", svc) == "sonnet 4.6"
         svc.get_model.assert_called_once_with("/tmp/proj")
+
+    def test_fallback_unknown_raw_id_passes_through(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import _resolve_model_label
+
+        svc = MagicMock()
+        svc.get_model.return_value = "claude-future-99"
+        assert _resolve_model_label("", "/tmp/proj", svc) == "claude-future-99"
 
     def test_empty_model_and_no_cwd_returns_empty(self) -> None:
         from claudewatch.ui.preferences.panes.sessions import _resolve_model_label

--- a/tests/usage/test_usage.py
+++ b/tests/usage/test_usage.py
@@ -3,7 +3,7 @@
 import json
 from unittest.mock import MagicMock
 
-from claudewatch.backend.usage.service import MODEL_DISPLAY_NAMES, UsageService
+from claudewatch.backend.usage.service import UsageService, model_display_name
 
 
 def _make_service(
@@ -19,24 +19,44 @@ def _make_service(
     return UsageService(mock_log)
 
 
-class TestModelDisplayNames:
-    """MODEL_DISPLAY_NAMES mapping tests."""
+class TestModelDisplayName:
+    """model_display_name derives a human label from a raw model id."""
 
-    def test_known_models_have_display_names(self):
-        assert MODEL_DISPLAY_NAMES["claude-opus-4-6"] == "opus 4.6"
-        assert MODEL_DISPLAY_NAMES["claude-sonnet-4-6"] == "sonnet 4.6"
-        assert MODEL_DISPLAY_NAMES["claude-haiku-4-5"] == "haiku 4.5"
+    def test_opus_with_minor(self):
+        assert model_display_name("claude-opus-4-7") == "opus 4.7"
+        assert model_display_name("claude-opus-4-6") == "opus 4.6"
 
-    def test_display_names_are_human_readable(self):
-        # Each display name should start with a real word, not a single letter.
-        # This guards against regressing to cryptic forms like "o4.6".
-        for display in MODEL_DISPLAY_NAMES.values():
-            family = display.split()[0]
-            assert len(family) > 1, f"display name {display!r} starts with a single letter"
+    def test_sonnet_with_minor(self):
+        assert model_display_name("claude-sonnet-4-6") == "sonnet 4.6"
+
+    def test_haiku_with_minor(self):
+        assert model_display_name("claude-haiku-4-5") == "haiku 4.5"
+
+    def test_date_suffix_stripped(self):
+        # 8+ digit release date trailing the version is dropped.
+        assert model_display_name("claude-haiku-4-5-20251001") == "haiku 4.5"
+        assert model_display_name("claude-sonnet-4-5-20250514") == "sonnet 4.5"
+
+    def test_no_minor_with_date(self):
+        # Family + major + date with no minor: keep just family + major.
+        assert model_display_name("claude-opus-4-20250512") == "opus 4"
+
+    def test_unrecognized_id_passes_through(self):
+        # Unknown patterns are returned unchanged so the user still sees something.
+        assert model_display_name("claude-future-99") == "claude-future-99"
+        assert model_display_name("gpt-4") == "gpt-4"
+
+    def test_empty_input(self):
+        assert model_display_name("") == ""
+
+    def test_future_minor_versions_handled(self):
+        # New models should derive without code changes.
+        assert model_display_name("claude-opus-5-0") == "opus 5.0"
+        assert model_display_name("claude-sonnet-5-2") == "sonnet 5.2"
 
 
 class TestUsageServiceGetModel:
-    """Tests for UsageService.get_model."""
+    """Tests for UsageService.get_model — returns raw model ids."""
 
     def test_returns_empty_when_no_jsonl_found(self):
         svc = _make_service(find_most_recent=None)
@@ -46,10 +66,10 @@ class TestUsageServiceGetModel:
         svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail="")
         assert svc.get_model("/Users/dev/myapp") == ""
 
-    def test_returns_display_name_for_known_model(self):
+    def test_returns_raw_id_for_known_model(self):
         tail = json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}}) + "\n"
         svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
-        assert svc.get_model("/Users/dev/myapp") == "opus 4.6"
+        assert svc.get_model("/Users/dev/myapp") == "claude-opus-4-6"
 
     def test_returns_raw_model_for_unknown(self):
         tail = json.dumps({"type": "assistant", "message": {"model": "claude-future-99"}}) + "\n"
@@ -64,12 +84,29 @@ class TestUsageServiceGetModel:
             + "\n"
         )
         svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
-        assert svc.get_model("/Users/dev/myapp") == "opus 4.6"
+        assert svc.get_model("/Users/dev/myapp") == "claude-opus-4-6"
+
+    def test_skips_synthetic_placeholder(self):
+        # Claude Code sometimes emits "<synthetic>" as a model value on internal
+        # entries — we must not let that leak into history/display.
+        tail = (
+            json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}})
+            + "\n"
+            + json.dumps({"type": "assistant", "message": {"model": "<synthetic>"}})
+            + "\n"
+        )
+        svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
+        assert svc.get_model("/Users/dev/myapp") == "claude-opus-4-6"
+
+    def test_returns_empty_when_only_synthetic(self):
+        tail = json.dumps({"type": "assistant", "message": {"model": "<synthetic>"}}) + "\n"
+        svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
+        assert svc.get_model("/Users/dev/myapp") == ""
 
     def test_handles_invalid_json_lines(self):
         tail = "not json\n" + json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}}) + "\n"
         svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
-        assert svc.get_model("/Users/dev/myapp") == "opus 4.6"
+        assert svc.get_model("/Users/dev/myapp") == "claude-opus-4-6"
 
     def test_handles_non_dict_message(self):
         tail = json.dumps({"type": "assistant", "message": "string"}) + "\n"


### PR DESCRIPTION
Both the menubar Recent submenu and the preferences Sessions pane were rendering up to seven different formats for the same model — a mix of `o4.6`, `opus 4.6`, `claude-opus-4-7`, the literal `<synthetic>` placeholder, and blanks.

`UsageService.get_model` returned the display name, so `history.json` stored whatever the display string happened to be the moment a session ended. Renaming the display labels then froze the old strings in every file forever.

Changes:

- `get_model` returns the raw model id; display mapping moves to `model_display_name(raw_id)`, a regex that derives `family major.minor` and drops the dated suffix. New models render correctly without a code change.
- `<synthetic>` is filtered in the live read and the seed path, matching the analytics repo.
- Existing files are migrated on load: stale display strings map back to canonical raw ids and the file is rewritten once.
- `get_history` only seeds from `~/.claude/projects/` when the file does not exist. An empty file means the user cleared their history on purpose, so deleted entries no longer reappear on the next read.

Verified locally against my own `history.json` — the 7-format mess collapses to 4 clean labels (`opus 4.6`, `opus 4.7`, `haiku 4.5`, empty).