### PR TITLE
harden: reject symlinks at the final JSONL component via O_NOFOLLOW

### DIFF
--- a/claudewatch/backend/core/session_log/jsonl.py
+++ b/claudewatch/backend/core/session_log/jsonl.py
@@ -49,13 +49,25 @@ def is_safe_jsonl_path(path: str) -> bool:
     return real_path.startswith(real_proj_dir + os.sep)
 
 
+def _open_nofollow(path: str, mode: str) -> object:
+    """Open ``path`` with O_NOFOLLOW so a symlink at the final component is rejected.
+
+    is_safe_jsonl_path() filters at discovery time, but a symlink swap between
+    that check and this open would defeat it (TOCTOU). O_NOFOLLOW collapses the
+    final-component variant of that race: the open syscall itself fails with
+    ELOOP if the path is a symlink, regardless of where it points.
+    """
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    return os.fdopen(fd, mode)
+
+
 def read_jsonl_tail(path: str, tail_bytes: int = 10240) -> str:
     """Read the last N bytes of a JSONL file as UTF-8 text.
 
     Returns empty string on error.
     """
     try:
-        with open(path, "rb") as f:
+        with _open_nofollow(path, "rb") as f:
             f.seek(0, 2)
             size = f.tell()
             f.seek(max(0, size - tail_bytes))
@@ -70,7 +82,7 @@ def read_jsonl_full(path: str) -> list[str]:
     Returns empty list on error.
     """
     try:
-        with open(path) as f:
+        with _open_nofollow(path, "r") as f:
             return f.readlines()
     except OSError:
         return []

--- a/tests/core/test_jsonl_reader.py
+++ b/tests/core/test_jsonl_reader.py
@@ -87,6 +87,17 @@ class TestReadJsonlTail:
     def test_returns_empty_for_missing_file(self):
         assert read_jsonl_tail("/nonexistent/path.jsonl") == ""
 
+    def test_refuses_symlink_at_final_component(self, tmp_path):
+        """O_NOFOLLOW: a symlink at the final path component must not be followed."""
+        target = tmp_path / "real.jsonl"
+        target.write_text('{"a": 1}\n')
+        link = tmp_path / "linked.jsonl"
+        link.symlink_to(target)
+        # Direct read of the real file works.
+        assert '{"a": 1}' in read_jsonl_tail(str(target))
+        # Read through the symlink is refused (returns "").
+        assert read_jsonl_tail(str(link)) == ""
+
 
 class TestReadJsonlFull:
     """Tests for read_jsonl_full."""
@@ -99,6 +110,15 @@ class TestReadJsonlFull:
 
     def test_returns_empty_for_missing_file(self):
         assert read_jsonl_full("/nonexistent/path.jsonl") == []
+
+    def test_refuses_symlink_at_final_component(self, tmp_path):
+        """O_NOFOLLOW: symlink at the final path component must not be followed."""
+        target = tmp_path / "real.jsonl"
+        target.write_text('{"x": 1}\n')
+        link = tmp_path / "linked.jsonl"
+        link.symlink_to(target)
+        assert read_jsonl_full(str(target)) == ['{"x": 1}\n']
+        assert read_jsonl_full(str(link)) == []
 
 
 class TestGetSessionIdFromPath:


### PR DESCRIPTION
Closes the final-component symlink TOCTOU on JSONL reads.

is_safe_jsonl_path uses os.path.realpath at discovery, then we open() later. Between those two calls, a symlink swap could escape. Opening with O_NOFOLLOW collapses that window for the final component — the open syscall fails outright if the path is a symlink, no matter where it points.

Parent components are still defended by is_safe_jsonl_path. This is defense-in-depth — the realistic threat (local user with write access to ~/.claude/projects/) is low but worth tightening.