### PR TITLE
harden updater: require checksum, refuse install when it can't be fetched

### DIFF
--- a/claudewatch/backend/updates/service.py
+++ b/claudewatch/backend/updates/service.py
@@ -225,14 +225,18 @@ class UpdateService(BaseService):
             log.warning("update: download failed: %s", e)
             return False
 
-        # Verify checksum if available
+        # Checksum verification is mandatory. If the release doesn't expose a
+        # readable checksums.txt, refuse to install — an attacker who can block
+        # just the checksum fetch shouldn't be able to skip verification.
         expected = _fetch_expected_checksum(tag)
-        if expected:
-            actual = _sha256_file(zip_path)
-            if actual != expected:
-                log.warning("update: checksum mismatch — expected %s, got %s", expected[:12], actual[:12])
-                return False
-            log.info("update: checksum verified")
+        if not expected:
+            log.warning("update: no checksum available for %s — refusing to install", tag)
+            return False
+        actual = _sha256_file(zip_path)
+        if actual != expected:
+            log.warning("update: checksum mismatch — expected %s, got %s", expected[:12], actual[:12])
+            return False
+        log.info("update: checksum verified")
 
         # Unzip
         extract_dir = os.path.join(tmp_dir, "extracted")

--- a/tests/updates/test_updates.py
+++ b/tests/updates/test_updates.py
@@ -158,3 +158,34 @@ class TestUpdateService:
             result = self.svc.download_and_apply("v1.0.0")
 
         assert result is False
+
+    def test_download_refuses_install_without_checksum(self, tmp_path):
+        """If checksums.txt can't be fetched, the install must abort."""
+        download_result = MagicMock(returncode=0, stderr="")
+        with (
+            patch(f"{MODULE}._find_app_bundle", return_value="/Applications/ClaudeWatch.app"),
+            patch(f"{MODULE}.tempfile.mkdtemp", return_value=str(tmp_path)),
+            patch(f"{MODULE}.subprocess.run", return_value=download_result) as mock_run,
+            patch(f"{MODULE}._fetch_expected_checksum", return_value=None),
+            patch(f"{MODULE}._sha256_file") as mock_sha,
+        ):
+            # Pre-populate the would-be zip so the function gets past the download step.
+            (tmp_path / "update.zip").write_bytes(b"fake-zip")
+            result = self.svc.download_and_apply("v1.0.0")
+        assert result is False
+        mock_sha.assert_not_called()  # never compute a hash we can't verify against
+        assert mock_run.called
+
+    def test_download_refuses_install_on_checksum_mismatch(self, tmp_path):
+        """A real checksum that doesn't match the zip's hash must abort the install."""
+        download_result = MagicMock(returncode=0, stderr="")
+        with (
+            patch(f"{MODULE}._find_app_bundle", return_value="/Applications/ClaudeWatch.app"),
+            patch(f"{MODULE}.tempfile.mkdtemp", return_value=str(tmp_path)),
+            patch(f"{MODULE}.subprocess.run", return_value=download_result),
+            patch(f"{MODULE}._fetch_expected_checksum", return_value="a" * 64),
+            patch(f"{MODULE}._sha256_file", return_value="b" * 64),
+        ):
+            (tmp_path / "update.zip").write_bytes(b"fake-zip")
+            result = self.svc.download_and_apply("v1.0.0")
+        assert result is False


### PR DESCRIPTION
The auto-updater verifies the downloaded zip against checksums.txt — but only when that file is reachable. The previous `if expected:` gate meant a network-level attacker who blocks just the checksum fetch could bypass verification entirely while still being able to deliver a tampered zip.

Changed to mandatory: if checksums.txt can't be fetched or parsed, abort the install with a logged warning. Same-source TLS still does the bulk of the work — this closes the 'block one of the two requests' attack.

Two new tests cover the missing-checksum and mismatch paths; existing test for missing bundle stays in place.