### PR TITLE
fix: detection survives ghost windows, native installs, and ai-title tail decay

### DIFF
--- a/claudewatch/backend/core/helpers.py
+++ b/claudewatch/backend/core/helpers.py
@@ -10,6 +10,10 @@ log = logging.getLogger("claudewatch")
 
 _APPLESCRIPT_TIMEOUT = 10.0
 
+# Errors already logged at warning level — repeats drop to debug so a
+# persistent failure doesn't flood the log on every poll.
+_warned_applescript_errors: set[str] = set()
+
 
 def atomic_json_write(path: str, data: object, *, indent: int | None = 2) -> None:
     """Write JSON to ``path`` atomically: serialize to ``path + ".tmp"``, then rename.
@@ -48,6 +52,9 @@ def run_applescript(source: str, *, timeout: float = _APPLESCRIPT_TIMEOUT) -> st
             msg = error.get("NSAppleScriptErrorMessage", error)
             if "-60005" in str(msg):
                 log.warning("AppleScript error (Accessibility permissions required): %s", msg)
+            elif str(msg) not in _warned_applescript_errors:
+                _warned_applescript_errors.add(str(msg))
+                log.warning("AppleScript error: %s", msg)
             else:
                 log.debug("AppleScript error: %s", msg)
         result_holder.append(result.stringValue() or "" if result else "")

--- a/claudewatch/backend/core/models.py
+++ b/claudewatch/backend/core/models.py
@@ -69,20 +69,20 @@ class ClaudeSession:
     tab_index: int | None = None  # terminal tab index within IDE (0-based)
     session_id: str = ""  # Claude Code session UUID from JSONL filename
     agent_count: int = 0  # populated by analytics.enrich_sessions()
+    ai_title: str = ""  # Claude-generated session title from the matched JSONL
 
     @property
     def task_summary(self) -> str:
-        """Extract the Claude task/status from the window title.
-        Titles look like: 'project — ✳ Some Task — claude TMPDIR=...'"""
+        """The session's task: its aiTitle when known, else parsed from the window title.
+        Titles look like: 'project — ✳ Some Task — node ◂ claude — 120×40'"""
+        if self.ai_title:
+            return self.ai_title
         # Match all braille spinner frames (U+2800..U+28FF) plus ✳ and ●
         for sep_re in (r"— ✳ ", r"— [⠀-⣿] ", r"— ● "):
             m = re.search(sep_re, self.window_title)
             if m:
                 after = self.window_title[m.end() :]
-                for end in (" — claude", " — caffeinate", " — npm"):
-                    if end in after:
-                        after = after.split(end, 1)[0]
-                return after.strip()
+                return after.split(" — ", 1)[0].strip()
         return ""
 
     @property

--- a/claudewatch/backend/core/session_log/jsonl.py
+++ b/claudewatch/backend/core/session_log/jsonl.py
@@ -94,7 +94,7 @@ def get_session_id_from_path(path: str) -> str:
 
 
 def read_ai_title(path: str, tail_bytes: int = 10240) -> str:
-    """Return the latest aiTitle recorded in the JSONL, or "" if none.
+    """Return the latest aiTitle recorded in the JSONL tail, or "" if none.
 
     Claude Code writes `{"type":"ai-title","aiTitle":"..."}` periodically.
     We scan the tail in reverse so we pick up the most recent title.
@@ -102,8 +102,28 @@ def read_ai_title(path: str, tail_bytes: int = 10240) -> str:
     tail = read_jsonl_tail(path, tail_bytes=tail_bytes)
     if not tail:
         return ""
+    return _latest_ai_title(tail.splitlines())
+
+
+def read_ai_title_full(path: str) -> str:
+    """Scan the entire JSONL for the latest aiTitle, or "" if none.
+
+    Fallback for long sessions whose ai-title entries have scrolled out of
+    the tail window. Streams the file keeping only candidate lines, so large
+    logs aren't materialized in memory. Callers should cache the result.
+    """
     needle = f'"{EntryType.AI_TITLE}"'
-    for line in reversed(tail.splitlines()):
+    try:
+        with _open_nofollow(path, "r") as f:
+            candidates = [line for line in f if needle in line]
+    except OSError:
+        return ""
+    return _latest_ai_title(candidates)
+
+
+def _latest_ai_title(lines: list[str]) -> str:
+    needle = f'"{EntryType.AI_TITLE}"'
+    for line in reversed(lines):
         if needle not in line:
             continue
         try:

--- a/claudewatch/backend/core/session_log/service.py
+++ b/claudewatch/backend/core/session_log/service.py
@@ -19,8 +19,12 @@ class SessionLogService(BaseService):
         return jsonl.list_jsonls_in_cwd(cwd)
 
     def read_ai_title(self, path: str) -> str:
-        """Return the latest aiTitle recorded in a JSONL, or "" if none."""
+        """Return the latest aiTitle recorded in a JSONL's tail, or "" if none."""
         return jsonl.read_ai_title(path)
+
+    def read_ai_title_full(self, path: str) -> str:
+        """Scan the entire JSONL for the latest aiTitle. Callers should cache."""
+        return jsonl.read_ai_title_full(path)
 
     def is_safe_path(self, path: str) -> bool:
         """Check that a JSONL path resolves to within CLAUDE_PROJECTS_DIR."""

--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -55,6 +55,10 @@ class DetectionService(BaseService):
         # cwd → ({ai_title: jsonl_path}, timestamp). Lets each session in a shared
         # CWD read its own JSONL instead of the most-recent one for the project.
         self._ai_title_cache: dict[str, tuple[dict[str, str], float]] = {}
+        # path → last known aiTitle. Long sessions push their ai-title entry out
+        # of the tail window; this remembers it so the full-file scan runs at
+        # most once per path. Tail scans still pick up newer titles.
+        self._ai_title_by_path: dict[str, str] = {}
 
     # -- Process info helpers -----------------------------------------------
 
@@ -83,10 +87,12 @@ class DetectionService(BaseService):
             tell application "Terminal"
                 set output to ""
                 repeat with w in windows
-                    set wid to id of w
-                    repeat with t in tabs of w
-                        set output to output & (tty of t) & "|" & wid & "|" & (name of w) & linefeed
-                    end repeat
+                    try
+                        set wid to id of w
+                        repeat with t in tabs of w
+                            set output to output & (tty of t) & "|" & wid & "|" & (name of w) & linefeed
+                        end repeat
+                    end try
                 end repeat
                 return output
             end tell
@@ -212,7 +218,7 @@ class DetectionService(BaseService):
 
         mapping: dict[str, str] = {}
         for path in self._session_log_service.list_in_cwd(cwd):
-            title = self._session_log_service.read_ai_title(path)
+            title = self._read_ai_title(path)
             if not title:
                 continue
             # If two JSONLs share an ai-title (rare, e.g. after a session
@@ -222,6 +228,18 @@ class DetectionService(BaseService):
 
         self._ai_title_cache[cwd] = (mapping, now)
         return mapping
+
+    def _read_ai_title(self, path: str) -> str:
+        """Read a JSONL's aiTitle: cheap tail scan first, full scan once as fallback."""
+        title = self._session_log_service.read_ai_title(path)
+        if title:
+            self._ai_title_by_path[path] = title
+            return title
+        if path in self._ai_title_by_path:
+            return self._ai_title_by_path[path]
+        title = self._session_log_service.read_ai_title_full(path)
+        self._ai_title_by_path[path] = title
+        return title
 
     # -- JSONL status helpers -----------------------------------------------
 
@@ -337,6 +355,14 @@ class DetectionService(BaseService):
         except (subprocess.TimeoutExpired, OSError):
             pids_out = ""
         raw_pids = [int(p) for p in pids_out.splitlines() if p.strip().isdigit()]
+        # pgrep matches argv[0] and misses native-installer processes whose
+        # kernel name is the version string (~/.local/share/claude/versions/X).
+        # Union with a libproc scan on executable path so neither source alone
+        # has to be complete.
+        pgrep_pids = set(raw_pids)
+        for proc in self._process_service.list_all():
+            if proc.pid not in pgrep_pids and _is_claude_cli(proc.comm):
+                raw_pids.append(proc.pid)
         child_pids = self._process_service.get_child_pids()
         pids = [p for p in raw_pids if p not in child_pids][:_MAX_SESSIONS]
         log.debug("detect: found %d claude processes", len(pids))
@@ -429,6 +455,7 @@ class DetectionService(BaseService):
                     window_id=window_id,
                     status=status,
                     session_id=self._get_session_id(cwd, jpath),
+                    ai_title=self._ai_title_by_path.get(jpath, "") if jpath else "",
                 )
             )
 
@@ -479,6 +506,16 @@ class DetectionService(BaseService):
             # else: title confirms IDLE or WORKING — trust it
 
         return sessions
+
+
+def _is_claude_cli(comm: str) -> bool:
+    """Match Claude Code CLI executables by path.
+
+    Covers the native installer (~/.local/share/claude/versions/<x.y.z>) and
+    installs whose binary is named exactly 'claude'. Case-sensitive so Claude
+    Desktop ('Claude', 'Claude Helper') doesn't match.
+    """
+    return os.path.basename(comm) == "claude" or "/claude/versions/" in comm
 
 
 def _format_tool_use(tool: dict) -> ToolUseInfo:

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from claudewatch.backend.core.helpers import (
+    _warned_applescript_errors,
     atomic_json_write,
     escape_applescript,
     is_accessibility_trusted,
@@ -89,7 +90,8 @@ class TestRunApplescriptErrorLogging:
         assert result == ""
         assert any("-60005" in r.message and r.levelno == logging.WARNING for r in caplog.records)
 
-    def test_logs_debug_for_other_errors(self, caplog: object) -> None:
+    def test_logs_warning_for_other_errors(self, caplog: object) -> None:
+        _warned_applescript_errors.clear()
         with (
             patch("claudewatch.backend.core.helpers.NSAppleScript") as mock_cls,
             caplog.at_level(logging.DEBUG, logger="claudewatch"),  # type: ignore[union-attr]
@@ -102,8 +104,7 @@ class TestRunApplescriptErrorLogging:
             mock_cls.alloc.return_value.initWithSource_.return_value = mock_script
 
             run_applescript("bad script")
-        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert not warning_records
+        assert any("Some other error" in r.message and r.levelno == logging.WARNING for r in caplog.records)
 
 
 class TestIsAccessibilityTrusted:

--- a/tests/core/test_jsonl_reader.py
+++ b/tests/core/test_jsonl_reader.py
@@ -8,6 +8,7 @@ from claudewatch.backend.core.session_log.jsonl import (
     get_session_id_from_path,
     list_jsonls_in_cwd,
     read_ai_title,
+    read_ai_title_full,
     read_jsonl_full,
     read_jsonl_tail,
 )
@@ -197,3 +198,30 @@ class TestReadAiTitle:
         f = tmp_path / "s.jsonl"
         f.write_text('not-json-at-all\n{"type": "ai-title", "aiTitle": "Valid title"}\n')
         assert read_ai_title(str(f)) == "Valid title"
+
+
+class TestReadAiTitleFull:
+    """Tests for read_ai_title_full."""
+
+    def _long_session(self, tmp_path, title_line: str):
+        filler = '{"type": "assistant", "message": {"content": [{"type": "text", "text": "%s"}]}}\n' % ("x" * 200)
+        f = tmp_path / "s.jsonl"
+        f.write_text(title_line + filler * 100)
+        return f
+
+    def test_finds_title_outside_tail_window(self, tmp_path):
+        f = self._long_session(tmp_path, '{"type": "ai-title", "aiTitle": "Old long session"}\n')
+        assert read_ai_title(str(f)) == ""
+        assert read_ai_title_full(str(f)) == "Old long session"
+
+    def test_returns_latest_when_multiple(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        f.write_text('{"type": "ai-title", "aiTitle": "First"}\n{"type": "ai-title", "aiTitle": "Second"}\n')
+        assert read_ai_title_full(str(f)) == "Second"
+
+    def test_returns_empty_when_no_title(self, tmp_path):
+        f = self._long_session(tmp_path, "")
+        assert read_ai_title_full(str(f)) == ""
+
+    def test_returns_empty_for_missing_file(self):
+        assert read_ai_title_full("/nonexistent/x.jsonl") == ""

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -34,6 +34,29 @@ class TestClaudeSession:
         )
         assert s.task_summary == "Running tests"
 
+    def test_task_summary_strips_host_suffix_in_current_title_format(self):
+        s = ClaudeSession(
+            pid=1,
+            tty="ttys001",
+            project="myapp",
+            cwd="/tmp/myapp",
+            host_app=HostApp.TERMINAL,
+            window_title="myapp — ✳ Fix login bug — node ◂ claude — 120×40",
+        )
+        assert s.task_summary == "Fix login bug"
+
+    def test_task_summary_prefers_ai_title(self):
+        s = ClaudeSession(
+            pid=1,
+            tty="ttys001",
+            project="myapp",
+            cwd="/tmp/myapp",
+            host_app=HostApp.VSCODE,
+            window_title="VS Code",
+            ai_title="Refactor detection service",
+        )
+        assert s.task_summary == "Refactor detection service"
+
     def test_task_summary_no_task(self):
         s = ClaudeSession(
             pid=1,

--- a/tests/detection/test_detect_integration.py
+++ b/tests/detection/test_detect_integration.py
@@ -18,7 +18,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 from claudewatch.backend.core.models import SessionStatus
-from claudewatch.backend.core.process.models import ProcessInfo
+from claudewatch.backend.core.process.models import ProcessEntry, ProcessInfo
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.detection.service import DetectionService
 
@@ -88,6 +88,34 @@ class TestDetectEmpty:
         svc = _build_service(str(tmp_path), [])
         try:
             assert svc.detect() == []
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
+    def test_finds_native_installer_process_missed_by_pgrep(self, tmp_path):
+        """Native-installer claude (kernel name = version string) is invisible
+        to pgrep -x; the libproc path scan must still find it."""
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+        _write_jsonl(
+            os.path.join(proj_dir, "s1.jsonl"),
+            [{"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}}],
+            age_seconds=120,
+        )
+        svc = _build_service(
+            str(tmp_path),
+            [],  # pgrep finds nothing
+            pid_info={100: ProcessInfo(tty="ttys001", ppid=1, comm="claude")},
+            pid_cwds={100: cwd},
+            terminal_titles={"/dev/ttys001": ("myapp — ✳ claude", 1)},
+        )
+        svc._process_service.list_all.return_value = [
+            ProcessEntry(pid=100, tty="ttys001", ppid=1, comm="/Users/dev/.local/share/claude/versions/2.1.170"),
+            ProcessEntry(pid=200, tty="??", ppid=1, comm="/Applications/Claude.app/Contents/MacOS/Claude"),
+        ]
+        try:
+            sessions = svc.detect()
+            assert [s.pid for s in sessions] == [100]
         finally:
             for p in svc._test_patchers:
                 p.stop()
@@ -389,6 +417,85 @@ class TestDetectSharedCwdAttention:
         finally:
             for p in svc._test_patchers:
                 p.stop()
+
+    def test_long_session_title_outside_tail_still_gets_attention(self, tmp_path):
+        """ai-title entry pushed out of the 10KB tail — full-scan fallback still matches.
+
+        Long sessions write their ai-title early; once the log grows past the
+        tail window, tail-only matching degrades to the shared most-recent
+        fallback and the session reads a sibling's JSONL.
+        """
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+
+        # Session A: actively streaming, fresh JSONL — the most-recent one.
+        _write_jsonl(
+            os.path.join(proj_dir, "active.jsonl"),
+            [
+                {"type": "ai-title", "aiTitle": "Wire up search filter"},
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}},
+            ],
+        )
+        # Session B: long session — ai-title at the top, >10KB of filler after it,
+        # ending with an unresolved tool_use.
+        filler = [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "x" * 200}]}} for _ in range(100)
+        ]
+        _write_jsonl(
+            os.path.join(proj_dir, "long.jsonl"),
+            [
+                {"type": "ai-title", "aiTitle": "Investigate stale cache"},
+                *filler,
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "tool_use", "name": "Write", "input": {"file_path": "/x/README.md"}}]
+                    },
+                },
+            ],
+            age_seconds=30,
+        )
+
+        svc = _build_service(
+            str(tmp_path),
+            [100, 200],
+            pid_info={
+                100: ProcessInfo(tty="ttys001", ppid=1, comm="claude"),
+                200: ProcessInfo(tty="ttys002", ppid=1, comm="claude"),
+            },
+            pid_cwds={100: cwd, 200: cwd},
+            terminal_titles={
+                "/dev/ttys001": ("myapp — ⠂ Wire up search filter — node ◂ claude", 1),
+                "/dev/ttys002": ("myapp — ✳ Investigate stale cache — node ◂ claude", 2),
+            },
+        )
+        try:
+            sessions = svc.detect()
+            by_pid = {s.pid: s for s in sessions}
+            assert by_pid[100].status == SessionStatus.WORKING
+            assert by_pid[200].status == SessionStatus.ATTENTION
+            assert "Write" in by_pid[200].prompt_text
+            assert by_pid[100].ai_title == "Wire up search filter"
+            assert by_pid[200].ai_title == "Investigate stale cache"
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
+    def test_full_scan_runs_once_per_path(self):
+        """Tail miss triggers one full scan; the result is remembered afterwards."""
+        svc = DetectionService(MagicMock(), MagicMock())
+        svc._session_log_service.read_ai_title.return_value = ""
+        svc._session_log_service.read_ai_title_full.return_value = "Remembered title"
+
+        assert svc._read_ai_title("/p/s.jsonl") == "Remembered title"
+        assert svc._read_ai_title("/p/s.jsonl") == "Remembered title"
+        assert svc._session_log_service.read_ai_title_full.call_count == 1
+
+        # A newer title arriving in the tail supersedes the remembered one.
+        svc._session_log_service.read_ai_title.return_value = "Newer title"
+        assert svc._read_ai_title("/p/s.jsonl") == "Newer title"
+        assert svc._read_ai_title("/p/s.jsonl") == "Newer title"
+        assert svc._session_log_service.read_ai_title_full.call_count == 1
 
     def test_brand_new_session_no_ai_title_falls_back(self, tmp_path):
         """Session with no aiTitle in window title falls back to most-recent JSONL."""


### PR DESCRIPTION
## Summary

Three detection failures seen live: a ghost Terminal window aborted the whole AppleScript window scan (no titles, no window ids, every shared-CWD session collapsed onto the most-recent JSONL), `pgrep -x claude` missed native-installer processes (kernel name is the version string, e.g. `2.1.170`), and long sessions lost aiTitle matching once the entry scrolled past the 10KB tail.

## Changes

- per-window `try` in the Terminal enumeration AppleScript — one bad window no longer kills the scan
- AppleScript errors log at warning once per unique message, debug on repeats
- union pgrep results with a libproc scan on executable path (`/claude/versions/` or a binary named `claude`)
- full-file aiTitle scan fallback (streamed, cached once per path); sessions carry `ai_title` and `task_summary` prefers it over title parsing
- title parser handles the current `— node ◂ claude — WxH` suffix format

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] full suite: 798 passed, coverage 81.7%
- [x] smoke-tested against 8 live sessions sharing one CWD: all detected (incl. one invisible to pgrep), distinct session ids, correct statuses, labels show per-session titles