### PR TITLE
fix: security baseline never loaded back from NSUserDefaults

### DIFF
--- a/claudewatch/backend/security/repository.py
+++ b/claudewatch/backend/security/repository.py
@@ -60,15 +60,27 @@ class SecurityRepository:
     # -- Baseline persistence --
 
     def load_baseline(self) -> ConfigSnapshot | None:
-        """Load the last-known config snapshot from NSUserDefaults."""
+        """Load the last-known config snapshot from NSUserDefaults.
+
+        Stored as a JSON string: NSUserDefaults returns plist dicts as
+        NSDictionary proxies that fail isinstance(dict) and compare unreliably
+        against pure-Python snapshots. Legacy dict-typed values load as None,
+        which re-baselines once on upgrade.
+        """
         raw = get_setting(_BASELINE_KEY)
-        if not isinstance(raw, dict):
+        if not isinstance(raw, str):
             return None
-        return ConfigSnapshot.from_dict(raw)
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        return ConfigSnapshot.from_dict(data)
 
     def save_baseline(self, snapshot: ConfigSnapshot) -> None:
         """Persist a config snapshot as the new baseline."""
-        set_setting(_BASELINE_KEY, snapshot.to_dict())
+        set_setting(_BASELINE_KEY, json.dumps(snapshot.to_dict()))
 
     # -- Permission management --
 

--- a/tests/security/test_security_repository.py
+++ b/tests/security/test_security_repository.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -92,6 +92,54 @@ class TestCaptureSnapshot:
         repo = SecurityRepository(str(tmp_path))
         snap = repo.capture_snapshot()
         assert snap.settings == {}
+
+
+class TestBaselinePersistence:
+    def _patched_store(self):
+        store: dict[str, object] = {}
+        get_patch = patch(
+            "claudewatch.backend.security.repository.get_setting",
+            side_effect=store.get,
+        )
+        set_patch = patch(
+            "claudewatch.backend.security.repository.set_setting",
+            side_effect=store.__setitem__,
+        )
+        return store, get_patch, set_patch
+
+    def test_save_load_roundtrip(self, claude_dir: str) -> None:
+        repo = SecurityRepository(claude_dir)
+        snap = repo.capture_snapshot()
+        store, get_patch, set_patch = self._patched_store()
+        with get_patch, set_patch:
+            repo.save_baseline(snap)
+            restored = repo.load_baseline()
+
+        # Stored as a JSON string — plist dicts come back from NSUserDefaults
+        # as NSDictionary proxies that fail isinstance(dict).
+        assert isinstance(store["security.last_config_snapshot"], str)
+        assert restored is not None
+        assert restored.to_dict() == snap.to_dict()
+
+    def test_load_returns_none_for_legacy_dict_value(self) -> None:
+        repo = SecurityRepository("/nonexistent")
+        store, get_patch, set_patch = self._patched_store()
+        store["security.last_config_snapshot"] = {"settings": {}}
+        with get_patch, set_patch:
+            assert repo.load_baseline() is None
+
+    def test_load_returns_none_when_unset(self) -> None:
+        repo = SecurityRepository("/nonexistent")
+        _, get_patch, set_patch = self._patched_store()
+        with get_patch, set_patch:
+            assert repo.load_baseline() is None
+
+    def test_load_returns_none_for_corrupt_json(self) -> None:
+        repo = SecurityRepository("/nonexistent")
+        store, get_patch, set_patch = self._patched_store()
+        store["security.last_config_snapshot"] = "not json {{{"
+        with get_patch, set_patch:
+            assert repo.load_baseline() is None
 
 
 class TestConfigSnapshotSerialization:


### PR DESCRIPTION
## Summary

`load_baseline` checked `isinstance(raw, dict)`, but NSUserDefaults returns plist dicts as NSDictionary proxies that fail that check. The baseline never loaded, so config monitoring never diffed anything and the baseline re-saved every 30s poll (log churn).

## Changes

- store the baseline as a JSON string (plist-safe, exact round-trip, no NSNumber/NSArray comparison quirks in `diff_snapshots`)
- legacy dict-typed values load as None → one-time re-baseline on upgrade
- roundtrip tests: save/load, legacy dict value, unset, corrupt JSON

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] full suite: 793 passed, coverage 81.7%
- [x] string roundtrip verified against real NSUserDefaults (`pyobjc_unicode` subclasses `str`)