### PR TITLE
fix: derive model display names from the id instead of a lookup table

### DIFF
--- a/claudewatch/backend/usage/service.py
+++ b/claudewatch/backend/usage/service.py
@@ -10,12 +10,13 @@ from claudewatch.backend.core.dto import TokenUsageDTO
 from claudewatch.backend.core.service import BaseService
 from claudewatch.backend.core.session_log.service import SessionLogService
 
-# Parses a raw Claude model id into family + major[.minor]. Trailing 8+ digit
-# release dates are ignored so 'claude-haiku-4-5-20251001' collapses to the
-# same label as 'claude-haiku-4-5'. The minor segment is capped at six digits
-# so it never swallows a date suffix that follows a model with no minor
+# Parses a raw Claude model id into family + major[.minor]. The family is any
+# alphabetic word so new model lines derive without code changes. Trailing 8+
+# digit release dates are ignored so 'claude-haiku-4-5-20251001' collapses to
+# the same label as 'claude-haiku-4-5'. The minor segment is capped at six
+# digits so it never swallows a date suffix that follows a model with no minor
 # component (e.g. 'claude-opus-4-20250512' → family 4, no minor, date dropped).
-_MODEL_RE = re.compile(r"^claude-(opus|sonnet|haiku)-(\d+)(?:-(\d{1,6}))?(?:-\d{8,})?$")
+_MODEL_RE = re.compile(r"^claude-([a-z]+)-(\d+)(?:-(\d{1,6}))?(?:-\d{8,})?$")
 
 
 def model_display_name(raw_id: str) -> str:
@@ -25,6 +26,7 @@ def model_display_name(raw_id: str) -> str:
         'claude-opus-4-7'            -> 'opus 4.7'
         'claude-haiku-4-5-20251001'  -> 'haiku 4.5'
         'claude-opus-4-20250512'     -> 'opus 4'
+        'claude-fable-5'             -> 'fable 5'
 
     Any id that doesn't match the expected pattern is returned unchanged —
     callers display the raw value as a last-resort fallback rather than

--- a/tests/ui/test_panes.py
+++ b/tests/ui/test_panes.py
@@ -274,11 +274,11 @@ class TestResolveModelLabel:
         assert _resolve_model_label("claude-opus-4-6", "/tmp/proj", svc) == "opus 4.6"
         svc.get_model.assert_not_called()
 
-    def test_unknown_model_id_falls_through(self) -> None:
+    def test_new_family_id_derives_label(self) -> None:
         from claudewatch.ui.preferences.panes.sessions import _resolve_model_label
 
         svc = MagicMock()
-        assert _resolve_model_label("claude-future-99", "/tmp/proj", svc) == "claude-future-99"
+        assert _resolve_model_label("claude-future-99", "/tmp/proj", svc) == "future 99"
         svc.get_model.assert_not_called()
 
     def test_empty_model_falls_back_to_usage_service(self) -> None:
@@ -289,12 +289,12 @@ class TestResolveModelLabel:
         assert _resolve_model_label("", "/tmp/proj", svc) == "sonnet 4.6"
         svc.get_model.assert_called_once_with("/tmp/proj")
 
-    def test_fallback_unknown_raw_id_passes_through(self) -> None:
+    def test_fallback_service_id_derives_label(self) -> None:
         from claudewatch.ui.preferences.panes.sessions import _resolve_model_label
 
         svc = MagicMock()
         svc.get_model.return_value = "claude-future-99"
-        assert _resolve_model_label("", "/tmp/proj", svc) == "claude-future-99"
+        assert _resolve_model_label("", "/tmp/proj", svc) == "future 99"
 
     def test_empty_model_and_no_cwd_returns_empty(self) -> None:
         from claudewatch.ui.preferences.panes.sessions import _resolve_model_label

--- a/tests/usage/test_usage.py
+++ b/tests/usage/test_usage.py
@@ -41,10 +41,14 @@ class TestModelDisplayName:
         # Family + major + date with no minor: keep just family + major.
         assert model_display_name("claude-opus-4-20250512") == "opus 4"
 
+    def test_new_family_derives_without_code_changes(self):
+        assert model_display_name("claude-fable-5") == "fable 5"
+        assert model_display_name("claude-future-99") == "future 99"
+
     def test_unrecognized_id_passes_through(self):
-        # Unknown patterns are returned unchanged so the user still sees something.
-        assert model_display_name("claude-future-99") == "claude-future-99"
+        # Non-Claude / unparseable ids are returned unchanged.
         assert model_display_name("gpt-4") == "gpt-4"
+        assert model_display_name("claude-fable-5[1m]") == "claude-fable-5[1m]"
 
     def test_empty_input(self):
         assert model_display_name("") == ""


### PR DESCRIPTION
## Summary

`model_display_name` hardcodes the family alternation `(opus|sonnet|haiku)`, so newer model lines render raw (`claude-fable-5` in the Models Used card). Generalize the family to any alphabetic word — the regex's own goal ('new models should derive without code changes'), extended to families.

## Changes

- `_MODEL_RE`: `(opus|sonnet|haiku)` → `([a-z]+)`; date-stripping and minor-capping behavior unchanged
- tests: `claude-fable-5` → `fable 5`, new-family derivation, non-Claude ids still pass through

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] full suite: 836 passed
- [x] verified against every distinct `primary_model` value in a real analytics.db