### PR TITLE
fix: summaries read the session's own JSONL, not the CWD's most recent

### DIFF
--- a/claudewatch/backend/core/session_log/service.py
+++ b/claudewatch/backend/core/session_log/service.py
@@ -18,6 +18,19 @@ class SessionLogService(BaseService):
         """List all JSONL paths in a CWD's project dir, mtime descending."""
         return jsonl.list_jsonls_in_cwd(cwd)
 
+    def resolve_jsonl(self, cwd: str, session_id: str = "") -> str | None:
+        """Path of a specific session's JSONL, or the most recent for the CWD.
+
+        With a session_id, returns that session's own file (None if gone) —
+        never a sibling's. Without one, falls back to the most recent.
+        """
+        if not session_id:
+            return jsonl.find_most_recent_jsonl(cwd)
+        for path in jsonl.list_jsonls_in_cwd(cwd):
+            if jsonl.get_session_id_from_path(path) == session_id:
+                return path
+        return None
+
     def read_ai_title(self, path: str) -> str:
         """Return the latest aiTitle recorded in a JSONL, or "" if none."""
         return jsonl.read_ai_title(path)

--- a/claudewatch/backend/summary/repository.py
+++ b/claudewatch/backend/summary/repository.py
@@ -81,25 +81,35 @@ class SummaryRepository:
         return f"{cwd}::{session_id}" if session_id else cwd
 
     def get_entry(self, cwd: str, session_id: str = "") -> SummaryEntry | None:
-        """Return the cached entry if JSONL hasn't changed significantly since generation."""
+        """Return the cached entry unless the session's own JSONL grew significantly.
+
+        Staleness is judged against the session's own file, not the CWD's
+        most-recent one — a sibling session writing must not invalidate this
+        entry. Plain mtime updates don't invalidate either (active sessions
+        write constantly); only >10KB growth or a missing file does.
+        """
         key = self.cache_key(cwd, session_id)
         with self._store_lock:
             self.load_store()
             entry = self._store.get(key)
         if not entry:
             return None
-        current_mtime = self.get_jsonl_mtime(cwd)
-        if not current_mtime or current_mtime > entry.mtime:
+        if not self.get_jsonl_mtime(cwd, session_id):
             return None
-        current_size = self.get_jsonl_size(cwd)
-        if current_size and entry.jsonl_size and current_size - entry.jsonl_size > _STALENESS_SIZE_THRESHOLD:
-            return None
+        current_size = self.get_jsonl_size(cwd, session_id)
+        if current_size and entry.jsonl_size:
+            if current_size - entry.jsonl_size > _STALENESS_SIZE_THRESHOLD:
+                return None
+            # JSONLs only append — a recorded size larger than the file means
+            # the entry was generated from a different (sibling) file.
+            if entry.jsonl_size > current_size:
+                return None
         return entry
 
     def cache(self, cwd: str, summary: str, session_id: str = "") -> None:
         """Persist a summary string as the title."""
         key = self.cache_key(cwd, session_id)
-        mtime = self.get_jsonl_mtime(cwd) or time.time()
+        mtime = self.get_jsonl_mtime(cwd, session_id) or time.time()
         with self._store_lock:
             self.load_store()
             existing = self._store.get(key)
@@ -112,8 +122,8 @@ class SummaryRepository:
     def cache_full(self, cwd: str, title: str, summary: str, session_id: str = "") -> None:
         """Persist both title and bulleted summary."""
         key = self.cache_key(cwd, session_id)
-        mtime = self.get_jsonl_mtime(cwd) or time.time()
-        size = self.get_jsonl_size(cwd)
+        mtime = self.get_jsonl_mtime(cwd, session_id) or time.time()
+        size = self.get_jsonl_size(cwd, session_id)
         with self._store_lock:
             self.load_store()
             self._store[key] = SummaryEntry(title=title, summary=summary, mtime=mtime, jsonl_size=size)
@@ -135,9 +145,9 @@ class SummaryRepository:
 
     # -- JSONL metadata -----------------------------------------------------
 
-    def get_jsonl_mtime(self, cwd: str) -> float:
-        """Get the modification time of the most recent JSONL for a CWD."""
-        path = self._session_log_service.find_most_recent(cwd)
+    def get_jsonl_mtime(self, cwd: str, session_id: str = "") -> float:
+        """Modification time of the session's JSONL (most recent when no session_id)."""
+        path = self._session_log_service.resolve_jsonl(cwd, session_id)
         if path:
             try:
                 return os.path.getmtime(path)
@@ -145,9 +155,9 @@ class SummaryRepository:
                 pass
         return 0.0
 
-    def get_jsonl_size(self, cwd: str) -> int:
-        """Get the file size of the most recent JSONL for a CWD."""
-        path = self._session_log_service.find_most_recent(cwd)
+    def get_jsonl_size(self, cwd: str, session_id: str = "") -> int:
+        """File size of the session's JSONL (most recent when no session_id)."""
+        path = self._session_log_service.resolve_jsonl(cwd, session_id)
         if path:
             try:
                 return os.path.getsize(path)

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -151,12 +151,8 @@ class SummaryService(BaseService):
         except OSError:
             return None
 
-    def _extract_recap(self, cwd: str) -> str | None:
-        """Return the most recent away_summary from the JSONL session log."""
-        path = self._session_log_service.find_most_recent(cwd)
-        if not path:
-            return None
-
+    def _extract_recap(self, path: str) -> str | None:
+        """Return the most recent away_summary from a JSONL session log."""
         # Tail scan first; full scan as fallback because recaps sit where the
         # pause happened and can scroll past the 200KB tail window for active sessions.
         tail = self._session_log_service.read_tail(path, tail_bytes=_TAIL_BYTES)
@@ -171,11 +167,8 @@ class SummaryService(BaseService):
             return None
         return _find_last_recap(lines)
 
-    def _extract_ai_title(self, cwd: str) -> str | None:
-        """Extract Claude Code's native ai-title entry from the JSONL session log."""
-        path = self._session_log_service.find_most_recent(cwd)
-        if not path:
-            return None
+    def _extract_ai_title(self, path: str) -> str | None:
+        """Extract Claude Code's native ai-title entry from a JSONL session log."""
         try:
             with open(path) as f:
                 lines = f.readlines()
@@ -184,26 +177,38 @@ class SummaryService(BaseService):
         return _find_last_ai_title(lines)
 
     def generate_and_cache(self, cwd: str, session_id: str = "") -> str:
-        """Extract recap+title from JSONL and persist. Returns the title (or empty)."""
+        """Extract recap+title from the session's own JSONL and persist.
+
+        Returns the title (or empty). Reading the session's own file matters:
+        with shared-CWD setups the most-recent JSONL usually belongs to a
+        sibling session, and its recap would be cached for everyone.
+        """
         key = self._cache_key(cwd, session_id)
         cached = self.get_cached(cwd, session_id)
         if cached is not None:
             return cached
 
+        path = self._session_log_service.resolve_jsonl(cwd, session_id)
+        if not path:
+            return ""
+
         # Skip if we already checked and found no recap, and the JSONL hasn't changed.
-        current_mtime = self._repo.get_jsonl_mtime(cwd)
+        try:
+            current_mtime = os.path.getmtime(path)
+        except OSError:
+            current_mtime = 0.0
         with self._no_recap_lock:
             last_check = self._no_recap_mtimes.get(key)
             if last_check is not None and current_mtime and last_check == current_mtime:
                 return ""
 
-        recap = self._extract_recap(cwd)
+        recap = self._extract_recap(path)
         if recap is None:
             with self._no_recap_lock:
                 self._no_recap_mtimes[key] = current_mtime
             return ""
 
-        title = _truncate_title(self._extract_ai_title(cwd) or recap)
+        title = _truncate_title(self._extract_ai_title(path) or recap)
         self.cache_full(cwd, title, recap, session_id)
         log.debug("summarize: cached recap for %s", os.path.basename(cwd))
         return title

--- a/claudewatch/ui/menu/session_submenu.py
+++ b/claudewatch/ui/menu/session_submenu.py
@@ -54,8 +54,9 @@ def build_session_submenu(
     if summary:
         add_summary_lines(summary_sub, summary, d)
     else:
-        if generating:
-            summary_sub.addItem_(make_menu_item("Generating…", None, d))
+        # An empty NSMenu never opens on hover — always give the submenu a row.
+        placeholder = "Generating…" if generating else "No recap yet"
+        summary_sub.addItem_(make_menu_item(placeholder, None, d))
         if act.track_summary:
             act.track_summary()
     summary_item.setSubmenu_(summary_sub)

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -391,7 +391,7 @@ class ClaudeWatchApp:
                 modal_dismissed = threading.Event()
 
                 def _fill_summary() -> None:
-                    summary = self._summary_service.generate_and_cache(cwd)
+                    summary = self._summary_service.generate_and_cache(cwd, sid)
                     if summary and not modal_dismissed.is_set():
                         text_field.performSelectorOnMainThread_withObject_waitUntilDone_(
                             "setStringValue:",
@@ -413,7 +413,7 @@ class ClaudeWatchApp:
                     note = str(text_field.stringValue()).strip()
                     self._bookmark_service.add(sid, project, cwd, note)
                     if note:
-                        self._summary_service.cache(cwd, note)
+                        self._summary_service.cache(cwd, note, sid)
 
                     quit_alert = NSAlert.alloc().init()
                     quit_alert.setMessageText_("Quit this session?")
@@ -434,6 +434,7 @@ class ClaudeWatchApp:
         pid = session.pid
         project = session.project
         cwd = session.cwd
+        sid = session.session_id
         tty = session.tty
         wid = session.window_id
         pinned = cwd in self._bookmark_service.get_bookmarked_cwds()
@@ -463,7 +464,7 @@ class ClaudeWatchApp:
                 finally:
                     self._modal_active = False
             if exited:
-                threading.Thread(target=self._summary_service.generate_and_cache, args=(cwd,), daemon=True).start()
+                threading.Thread(target=self._summary_service.generate_and_cache, args=(cwd, sid), daemon=True).start()
             self._last_menu_key = ""
             self.update_display()
 

--- a/tests/summary/test_summary_repository.py
+++ b/tests/summary/test_summary_repository.py
@@ -95,7 +95,8 @@ class TestCache:
 
         proj_dir = tmp_path / "projects" / "-test"
         proj_dir.mkdir(parents=True)
-        (proj_dir / "s.jsonl").write_text("{}\n")
+        (proj_dir / "session-1.jsonl").write_text("{}\n")
+        (proj_dir / "session-2.jsonl").write_text("{}\n")
 
         repo = _make_repo(tmp_path)
         with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
@@ -107,6 +108,53 @@ class TestCache:
         assert a.title == "summary A"
         assert b is not None
         assert b.title == "summary B"
+
+    def test_sibling_activity_does_not_invalidate_entry(self, tmp_path):
+        """A sibling session's fresh JSONL must not stale this session's entry."""
+        from unittest.mock import patch
+
+        proj_dir = tmp_path / "projects" / "-test"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "mine.jsonl").write_text("{}\n")
+
+        repo = _make_repo(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            repo.cache_full("/test", "title", "recap", "mine")
+            (proj_dir / "sibling.jsonl").write_text("{}\n" * 5000)
+            entry = repo.get_entry("/test", "mine")
+        assert entry is not None
+        assert entry.summary == "recap"
+
+    def test_entry_recorded_from_larger_file_invalidates(self, tmp_path):
+        """An entry whose recorded size exceeds the file was cached from a
+        sibling's JSONL (files only append) — it must not be served."""
+        from unittest.mock import patch
+
+        proj_dir = tmp_path / "projects" / "-test"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "mine.jsonl").write_text("{}\n")
+
+        repo = _make_repo(tmp_path)
+        repo._store_loaded = True
+        repo._store = {
+            "/test::mine": SummaryEntry(title="wrong", summary="sibling recap", mtime=time.time(), jsonl_size=2824980)
+        }
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            assert repo.get_entry("/test", "mine") is None
+
+    def test_own_file_growth_invalidates_entry(self, tmp_path):
+        from unittest.mock import patch
+
+        proj_dir = tmp_path / "projects" / "-test"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "mine.jsonl").write_text("{}\n")
+
+        repo = _make_repo(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            repo.cache_full("/test", "title", "recap", "mine")
+            (proj_dir / "mine.jsonl").write_text("x" * 20480)  # grew past the 10KB threshold
+            entry = repo.get_entry("/test", "mine")
+        assert entry is None
 
 
 class TestClearAll:

--- a/tests/summary/test_summary_service.py
+++ b/tests/summary/test_summary_service.py
@@ -117,8 +117,7 @@ class TestExtractRecap:
             ],
         )
         svc = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_recap("/Users/dev/myapp")
+        result = svc._extract_recap(str(proj_dir / "session.jsonl"))
         assert result == "Fixed auth middleware and added tests."
 
     def test_returns_none_when_no_recap(self, tmp_path):
@@ -129,14 +128,12 @@ class TestExtractRecap:
             [{"type": "user", "message": {"content": "hello"}, "timestamp": ""}],
         )
         svc = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_recap("/Users/dev/myapp")
+        result = svc._extract_recap(str(proj_dir / "session.jsonl"))
         assert result is None
 
-    def test_returns_none_for_missing_project(self, tmp_path):
+    def test_returns_none_for_missing_file(self, tmp_path):
         svc = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "nope")):
-            result = svc._extract_recap("/Users/dev/myapp")
+        result = svc._extract_recap(str(tmp_path / "nope.jsonl"))
         assert result is None
 
     def test_full_scan_finds_recap_past_tail(self, tmp_path):
@@ -156,8 +153,7 @@ class TestExtractRecap:
         _write_jsonl(proj_dir / "session.jsonl", entries)
 
         svc = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_recap("/Users/dev/myapp")
+        result = svc._extract_recap(str(proj_dir / "session.jsonl"))
         assert result == "Early recap deep in the file."
 
 
@@ -175,8 +171,7 @@ class TestExtractAiTitle:
             ],
         )
         svc = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_ai_title("/Users/dev/myapp")
+        result = svc._extract_ai_title(str(proj_dir / "session.jsonl"))
         assert result == "Refactor auth module"
 
     def test_returns_none_when_absent(self, tmp_path):
@@ -187,8 +182,7 @@ class TestExtractAiTitle:
             [{"type": "user", "message": {"content": "hi"}, "timestamp": ""}],
         )
         svc = _make_service(tmp_path)
-        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
-            result = svc._extract_ai_title("/Users/dev/myapp")
+        result = svc._extract_ai_title(str(proj_dir / "session.jsonl"))
         assert result is None
 
 
@@ -216,6 +210,59 @@ class TestGenerateAndCache:
             assert result
             cached = svc.get_cached_summary("/Users/dev/myapp")
             assert cached == "Fixed auth middleware and added integration tests."
+
+    def test_shared_cwd_sessions_get_their_own_recaps(self, tmp_path):
+        """Each session reads its own JSONL — never a sibling's recap."""
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "sess-a.jsonl",
+            [
+                {
+                    "type": "system",
+                    "subtype": "away_summary",
+                    "content": "Recap for session A.",
+                    "timestamp": "2026-01-01T00:05:00Z",
+                },
+            ],
+        )
+        _write_jsonl(
+            proj_dir / "sess-b.jsonl",
+            [
+                {
+                    "type": "system",
+                    "subtype": "away_summary",
+                    "content": "Recap for session B.",
+                    "timestamp": "2026-01-01T00:06:00Z",
+                },
+            ],
+        )
+        svc = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            svc.generate_and_cache("/Users/dev/myapp", "sess-a")
+            svc.generate_and_cache("/Users/dev/myapp", "sess-b")
+            assert svc.get_cached_summary("/Users/dev/myapp", "sess-a") == "Recap for session A."
+            assert svc.get_cached_summary("/Users/dev/myapp", "sess-b") == "Recap for session B."
+
+    def test_missing_session_file_yields_no_summary(self, tmp_path):
+        """A session_id whose JSONL is gone must not fall back to a sibling's file."""
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "other.jsonl",
+            [
+                {
+                    "type": "system",
+                    "subtype": "away_summary",
+                    "content": "Sibling recap.",
+                    "timestamp": "2026-01-01T00:05:00Z",
+                },
+            ],
+        )
+        svc = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            assert svc.generate_and_cache("/Users/dev/myapp", "gone") == ""
+            assert svc.get_cached_summary("/Users/dev/myapp", "gone") is None
 
     def test_uses_ai_title_when_available(self, tmp_path):
         proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
@@ -336,17 +383,30 @@ class TestCacheSummary:
             result = svc.get_cached("/test")
         assert result == "test summary"
 
-    def test_stale_cache_returns_none(self, tmp_path):
+    def test_grown_jsonl_invalidates_cache(self, tmp_path):
+        svc = _make_service(tmp_path)
+        proj_dir = tmp_path / "projects" / "-test"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "s.jsonl").write_text("x" * 20480)
+
+        svc._repo._store_loaded = True
+        svc._repo._store = {"/test": SummaryEntry(title="", summary="old", mtime=1.0, jsonl_size=10)}
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = svc.get_cached("/test")
+        assert result is None
+
+    def test_newer_mtime_alone_does_not_invalidate_cache(self, tmp_path):
+        """Active sessions touch their JSONL constantly; only real growth invalidates."""
         svc = _make_service(tmp_path)
         proj_dir = tmp_path / "projects" / "-test"
         proj_dir.mkdir(parents=True)
         (proj_dir / "s.jsonl").write_text("{}\n")
 
         svc._repo._store_loaded = True
-        svc._repo._store = {"/test": SummaryEntry(title="", summary="old", mtime=1.0)}
+        svc._repo._store = {"/test": SummaryEntry(title="", summary="old", mtime=1.0, jsonl_size=3)}
         with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
             result = svc.get_cached("/test")
-        assert result is None
+        assert result == "old"
 
 
 class TestGetStatus:


### PR DESCRIPTION
## Summary

Summary extraction resolved `find_most_recent(cwd)`, so with several sessions sharing a CWD every session cached the same sibling recap. Worse, staleness compared against the most-recent file's mtime, so an active sibling invalidated every entry within seconds — the Summary submenu ended up empty (and an empty NSMenu doesn't open at all).

## Changes

- `SessionLogService.resolve_jsonl(cwd, session_id)` — a session's own file, never a sibling's; no fallback when the file is gone
- extraction + staleness metadata keyed to the session's own JSONL
- staleness = size-based only: >10KB growth invalidates, plain mtime updates don't (active sessions write constantly); a recorded size larger than the file means the entry came from a different file (JSONLs only append) and is rejected
- Summary submenu always has a row ("No recap yet" / "Generating…") so it can open

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] full suite: 795 passed, coverage 81.7%
- [x] smoke-tested against a real store poisoned with identical entries: all invalidate, per-session re-extraction returns distinct recaps