### PR TITLE
fix: key bookmarks by session id so shared-CWD sessions don't collide

### DIFF
--- a/claudewatch/backend/bookmark/repository.py
+++ b/claudewatch/backend/bookmark/repository.py
@@ -67,12 +67,18 @@ def _save(pins: list[_BookmarkRecord]) -> None:
 
 
 def add_bookmark(session_id: str, project: str, cwd: str, note: str) -> None:
-    """Bookmark a session with a note. Updates if already bookmarked."""
+    """Bookmark a session with a note. Updates if already bookmarked.
+
+    Keyed by session_id: multiple sessions sharing a CWD each get their own
+    bookmark. Entries without a session_id (legacy) match by CWD.
+    """
     with _LOCK:
         bookmarks = _load()
         ts = datetime.now(tz=UTC).isoformat()
         for entry in bookmarks:
-            if entry["cwd"] == cwd:
+            same_session = bool(session_id) and entry.get("session_id") == session_id
+            legacy_same_cwd = not session_id and not entry.get("session_id") and entry["cwd"] == cwd
+            if same_session or legacy_same_cwd:
                 entry["session_id"] = session_id
                 entry["note"] = note
                 entry["timestamp"] = ts
@@ -121,12 +127,15 @@ def clear_all_bookmarks() -> None:
     log.info("bookmark.cleared_all")
 
 
-def remove_bookmark(cwd: str) -> None:
-    """Remove a bookmark by CWD."""
+def remove_bookmark(session_id: str, cwd: str = "") -> None:
+    """Remove a bookmark by session id (CWD match for legacy entries without one)."""
     with _LOCK:
         bookmarks = _load()
         before = len(bookmarks)
-        bookmarks = [p for p in bookmarks if p["cwd"] != cwd]
+        if session_id:
+            bookmarks = [p for p in bookmarks if p.get("session_id") != session_id]
+        else:
+            bookmarks = [p for p in bookmarks if p.get("session_id") or p["cwd"] != cwd]
         if len(bookmarks) < before:
-            log.info("bookmark.removed cwd=%s", cwd)
+            log.info("bookmark.removed session=%s cwd=%s", session_id, cwd)
         _save(bookmarks)

--- a/claudewatch/backend/bookmark/service.py
+++ b/claudewatch/backend/bookmark/service.py
@@ -25,10 +25,24 @@ class BookmarkService(BaseService):
         bookmarks_repo.add_bookmark(session_id, project, cwd, note)
         self._invalidate()
 
-    def remove(self, cwd: str) -> None:
-        """Remove a bookmark by CWD."""
-        bookmarks_repo.remove_bookmark(cwd)
+    def remove(self, session_id: str, cwd: str = "") -> None:
+        """Remove a bookmark by session id (CWD fallback for legacy entries)."""
+        bookmarks_repo.remove_bookmark(session_id, cwd)
         self._invalidate()
+
+    def is_bookmarked(self, session_id: str, cwd: str) -> bool:
+        """True if this session is bookmarked.
+
+        Bookmarks with a session id match on it; legacy entries without one
+        match by CWD.
+        """
+        for b in self.get_all():
+            if b.session_id:
+                if session_id and b.session_id == session_id:
+                    return True
+            elif b.cwd == cwd:
+                return True
+        return False
 
     def get_all(self) -> list[BookmarkDTO]:
         """Return all bookmarked sessions as DTOs."""

--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -113,8 +113,9 @@ class MenuBuilder:
             )
             self._menu.addItem_(NSMenuItem.separatorItem())
 
-        pinned_cwds = self._app._bookmark_service.get_bookmarked_cwds()
+        bookmark_service = self._app._bookmark_service
         active_cwds = {s.cwd for s in sessions}
+        active_sids = {s.session_id for s in sessions if s.session_id}
 
         if not sessions:
             if self._app._has_polled:
@@ -144,7 +145,7 @@ class MenuBuilder:
                 )
                 self._menu.addItem_(header)
                 for s in attention:
-                    is_pinned = s.cwd in pinned_cwds
+                    is_pinned = bookmark_service.is_bookmarked(s.session_id, s.cwd)
                     self._add_session_items(s, suffixes[s.pid], pinned=is_pinned)
 
             if attention and (working or idle):
@@ -157,7 +158,7 @@ class MenuBuilder:
                 )
                 self._menu.addItem_(header)
                 for s in working:
-                    is_pinned = s.cwd in pinned_cwds
+                    is_pinned = bookmark_service.is_bookmarked(s.session_id, s.cwd)
                     self._add_session_items(s, suffixes[s.pid], pinned=is_pinned)
 
             if working and idle:
@@ -170,12 +171,16 @@ class MenuBuilder:
                 )
                 self._menu.addItem_(header)
                 for s in idle:
-                    is_pinned = s.cwd in pinned_cwds
+                    is_pinned = bookmark_service.is_bookmarked(s.session_id, s.cwd)
                     self._add_session_items(s, suffixes[s.pid], pinned=is_pinned)
 
         # Bookmarked sessions that are NOT currently active (respects feature toggle)
         pins = self._app._bookmark_service.get_all() if features.is_enabled(FeatureKey.BOOKMARKS) else []
-        inactive_pins = [p for p in pins if p.cwd not in active_cwds]
+        inactive_pins = [
+            p
+            for p in pins
+            if (p.session_id and p.session_id not in active_sids) or (not p.session_id and p.cwd not in active_cwds)
+        ]
         if inactive_pins:
             self._menu.addItem_(NSMenuItem.separatorItem())
             bm_menu_item = make_menu_item(f"Bookmarks ({len(inactive_pins)})", None, d)
@@ -192,7 +197,7 @@ class MenuBuilder:
                 actions = SessionActions(
                     activity=self._app._make_history_activity_handler(pin.project, pin.cwd),
                     resume=self._app._make_resume_handler(pin.session_id, pin.cwd),
-                    unbookmark=self._app._make_unbookmark_handler(pin.cwd),
+                    unbookmark=self._app._make_unbookmark_handler(pin.session_id, pin.cwd),
                     track_summary=lambda cwd=pin.cwd, sid=pin.session_id: self._app._summary_service.track_session(
                         cwd, session_id=sid or ""
                     ),
@@ -219,7 +224,8 @@ class MenuBuilder:
         for entry in history:
             if len(recent_entries) >= _recent_limit:
                 break
-            if entry.cwd in active_cwds or entry.cwd in pinned_cwds:
+            is_active = entry.session_id in active_sids if entry.session_id else entry.cwd in active_cwds
+            if is_active or bookmark_service.is_bookmarked(entry.session_id, entry.cwd):
                 continue
             try:
                 ended_dt = datetime.fromisoformat(entry.ended_at)
@@ -328,7 +334,7 @@ class MenuBuilder:
         actions = SessionActions(
             activity=self._app._make_activity_handler(s),
             bookmark=self._app._make_bookmark_handler(s) if not pinned and s.session_id else None,
-            unbookmark=self._app._make_unbookmark_handler(s.cwd) if pinned else None,
+            unbookmark=self._app._make_unbookmark_handler(s.session_id, s.cwd) if pinned else None,
             quit=self._app._make_quit_handler(s),
             track_summary=lambda cwd=s.cwd, sid=s.session_id, urgent=is_active: (
                 self._app._summary_service.track_session(cwd, urgent=urgent, session_id=sid)

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -436,7 +436,7 @@ class ClaudeWatchApp:
         cwd = session.cwd
         tty = session.tty
         wid = session.window_id
-        pinned = cwd in self._bookmark_service.get_bookmarked_cwds()
+        pinned = self._bookmark_service.is_bookmarked(session.session_id, cwd)
 
         def handler(_: NSMenuItem) -> None:
             exited = False
@@ -469,7 +469,7 @@ class ClaudeWatchApp:
 
         return handler
 
-    def _make_unbookmark_handler(self, cwd: str) -> MenuCallback:
+    def _make_unbookmark_handler(self, session_id: str, cwd: str = "") -> MenuCallback:
         def handler(_: NSMenuItem) -> None:
             self._modal_active = True
             try:
@@ -482,7 +482,7 @@ class ClaudeWatchApp:
                 alert.addButtonWithTitle_("Unpin")
                 alert.addButtonWithTitle_("Cancel")
                 if alert.runModal() == NSAlertFirstButtonReturn:
-                    self._bookmark_service.remove(cwd)
+                    self._bookmark_service.remove(session_id, cwd)
             finally:
                 self._modal_active = False
                 self._last_menu_key = ""

--- a/claudewatch/ui/preferences/handlers/history.py
+++ b/claudewatch/ui/preferences/handlers/history.py
@@ -75,9 +75,10 @@ def handle_bookmark(delegate: object, sender: object) -> None:
 
 
 def handle_unbookmark(delegate: object, sender: object) -> None:
-    """Remove a session from bookmarks."""
-    cwd = get_represented_object(sender)
-    get_bookmark_service().remove(cwd)
+    """Remove a session from bookmarks. Payload is 'session_id|cwd' (or bare cwd)."""
+    data = get_represented_object(sender)
+    sid, cwd = data.split("|", 1) if "|" in data else ("", data)
+    get_bookmark_service().remove(sid, cwd)
     from claudewatch.ui.preferences.panes.sessions import rebuild_rows
 
     rebuild_rows(delegate)

--- a/claudewatch/ui/preferences/panes/sessions.py
+++ b/claudewatch/ui/preferences/panes/sessions.py
@@ -130,13 +130,13 @@ def rebuild_rows(delegate: object) -> None:
 
     w = scroll.frame().size.width
     entries = [e.to_dict() for e in get_history_service().get_all()]
-    pinned_cwds = get_bookmark_service().get_bookmarked_cwds()
+    bookmark_svc = get_bookmark_service()
     summary_svc = get_summary_service()
     usage_svc = get_usage_service()
 
     # Filter: bookmarked only
     if delegate._history_bookmarked_only:
-        entries = [e for e in entries if e.get("cwd", "") in pinned_cwds]
+        entries = [e for e in entries if bookmark_svc.is_bookmarked(e.get("session_id", ""), e.get("cwd", ""))]
 
     # Search filter
     search = delegate._history_search
@@ -182,7 +182,7 @@ def rebuild_rows(delegate: object) -> None:
                 y,
                 w,
                 _ROW_H,
-                pinned_cwds,
+                bookmark_svc,
                 usage_svc,
                 summary_svc,
                 display_project,
@@ -248,7 +248,7 @@ def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001
     y: float,
     w: float,
     h: float,
-    pinned_cwds: set[str],
+    bookmark_svc: object,
     usage_svc: object,
     summary_svc: object,
     display_project: str = "",
@@ -262,7 +262,7 @@ def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001
     model_raw = entry.get("model", "")
     model = _resolve_model_label(model_raw, cwd, usage_svc)
     ended_at = entry.get("ended_at", "")
-    is_pinned = cwd in pinned_cwds
+    is_pinned = bookmark_svc.is_bookmarked(session_id, cwd)  # type: ignore[attr-defined]
 
     # Build context menu — use raw project as the stable identity for action payloads.
     row_menu = _build_row_menu(delegate, entry, is_pinned, cwd, session_id, raw_project, summary_svc)
@@ -275,7 +275,7 @@ def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001
     # Bookmark callback wiring — payload carries the raw project as identity.
     if is_pinned:
         bookmark_action = objc.selector(delegate.unbookmarkSession_, signature=b"v@:@")
-        bookmark_rep = cwd
+        bookmark_rep = f"{session_id}|{cwd}"
     else:
         bookmark_action = objc.selector(delegate.bookmarkSession_, signature=b"v@:@")
         bookmark_rep = f"{session_id}|{raw_project}|{cwd}"
@@ -349,7 +349,7 @@ def _build_row_menu(  # noqa: PLR0913, ARG001
     menu.addItem_(NSMenuItem.separatorItem())
 
     if is_pinned:
-        _add_action("Remove Bookmark", delegate.unbookmarkSession_, cwd)
+        _add_action("Remove Bookmark", delegate.unbookmarkSession_, f"{session_id}|{cwd}")
     else:
         _add_action("Bookmark", delegate.bookmarkSession_, f"{session_id}|{project}|{cwd}")
 

--- a/tests/bookmark/test_bookmark_service.py
+++ b/tests/bookmark/test_bookmark_service.py
@@ -19,8 +19,8 @@ class TestBookmarkService:
 
     @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
     def test_remove_delegates_to_repo(self, mock_repo):
-        self.svc.remove("/tmp/cwd")
-        mock_repo.remove_bookmark.assert_called_once_with("/tmp/cwd")
+        self.svc.remove("sid-1", "/tmp/cwd")
+        mock_repo.remove_bookmark.assert_called_once_with("sid-1", "/tmp/cwd")
 
     @patch("claudewatch.backend.bookmark.service.bookmarks_repo")
     def test_get_all_returns_bookmark_dtos(self, mock_repo):

--- a/tests/bookmark/test_bookmarks.py
+++ b/tests/bookmark/test_bookmarks.py
@@ -81,7 +81,7 @@ class TestBookmarkRemove:
         with patch.object(bookmarks, "_PATH", fake_path):
             bookmarks.add_bookmark("id-1", "proj-a", "/a", "note a")
             bookmarks.add_bookmark("id-2", "proj-b", "/b", "note b")
-            bookmarks.remove_bookmark("/a")
+            bookmarks.remove_bookmark("id-1")
             result = bookmarks.get_bookmarks()
 
         assert len(result) == 1
@@ -91,7 +91,7 @@ class TestBookmarkRemove:
         fake_path = str(tmp_path / "sessions.json")
         with patch.object(bookmarks, "_PATH", fake_path):
             bookmarks.add_bookmark("id-1", "proj-a", "/a", "note a")
-            bookmarks.remove_bookmark("/nonexistent")
+            bookmarks.remove_bookmark("id-nonexistent")
             result = bookmarks.get_bookmarks()
 
         assert len(result) == 1
@@ -100,10 +100,45 @@ class TestBookmarkRemove:
         fake_path = str(tmp_path / "sessions.json")
         with patch.object(bookmarks, "_PATH", fake_path):
             bookmarks.add_bookmark("id-1", "proj-a", "/a", "note a")
-            bookmarks.remove_bookmark("/a")
+            bookmarks.remove_bookmark("id-1")
             result = bookmarks.get_bookmarks()
 
         assert len(result) == 0
+
+    def test_remove_legacy_entry_by_cwd(self, tmp_path):
+        fake_path = str(tmp_path / "sessions.json")
+        with patch.object(bookmarks, "_PATH", fake_path):
+            bookmarks.add_bookmark("", "proj-a", "/a", "legacy")
+            bookmarks.add_bookmark("id-2", "proj-a", "/a", "keyed")
+            bookmarks.remove_bookmark("", "/a")
+            result = bookmarks.get_bookmarks()
+
+        assert len(result) == 1
+        assert result[0].session_id == "id-2"
+
+
+class TestSharedCwdBookmarks:
+    """Sessions sharing a CWD each keep their own bookmark."""
+
+    def test_two_sessions_same_cwd_both_kept(self, tmp_path):
+        fake_path = str(tmp_path / "sessions.json")
+        with patch.object(bookmarks, "_PATH", fake_path):
+            bookmarks.add_bookmark("id-1", "proj", "/shared", "first")
+            bookmarks.add_bookmark("id-2", "proj", "/shared", "second")
+            result = bookmarks.get_bookmarks()
+
+        assert len(result) == 2
+        assert {b.session_id for b in result} == {"id-1", "id-2"}
+
+    def test_rebookmark_same_session_updates_note(self, tmp_path):
+        fake_path = str(tmp_path / "sessions.json")
+        with patch.object(bookmarks, "_PATH", fake_path):
+            bookmarks.add_bookmark("id-1", "proj", "/shared", "old note")
+            bookmarks.add_bookmark("id-1", "proj", "/shared", "new note")
+            result = bookmarks.get_bookmarks()
+
+        assert len(result) == 1
+        assert result[0].note == "new note"
 
 
 class TestBookmarkTTLPruning:


### PR DESCRIPTION
## Summary

The bookmark domain was keyed by CWD everywhere: bookmarking a second session in the same CWD overwrote the first, the Bookmarks submenu hid any pin whose CWD had an active session, and the pinned marker applied to every session sharing the CWD.

## Changes

- `add_bookmark` dedupes by session_id; `remove_bookmark(session_id, cwd)` with CWD fallback for legacy entries without one
- `BookmarkService.is_bookmarked(session_id, cwd)` — single place for the matching rule
- menu markers, Bookmarks/Recent filters, quit-handler pinned check, and preferences history rows all keyed by session; unbookmark payloads carry `session_id|cwd`

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] full suite: 792 passed, coverage 81.5%
- [x] validated end-to-end: two shared-CWD bookmarks coexist, per-session markers, quit session surfaces under Bookmarks, unbookmark removes only its target