### PR TITLE
feat: recognize git worktree sessions, label as repo [branch]

### DIFF
--- a/claudewatch/backend/core/models.py
+++ b/claudewatch/backend/core/models.py
@@ -70,6 +70,8 @@ class ClaudeSession:
     session_id: str = ""  # Claude Code session UUID from JSONL filename
     agent_count: int = 0  # populated by analytics.enrich_sessions()
     ai_title: str = ""  # Claude-generated session title from the matched JSONL
+    worktree_repo: str = ""  # main repo name when cwd is a linked git worktree
+    worktree_branch: str = ""  # branch checked out in that worktree
 
     @property
     def task_summary(self) -> str:
@@ -90,15 +92,23 @@ class ClaudeSession:
         return self.status == SessionStatus.ATTENTION
 
     @property
+    def display_project(self) -> str:
+        """Project name for labels — 'repo [branch]' when cwd is a linked worktree."""
+        if self.worktree_repo:
+            branch = f" [{self.worktree_branch}]" if self.worktree_branch else ""
+            return f"{self.worktree_repo}{branch}"
+        return self.project
+
+    @property
     def menu_label(self) -> str:
         _max_label = 50
         ind = STATUS_INDICATOR[self.status]
         task = self.task_summary
         tab = f" (tab {self.tab_index + 1})" if self.tab_index is not None else ""
         if task and task != "Claude Code":
-            label = f"{ind} {self.project}{tab} — {task}"
+            label = f"{ind} {self.display_project}{tab} — {task}"
         else:
-            label = f"{ind} {self.project}{tab}"
+            label = f"{ind} {self.display_project}{tab}"
         if len(label) > _max_label:
             return label[: _max_label - 1] + "…"
         return label

--- a/claudewatch/backend/core/worktree.py
+++ b/claudewatch/backend/core/worktree.py
@@ -1,0 +1,84 @@
+"""Git worktree recognition from filesystem metadata — no subprocesses.
+
+Linked worktrees have a ``.git`` file (not a directory) whose ``gitdir:``
+line points into ``<repo>/.git/worktrees/<name>``. Recognizing one costs
+two small file reads, cheap enough for the detection poll loop.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+_MAX_WALK_UP = 8
+_WORKTREES_MARKER = f"{os.sep}.git{os.sep}worktrees{os.sep}"
+_DETACHED_SHA_LEN = 8
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    """A session cwd resolved to its main repository and checked-out branch."""
+
+    repo: str
+    branch: str  # short SHA when detached, "" when unreadable
+
+
+def resolve_worktree(cwd: str) -> WorktreeInfo | None:
+    """Return WorktreeInfo when cwd is inside a linked git worktree, else None.
+
+    Regular checkouts (``.git`` directory), bare repos, and submodules
+    (``.git`` file without the worktrees marker) all resolve to None.
+    """
+    if not cwd:
+        return None
+    root = _find_git_entry(cwd)
+    if not root:
+        return None
+    git_path = os.path.join(root, ".git")
+    if not os.path.isfile(git_path):
+        return None
+    gitdir = _read_gitdir(git_path)
+    if _WORKTREES_MARKER not in gitdir:
+        return None
+    repo_root = gitdir.split(_WORKTREES_MARKER, 1)[0]
+    return WorktreeInfo(repo=os.path.basename(repo_root), branch=_read_branch(gitdir))
+
+
+def _find_git_entry(start: str) -> str | None:
+    """Walk up from start looking for a directory containing ``.git``."""
+    path = os.path.abspath(start)
+    for _ in range(_MAX_WALK_UP):
+        if os.path.lexists(os.path.join(path, ".git")):
+            return path
+        parent = os.path.dirname(path)
+        if parent == path:
+            return None
+        path = parent
+    return None
+
+
+def _read_gitdir(git_file: str) -> str:
+    """Parse the ``gitdir:`` pointer from a ``.git`` file (resolves relative paths)."""
+    try:
+        with open(git_file) as f:
+            line = f.readline().strip()
+    except OSError:
+        return ""
+    if not line.startswith("gitdir:"):
+        return ""
+    gitdir = line.removeprefix("gitdir:").strip()
+    if not os.path.isabs(gitdir):
+        gitdir = os.path.normpath(os.path.join(os.path.dirname(git_file), gitdir))
+    return gitdir
+
+
+def _read_branch(gitdir: str) -> str:
+    """Read the checked-out branch from the worktree's HEAD file."""
+    try:
+        with open(os.path.join(gitdir, "HEAD")) as f:
+            head = f.readline().strip()
+    except OSError:
+        return ""
+    if head.startswith("ref: refs/heads/"):
+        return head.removeprefix("ref: refs/heads/")
+    return head[:_DETACHED_SHA_LEN]

--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -15,6 +15,7 @@ from claudewatch.backend.core.process.service import ProcessService
 from claudewatch.backend.core.service import BaseService
 from claudewatch.backend.core.session_log.schema import BlockType, EntryType
 from claudewatch.backend.core.session_log.service import SessionLogService
+from claudewatch.backend.core.worktree import WorktreeInfo, resolve_worktree
 from claudewatch.backend.detection.constants import HOST_PROCESS_NAMES, IDLE_INDICATOR
 from claudewatch.backend.detection.models import PendingToolResult, TerminalMatch, ToolUseInfo
 
@@ -26,6 +27,7 @@ _TEXT_MAX_LEN = 80
 _WIN_SPLIT_FIELDS = 3
 _TERMINAL_CACHE_TTL = 3  # seconds between AppleScript refreshes
 _AI_TITLE_CACHE_TTL = 3  # seconds between per-CWD ai-title scans
+_WORKTREE_CACHE_TTL = 30  # seconds between per-CWD worktree re-resolution
 _JSONL_STREAMING_THRESHOLD = 5  # JSONL modified within this → actively streaming
 _JSONL_IDLE_THRESHOLD = 60  # JSONL not modified within this → definitely idle
 
@@ -59,6 +61,9 @@ class DetectionService(BaseService):
         # of the tail window; this remembers it so the full-file scan runs at
         # most once per path. Tail scans still pick up newer titles.
         self._ai_title_by_path: dict[str, str] = {}
+        # cwd → (WorktreeInfo | None, timestamp). Branch switches are rare, so
+        # a longer TTL than the title caches.
+        self._worktree_cache: dict[str, tuple[WorktreeInfo | None, float]] = {}
 
     # -- Process info helpers -----------------------------------------------
 
@@ -229,6 +234,15 @@ class DetectionService(BaseService):
         self._ai_title_cache[cwd] = (mapping, now)
         return mapping
 
+    def _get_worktree(self, cwd: str) -> WorktreeInfo | None:
+        now = time.time()
+        cached = self._worktree_cache.get(cwd)
+        if cached is not None and now - cached[1] < _WORKTREE_CACHE_TTL:
+            return cached[0]
+        info = resolve_worktree(cwd)
+        self._worktree_cache[cwd] = (info, now)
+        return info
+
     def _read_ai_title(self, path: str) -> str:
         """Read a JSONL's aiTitle: cheap tail scan first, full scan once as fallback."""
         title = self._session_log_service.read_ai_title(path)
@@ -384,6 +398,9 @@ class DetectionService(BaseService):
         for stale_cwd in list(self._ai_title_cache.keys()):
             if stale_cwd not in live_cwds:
                 del self._ai_title_cache[stale_cwd]
+        for stale_cwd in list(self._worktree_cache.keys()):
+            if stale_cwd not in live_cwds:
+                del self._worktree_cache[stale_cwd]
 
         # Per-CWD fallback (most-recent JSONL) when ai-title matching can't
         # disambiguate a session. Built lazily.
@@ -443,6 +460,7 @@ class DetectionService(BaseService):
             fallback = cwd_fallback_jsonl[cwd]
             jpath = _match_jsonl_by_title(window_title, self._get_ai_title_map(cwd), fallback)
             session_jsonl[pid] = jpath
+            worktree = self._get_worktree(cwd)
 
             sessions.append(
                 ClaudeSession(
@@ -456,6 +474,8 @@ class DetectionService(BaseService):
                     status=status,
                     session_id=self._get_session_id(cwd, jpath),
                     ai_title=self._ai_title_by_path.get(jpath, "") if jpath else "",
+                    worktree_repo=worktree.repo if worktree else "",
+                    worktree_branch=worktree.branch if worktree else "",
                 )
             )
 

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -57,6 +57,30 @@ class TestClaudeSession:
         )
         assert s.task_summary == "Refactor detection service"
 
+    def test_menu_label_shows_worktree_repo_and_branch(self):
+        s = ClaudeSession(
+            pid=1,
+            tty="ttys001",
+            project="wt1",
+            cwd="/tmp/worktrees/wt1",
+            host_app=HostApp.TERMINAL,
+            worktree_repo="myrepo",
+            worktree_branch="feature-x",
+        )
+        assert s.display_project == "myrepo [feature-x]"
+        assert "myrepo [feature-x]" in s.menu_label
+        assert "wt1" not in s.menu_label
+
+    def test_display_project_falls_back_to_project(self):
+        s = ClaudeSession(
+            pid=1,
+            tty="ttys001",
+            project="myapp",
+            cwd="/tmp/myapp",
+            host_app=HostApp.TERMINAL,
+        )
+        assert s.display_project == "myapp"
+
     def test_task_summary_no_task(self):
         s = ClaudeSession(
             pid=1,

--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -1,0 +1,79 @@
+"""Tests for claudewatch.backend.core.worktree."""
+
+import os
+
+from claudewatch.backend.core.worktree import resolve_worktree
+
+
+def _make_repo_with_worktree(tmp_path, *, branch="feature-x", detached_sha="", relative_gitdir=False):
+    """Lay out a main repo plus a linked worktree the way git does."""
+    repo = tmp_path / "myrepo"
+    wt_admin = repo / ".git" / "worktrees" / "wt1"
+    wt_admin.mkdir(parents=True)
+    if detached_sha:
+        (wt_admin / "HEAD").write_text(f"{detached_sha}\n")
+    else:
+        (wt_admin / "HEAD").write_text(f"ref: refs/heads/{branch}\n")
+
+    worktree = tmp_path / "worktrees" / "wt1"
+    worktree.mkdir(parents=True)
+    gitdir = os.path.relpath(wt_admin, worktree) if relative_gitdir else str(wt_admin)
+    (worktree / ".git").write_text(f"gitdir: {gitdir}\n")
+    return worktree
+
+
+class TestResolveWorktree:
+    def test_linked_worktree_resolves_repo_and_branch(self, tmp_path):
+        worktree = _make_repo_with_worktree(tmp_path, branch="thomas/some-fix")
+        info = resolve_worktree(str(worktree))
+        assert info is not None
+        assert info.repo == "myrepo"
+        assert info.branch == "thomas/some-fix"
+
+    def test_resolves_from_subdirectory(self, tmp_path):
+        worktree = _make_repo_with_worktree(tmp_path)
+        sub = worktree / "src" / "pkg"
+        sub.mkdir(parents=True)
+        info = resolve_worktree(str(sub))
+        assert info is not None
+        assert info.repo == "myrepo"
+
+    def test_relative_gitdir_pointer(self, tmp_path):
+        worktree = _make_repo_with_worktree(tmp_path, relative_gitdir=True)
+        info = resolve_worktree(str(worktree))
+        assert info is not None
+        assert info.repo == "myrepo"
+        assert info.branch == "feature-x"
+
+    def test_detached_head_uses_short_sha(self, tmp_path):
+        worktree = _make_repo_with_worktree(tmp_path, detached_sha="a" * 40)
+        info = resolve_worktree(str(worktree))
+        assert info is not None
+        assert info.branch == "a" * 8
+
+    def test_missing_head_yields_empty_branch(self, tmp_path):
+        worktree = _make_repo_with_worktree(tmp_path)
+        os.remove(tmp_path / "myrepo" / ".git" / "worktrees" / "wt1" / "HEAD")
+        info = resolve_worktree(str(worktree))
+        assert info is not None
+        assert info.branch == ""
+
+    def test_regular_checkout_is_not_a_worktree(self, tmp_path):
+        repo = tmp_path / "regular"
+        (repo / ".git").mkdir(parents=True)
+        assert resolve_worktree(str(repo)) is None
+
+    def test_submodule_style_git_file_is_not_a_worktree(self, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / ".git").write_text("gitdir: ../.git/modules/sub\n")
+        assert resolve_worktree(str(sub)) is None
+
+    def test_no_git_anywhere(self, tmp_path):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        assert resolve_worktree(str(plain)) is None
+
+    def test_empty_and_missing_cwd(self):
+        assert resolve_worktree("") is None
+        assert resolve_worktree("/nonexistent/nowhere") is None

--- a/tests/detection/test_detect_integration.py
+++ b/tests/detection/test_detect_integration.py
@@ -140,6 +140,42 @@ class TestDetectEmpty:
                 p.stop()
 
 
+class TestDetectWorktreeSession:
+    def test_worktree_cwd_gets_repo_and_branch(self, tmp_path):
+        """A session running in a linked git worktree carries repo + branch."""
+        repo = tmp_path / "myrepo"
+        wt_admin = repo / ".git" / "worktrees" / "wt1"
+        wt_admin.mkdir(parents=True)
+        (wt_admin / "HEAD").write_text("ref: refs/heads/feature-x\n")
+        worktree = tmp_path / "wt1"
+        worktree.mkdir()
+        (worktree / ".git").write_text(f"gitdir: {wt_admin}\n")
+
+        cwd = str(worktree)
+        proj_dir = _cwd_to_proj_dir(str(tmp_path / "projects"), cwd)
+        _write_jsonl(
+            os.path.join(proj_dir, "s1.jsonl"),
+            [{"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}}],
+            age_seconds=120,
+        )
+        svc = _build_service(
+            str(tmp_path / "projects"),
+            [100],
+            pid_info={100: ProcessInfo(tty="ttys001", ppid=1, comm="claude")},
+            pid_cwds={100: cwd},
+            terminal_titles={"/dev/ttys001": ("wt1 — ✳ claude", 1)},
+        )
+        try:
+            sessions = svc.detect()
+            assert len(sessions) == 1
+            assert sessions[0].worktree_repo == "myrepo"
+            assert sessions[0].worktree_branch == "feature-x"
+            assert "myrepo [feature-x]" in sessions[0].menu_label
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
+
 class TestDetectSingleSession:
     def test_idle_title_stale_jsonl(self, tmp_path):
         """Single session with ✳ title and 3-day-old JSONL → IDLE."""


### PR DESCRIPTION
## Summary

Sessions launched inside a linked git worktree show the worktree directory's (often opaque) name. Recognize them and label as `repo [branch]` instead.

## Changes

- `core/worktree.py`: resolves linked worktrees from filesystem metadata only — a worktree's `.git` is a file pointing into `<repo>/.git/worktrees/<name>`; two small file reads, no subprocess in the poll loop. Regular checkouts, bare repos, and submodules resolve to None.
- `ClaudeSession.worktree_repo/worktree_branch` + `display_project`; menu labels use it
- handles relative `gitdir:` pointers, walks up from subdirectories, short SHA for detached HEAD
- detection caches resolution per CWD (30s TTL, evicted with the other caches)

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] full suite: 870 passed
- [x] validated against a worktree created by real `git worktree add` (root + nested subdir + main checkout)