### PR TITLE
fix: unmatched sessions no longer inherit a sibling's identity via the fallback JSONL

### DIFF
--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -409,6 +409,8 @@ class DetectionService(BaseService):
         # most-recent file in the project dir often belongs to a sibling
         # session, so we match on aiTitle from the window title instead.
         session_jsonl: dict[int, str | None] = {}
+        # pid → whether its JSONL was matched via aiTitle (vs the most-recent fallback)
+        matched_by_title: dict[int, bool] = {}
 
         sessions = []
         for pid in pids:
@@ -458,8 +460,9 @@ class DetectionService(BaseService):
             if cwd not in cwd_fallback_jsonl:
                 cwd_fallback_jsonl[cwd] = self._session_log_service.find_most_recent(cwd)
             fallback = cwd_fallback_jsonl[cwd]
-            jpath = _match_jsonl_by_title(window_title, self._get_ai_title_map(cwd), fallback)
+            jpath, title_matched = _match_jsonl_by_title(window_title, self._get_ai_title_map(cwd), fallback)
             session_jsonl[pid] = jpath
+            matched_by_title[pid] = title_matched
             worktree = self._get_worktree(cwd)
 
             sessions.append(
@@ -478,6 +481,18 @@ class DetectionService(BaseService):
                     worktree_branch=worktree.branch if worktree else "",
                 )
             )
+
+        # A fallback JSONL that another session already claimed via title match
+        # belongs to that session. Dressing an unmatched session in it would
+        # mirror the sibling's title, status, and summary — show it plainly
+        # (no session id, title-only status) until its own aiTitle appears.
+        claimed_paths = {session_jsonl[s.pid] for s in sessions if matched_by_title.get(s.pid) and session_jsonl[s.pid]}
+        for s in sessions:
+            jpath = session_jsonl.get(s.pid)
+            if jpath and not matched_by_title.get(s.pid) and jpath in claimed_paths:
+                session_jsonl[s.pid] = None
+                s.session_id = ""
+                s.ai_title = ""
 
         self._get_ide_tab_indices(sessions, all_ps)
 
@@ -563,23 +578,24 @@ def _match_jsonl_by_title(
     window_title: str,
     ai_title_map: dict[str, str],
     fallback: str | None,
-) -> str | None:
+) -> tuple[str | None, bool]:
     """Find the JSONL whose aiTitle appears as a substring of the window title.
 
     Used to disambiguate multiple Claude sessions sharing a CWD. Longest match
     wins so a substring title doesn't shadow a more specific one. Returns
-    `fallback` if nothing matches — which preserves prior behavior for
-    brand-new sessions (no ai-title yet) and IDE sessions (no terminal title).
+    (path, matched_by_title); the path is `fallback` when nothing matches —
+    which preserves prior behavior for brand-new sessions (no ai-title yet)
+    and IDE sessions (no terminal title).
     """
     if not window_title or not ai_title_map:
-        return fallback
+        return (fallback, False)
     best_title = ""
     best_path = fallback
     for title, path in ai_title_map.items():
         if title and title in window_title and len(title) > len(best_title):
             best_title = title
             best_path = path
-    return best_path
+    return (best_path, bool(best_title))
 
 
 def _has_working_indicator(window_title: str) -> bool:

--- a/tests/detection/test_attention_status.py
+++ b/tests/detection/test_attention_status.py
@@ -310,7 +310,7 @@ class TestMatchJsonlByTitle:
     def test_substring_match_returns_path(self):
         mapping = {"Wire up search filter": "/proj/a.jsonl"}
         title = "myapp — ✳ Wire up search filter — node ◂ claude — 177×47"
-        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == "/proj/a.jsonl"
+        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == ("/proj/a.jsonl", True)
 
     def test_longest_match_wins(self):
         mapping = {
@@ -318,25 +318,25 @@ class TestMatchJsonlByTitle:
             "Review PR #593 backend": "/proj/long.jsonl",
         }
         title = "myapp — ✳ Review PR #593 backend — node ◂ claude — 80×24"
-        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == "/proj/long.jsonl"
+        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == ("/proj/long.jsonl", True)
 
     def test_no_match_returns_fallback(self):
         mapping = {"Some other title": "/proj/other.jsonl"}
         title = "myapp — ✳ Brand new session — claude"
-        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == "/fallback.jsonl"
+        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == ("/fallback.jsonl", False)
 
     def test_empty_map_returns_fallback(self):
-        assert _match_jsonl_by_title("any title", {}, "/fallback.jsonl") == "/fallback.jsonl"
+        assert _match_jsonl_by_title("any title", {}, "/fallback.jsonl") == ("/fallback.jsonl", False)
 
     def test_empty_title_returns_fallback(self):
         mapping = {"Some title": "/proj/a.jsonl"}
-        assert _match_jsonl_by_title("", mapping, "/fallback.jsonl") == "/fallback.jsonl"
+        assert _match_jsonl_by_title("", mapping, "/fallback.jsonl") == ("/fallback.jsonl", False)
 
     def test_empty_title_value_skipped(self):
         # An empty aiTitle would substring-match every title — must be ignored.
         mapping = {"": "/proj/empty.jsonl", "Real title": "/proj/real.jsonl"}
         title = "myapp — ✳ Real title — claude"
-        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == "/proj/real.jsonl"
+        assert _match_jsonl_by_title(title, mapping, "/fallback.jsonl") == ("/proj/real.jsonl", True)
 
     def test_returns_fallback_when_fallback_is_none(self):
-        assert _match_jsonl_by_title("x", {}, None) is None
+        assert _match_jsonl_by_title("x", {}, None) == (None, False)

--- a/tests/detection/test_detect_integration.py
+++ b/tests/detection/test_detect_integration.py
@@ -533,6 +533,49 @@ class TestDetectSharedCwdAttention:
         assert svc._read_ai_title("/p/s.jsonl") == "Newer title"
         assert svc._session_log_service.read_ai_title_full.call_count == 1
 
+    def test_fresh_session_does_not_inherit_siblings_identity(self, tmp_path):
+        """A new session whose fallback JSONL is title-matched to a sibling must
+        not mirror that sibling's title, session id, or attention status."""
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+        # Session A: active, has an unresolved tool_use, aiTitle known.
+        _write_jsonl(
+            os.path.join(proj_dir, "active.jsonl"),
+            [
+                {"type": "ai-title", "aiTitle": "Fix claudewatch bugs"},
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}]},
+                },
+            ],
+            age_seconds=30,
+        )
+        svc = _build_service(
+            str(tmp_path),
+            [100, 200],
+            pid_info={
+                100: ProcessInfo(tty="ttys001", ppid=1, comm="claude"),
+                200: ProcessInfo(tty="ttys002", ppid=1, comm="claude"),
+            },
+            pid_cwds={100: cwd, 200: cwd},
+            terminal_titles={
+                "/dev/ttys001": ("myapp — ✳ Fix claudewatch bugs — node ◂ claude", 1),
+                "/dev/ttys002": ("myapp — ✳ Claude Code", 2),  # brand new, no aiTitle yet
+            },
+        )
+        try:
+            sessions = svc.detect()
+            by_pid = {s.pid: s for s in sessions}
+            assert by_pid[100].status == SessionStatus.ATTENTION
+            assert by_pid[100].ai_title == "Fix claudewatch bugs"
+            # The fresh session stays plain: no borrowed identity, no false attention.
+            assert by_pid[200].status == SessionStatus.IDLE
+            assert by_pid[200].ai_title == ""
+            assert by_pid[200].session_id == ""
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
     def test_brand_new_session_no_ai_title_falls_back(self, tmp_path):
         """Session with no aiTitle in window title falls back to most-recent JSONL."""
         cwd = "/Users/dev/myapp"


### PR DESCRIPTION
## Summary

A brand-new session (no aiTitle yet) falls back to the CWD's most-recent JSONL — which in shared-CWD setups usually belongs to an actively-working sibling. The new session then mirrored that sibling's title, session id, ATTENTION status, and summary; clicking its Needs Attention row focused a window with nothing to attend to.

## Changes

- `_match_jsonl_by_title` returns whether the match came from an aiTitle hit or the fallback
- a fallback JSONL already claimed by a title-matched sibling is discarded: the unmatched session keeps its plain label, empty session id, and title-only status until its own aiTitle appears
- single-session fallback behavior unchanged (brand-new solo sessions still reach ATTENTION)

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] full suite: 871 passed
- [x] live-verified: 11 real sessions, the fresh one shows plain '360privacy · Idle' instead of duplicating the active session's row