### PR TITLE
feat: sessions pane per-session titles, stale-entry handling, richer header

### DIFF
--- a/claudewatch/backend/history/dependencies.py
+++ b/claudewatch/backend/history/dependencies.py
@@ -1,8 +1,9 @@
 from functools import lru_cache
 
+from claudewatch.backend.core.session_log.dependencies import get_session_log_service
 from claudewatch.backend.history.service import HistoryService
 
 
 @lru_cache(maxsize=1)
 def get_history_service() -> HistoryService:
-    return HistoryService()
+    return HistoryService(get_session_log_service())

--- a/claudewatch/backend/history/service.py
+++ b/claudewatch/backend/history/service.py
@@ -4,6 +4,7 @@ import threading
 
 from claudewatch.backend.core.dto import HistoryEntryDTO
 from claudewatch.backend.core.service import BaseService
+from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.history import repository as history_repo
 
 
@@ -15,10 +16,28 @@ class HistoryService(BaseService):
     invalidated by every mutation.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, session_log_service: SessionLogService | None = None) -> None:
         super().__init__()
+        self._session_log_service = session_log_service or SessionLogService()
         self._cache: list[HistoryEntryDTO] | None = None
         self._cache_lock = threading.Lock()
+
+    def logs_exist(self, cwd: str, session_id: str = "") -> bool:
+        """True if the session's JSONL (or any log for the CWD) is still on disk.
+
+        Entries whose logs are gone (deleted worktrees, moved projects) can't
+        show a model, tokens, or summary — the UI dims them as stale.
+        """
+        return self._session_log_service.resolve_jsonl(cwd, session_id) is not None
+
+    def remove_stale(self) -> int:
+        """Remove entries whose session logs no longer exist. Returns count removed."""
+        stale = [e for e in self.get_all() if not self.logs_exist(e.cwd, e.session_id)]
+        for entry in stale:
+            history_repo.remove_history_entry(entry.cwd)
+        if stale:
+            self._invalidate()
+        return len(stale)
 
     def record(self, session_id: str, project: str, cwd: str, model: str, host_app: str) -> None:
         """Record a session when it ends."""

--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -204,6 +204,13 @@ class SummaryService(BaseService):
 
         recap = self._extract_recap(path)
         if recap is None:
+            # No recap yet — cache the session's aiTitle alone so history rows
+            # and menus still get a per-session name. The entry invalidates on
+            # file growth, so a recap written later replaces it.
+            title = _truncate_title(self._extract_ai_title(path) or "")
+            if title:
+                self.cache_full(cwd, title, "", session_id)
+                return title
             with self._no_recap_lock:
                 self._no_recap_mtimes[key] = current_mtime
             return ""

--- a/claudewatch/ui/components/composites/session_row.py
+++ b/claudewatch/ui/components/composites/session_row.py
@@ -25,6 +25,7 @@ def build_session_row(  # noqa: PLR0913
     model: str = "",
     ended_at: str = "",
     bookmarked: bool = False,
+    stale: bool = False,
     width: float,
     height: float,
     summary_title: str = "",
@@ -57,8 +58,8 @@ def build_session_row(  # noqa: PLR0913
                 bookmark_button.cell().setRepresentedObject_(bookmark_represented_object)
         view.addSubview_(bookmark_button)
 
-    # Project name
-    project_label = label(project, size=Font.BODY, bold=True)
+    # Project name — dimmed when the session's logs are gone
+    project_label = label(project, size=Font.BODY, bold=True, color=theme.tertiary if stale else None)
     project_label.setFrame_(NSMakeRect(_NAME_COL, name_y, usable_w - _NAME_COL - 30, 18))
     view.addSubview_(project_label)
 
@@ -85,6 +86,8 @@ def build_session_row(  # noqa: PLR0913
         meta_parts.append(model)
     if token_compact:
         meta_parts.append(token_compact)
+    if stale:
+        meta_parts.append("logs removed")
     if meta_parts:
         meta_text = " · ".join(meta_parts)
         meta_label = secondary_label(meta_text, size=Font.SMALL)

--- a/claudewatch/ui/preferences/delegate.py
+++ b/claudewatch/ui/preferences/delegate.py
@@ -122,6 +122,12 @@ class PrefsDelegate(NSObject):
         handle_bookmark_filter(self, sender)
 
     @objc_callback
+    def historyClearStale_(self, sender: objc.objc_object) -> None:  # noqa: N802
+        from claudewatch.ui.preferences.handlers.history import handle_clear_stale
+
+        handle_clear_stale(self, sender)
+
+    @objc_callback
     def showRowMenu_(self, sender: objc.objc_object) -> None:  # noqa: N802
         from claudewatch.ui.preferences.handlers.history import handle_show_row_menu
 

--- a/claudewatch/ui/preferences/handlers/history.py
+++ b/claudewatch/ui/preferences/handlers/history.py
@@ -46,6 +46,31 @@ def handle_sort_changed(delegate: object, sender: object) -> None:
     rebuild_rows(delegate)
 
 
+def handle_clear_stale(delegate: object, sender: object) -> None:  # noqa: ARG001
+    """Remove history entries whose session logs are gone, after confirmation."""
+    history = get_history_service()
+    stale_count = sum(1 for e in history.get_all() if not history.logs_exist(e.cwd, e.session_id))
+    NSApplication.sharedApplication().activateIgnoringOtherApps_(True)
+    alert = NSAlert.alloc().init()
+    if not stale_count:
+        alert.setMessageText_("No stale entries")
+        alert.setInformativeText_("Every recorded session still has its logs on disk.")
+        alert.addButtonWithTitle_("OK")
+        alert.runModal()
+        return
+    alert.setMessageText_(f"Clear {stale_count} stale {'entry' if stale_count == 1 else 'entries'}?")
+    alert.setInformativeText_(
+        "These sessions' logs are gone (deleted worktrees, moved projects). This cannot be undone."
+    )
+    alert.addButtonWithTitle_("Clear")
+    alert.addButtonWithTitle_("Cancel")
+    if alert.runModal() == NSAlertFirstButtonReturn:
+        history.remove_stale()
+        from claudewatch.ui.preferences.panes.sessions import rebuild_rows
+
+        rebuild_rows(delegate)
+
+
 def handle_bookmark_filter(delegate: object, sender: object) -> None:
     """Toggle bookmarked-only filter."""
     delegate._history_bookmarked_only = sender.state() == NSControlStateValueOn

--- a/claudewatch/ui/preferences/panes/sessions.py
+++ b/claudewatch/ui/preferences/panes/sessions.py
@@ -40,12 +40,19 @@ _ROW_H = 54
 
 
 def _build_subtitle() -> str:
-    """Build subtitle showing date range of recorded sessions."""
+    """Build subtitle with counts and date range of recorded sessions."""
     entries = get_history_service().get_all()
     if not entries:
         return "No sessions recorded yet"
-    oldest = min((e.ended_at or "" for e in entries), default="")
-    return f"Since {oldest[:10]}" if oldest and len(oldest) >= 10 else f"{len(entries)} sessions"
+    parts = [f"{len(entries)} session" + ("s" if len(entries) != 1 else "")]
+    week_cutoff = (datetime.now(tz=UTC) - timedelta(days=7)).isoformat()
+    this_week = sum(1 for e in entries if (e.ended_at or "") >= week_cutoff)
+    if this_week:
+        parts.append(f"{this_week} this week")
+    oldest = min((e.ended_at or "" for e in entries if e.ended_at), default="")
+    if len(oldest) >= 10:
+        parts.append(f"since {oldest[:10]}")
+    return " · ".join(parts)
 
 
 class SessionsPane(BasePane):
@@ -95,6 +102,15 @@ class SessionsPane(BasePane):
         bookmark_filter.setToolTip_("Show bookmarked only")
         view.addSubview_(bookmark_filter)
 
+        clear_stale = NSButton.alloc().initWithFrame_(NSMakeRect(_PAD + 392, toolbar_y - 1, 36, 24))
+        clear_stale.setTitle_("")
+        clear_stale.setImage_(sf_icon("trash", size=Font.SECONDARY))
+        clear_stale.setBezelStyle_(1)
+        clear_stale.setTarget_(self.delegate)
+        clear_stale.setAction_(objc.selector(self.delegate.historyClearStale_, signature=b"v@:@"))
+        clear_stale.setToolTip_("Clear entries whose session logs are gone")
+        view.addSubview_(clear_stale)
+
         # Separator
         separator_y = toolbar_y - Spacing.SM
         toolbar_separator = NSBox.alloc().initWithFrame_(NSMakeRect(_PAD, separator_y, self.width - _PAD * 2, 1))
@@ -129,10 +145,13 @@ def rebuild_rows(delegate: object) -> None:
         return
 
     w = scroll.frame().size.width
-    entries = [e.to_dict() for e in get_history_service().get_all()]
+    history_svc = get_history_service()
+    entries = [e.to_dict() for e in history_svc.get_all()]
     bookmark_svc = get_bookmark_service()
     summary_svc = get_summary_service()
     usage_svc = get_usage_service()
+
+    _queue_missing_titles(entries, summary_svc, history_svc)
 
     # Filter: bookmarked only
     if delegate._history_bookmarked_only:
@@ -147,7 +166,7 @@ def rebuild_rows(delegate: object) -> None:
             if search in proj:
                 filtered.append(e)
                 continue
-            cached = summary_svc.get_cached(e.get("cwd", ""))
+            cached = summary_svc.get_cached(e.get("cwd", ""), e.get("session_id", ""))
             if cached and search in cached.lower():
                 filtered.append(e)
         entries = filtered
@@ -186,11 +205,27 @@ def rebuild_rows(delegate: object) -> None:
                 usage_svc,
                 summary_svc,
                 display_project,
+                stale=not history_svc.logs_exist(entry.get("cwd", ""), entry.get("session_id", "")),
             )
 
     scroll.setDocumentView_(inner)
     inner.scrollPoint_((0, total_h))  # scroll to top (newest first)
     delegate._history_inner = inner
+
+
+def _queue_missing_titles(entries: list[dict], summary_svc: object, history_svc: object, limit: int = 30) -> None:
+    """Queue background title extraction for entries with nothing cached yet.
+
+    The summary thread fills them in; rows pick titles up on the next rebuild.
+    """
+    queued = 0
+    for e in entries:
+        if queued >= limit:
+            return
+        cwd, sid = e.get("cwd", ""), e.get("session_id", "")
+        if cwd and summary_svc.get_cached(cwd, sid) is None and history_svc.logs_exist(cwd, sid):  # type: ignore[attr-defined]
+            summary_svc.track_session(cwd, session_id=sid)  # type: ignore[attr-defined]
+            queued += 1
 
 
 def disambiguate_projects(entries: list[dict]) -> dict[str, str]:
@@ -252,6 +287,8 @@ def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001
     usage_svc: object,
     summary_svc: object,
     display_project: str = "",
+    *,
+    stale: bool = False,
 ) -> None:
     """Build a single history row using the SessionRow composite."""
 
@@ -270,7 +307,7 @@ def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001
     # Gather display data
     token_data = usage_svc.get_tokens(cwd)
     token_compact = format_tokens_compact(token_data)
-    cached_title = summary_svc.get_cached(cwd) if cwd else ""
+    cached_title = summary_svc.get_cached(cwd, session_id) if cwd else ""
 
     # Bookmark callback wiring — payload carries the raw project as identity.
     if is_pinned:
@@ -286,6 +323,7 @@ def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001
         model=model,
         ended_at=_relative_time(ended_at),
         bookmarked=is_pinned,
+        stale=stale,
         width=w,
         height=h,
         summary_title=cached_title or "",

--- a/tests/history/test_history.py
+++ b/tests/history/test_history.py
@@ -386,3 +386,44 @@ class TestSeedFiltersSynthetic:
             result = history._seed_from_jsonl()
 
         assert result[0]["model"] == "claude-opus-4-6"
+
+
+class TestStaleEntries:
+    """HistoryService.logs_exist / remove_stale — stale = session logs gone."""
+
+    def _service_with_entries(self, tmp_path, entries):
+        from claudewatch.backend.core.session_log.service import SessionLogService
+        from claudewatch.backend.history.service import HistoryService
+
+        fake_path = str(tmp_path / "history.json")
+        with open(fake_path, "w") as f:
+            json.dump(entries, f)
+        return HistoryService(SessionLogService()), fake_path
+
+    def test_logs_exist_true_when_session_file_present(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "sid-1.jsonl").write_text("{}\n")
+        svc, _ = self._service_with_entries(tmp_path, [])
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            assert svc.logs_exist("/Users/dev/myapp", "sid-1") is True
+            assert svc.logs_exist("/Users/dev/myapp", "sid-gone") is False
+            assert svc.logs_exist("/Users/dev/nowhere") is False
+
+    def test_remove_stale_keeps_live_entries(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-live"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "sid-live.jsonl").write_text("{}\n")
+        entries = [
+            {"session_id": "sid-live", "project": "live", "cwd": "/Users/dev/live", "ended_at": "2026-07-01"},
+            {"session_id": "sid-dead", "project": "dead", "cwd": "/Users/dev/dead", "ended_at": "2026-07-01"},
+        ]
+        svc, fake_path = self._service_with_entries(tmp_path, entries)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch.object(history, "_PATH", fake_path),
+        ):
+            removed = svc.remove_stale()
+            remaining = svc.get_all()
+        assert removed == 1
+        assert [e.cwd for e in remaining] == ["/Users/dev/live"]

--- a/tests/summary/test_summary_service.py
+++ b/tests/summary/test_summary_service.py
@@ -264,6 +264,25 @@ class TestGenerateAndCache:
             assert svc.generate_and_cache("/Users/dev/myapp", "gone") == ""
             assert svc.get_cached_summary("/Users/dev/myapp", "gone") is None
 
+    def test_caches_title_alone_when_no_recap_yet(self, tmp_path):
+        """Sessions without a recap still get their aiTitle cached for display."""
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "session.jsonl",
+            [
+                {"type": "ai-title", "aiTitle": "Refactor auth module"},
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}},
+            ],
+        )
+        svc = _make_service(tmp_path)
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            title = svc.generate_and_cache("/Users/dev/myapp")
+            assert title == "Refactor auth module"
+            assert svc.get_cached("/Users/dev/myapp") == "Refactor auth module"
+            # No recap content — the Summary submenu still shows its placeholder.
+            assert not svc.get_cached_summary("/Users/dev/myapp")
+
     def test_uses_ai_title_when_available(self, tmp_path):
         proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
         proj_dir.mkdir(parents=True)

--- a/tests/ui/composites/test_session_row.py
+++ b/tests/ui/composites/test_session_row.py
@@ -108,3 +108,8 @@ class TestSessionRowMetaLine:
     def test_no_meta_line_when_everything_empty(self) -> None:
         view = build_session_row(project="myproject", width=400, height=60)
         assert not any("·" in t for t in _label_texts(view))
+
+    def test_stale_row_notes_missing_logs(self) -> None:
+        view = build_session_row(project="myproject", ended_at="3d ago", stale=True, width=400, height=60)
+        meta = next(t for t in _label_texts(view) if "3d ago" in t)
+        assert meta == "3d ago · logs removed"


### PR DESCRIPTION
## Summary

Sessions pane UX: rows were ten bare '360privacy' lines with no per-session identity, dead entries (deleted worktrees) rendered as blank holes, and the header said only 'Since 2026-03-12'.

## Changes

- rows and search use `get_cached(cwd, session_id)` — per-session titles instead of the cwd-keyed lookup; uncached entries queue background title extraction (capped at 30/rebuild)
- `SummaryService.generate_and_cache` caches the aiTitle alone when no recap exists yet (recap replaces it on file growth)
- `HistoryService.logs_exist / remove_stale` (session_log wired via factory); stale rows dim + 'logs removed' in the meta line; toolbar trash button clears them after confirmation
- header: 'N sessions · M this week · since YYYY-MM-DD'

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] full suite: 878 passed
- [x] smoke: Preferences → Sessions with live + stale entries