### PR TITLE
fix: attention detection survives bookkeeping spam and claimed fallbacks

### DIFF
--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -306,9 +306,13 @@ class DetectionService(BaseService):
 
         # Scan in reverse. Track whether we've seen a tool_result (user entry)
         # AFTER the most recent assistant tool_use. If yes, the tool completed.
+        # Scan the whole tail: Claude Code writes many trailing bookkeeping
+        # entries — mode, permission-mode, attachment, queue-operation — that
+        # would push a pending tool_use past any fixed line window. The loop
+        # terminates at the first user, assistant, or progress entry anyway.
         seen_tool_result = False
 
-        for line in reversed(lines[-20:]):
+        for line in reversed(lines):
             try:
                 d = json.loads(line)
                 dtype = d.get("type")
@@ -490,9 +494,17 @@ class DetectionService(BaseService):
         for s in sessions:
             jpath = session_jsonl.get(s.pid)
             if jpath and not matched_by_title.get(s.pid) and jpath in claimed_paths:
-                session_jsonl[s.pid] = None
-                s.session_id = ""
-                s.ai_title = ""
+                # The most-recent unclaimed file is usually the unmatched
+                # session's own brand-new log — reading it keeps ATTENTION
+                # detection working (e.g. a first permission prompt) instead
+                # of going dark until an aiTitle appears.
+                replacement = next(
+                    (p for p in self._session_log_service.list_in_cwd(s.cwd) if p not in claimed_paths),
+                    None,
+                )
+                session_jsonl[s.pid] = replacement
+                s.session_id = self._get_session_id(s.cwd, replacement) if replacement else ""
+                s.ai_title = self._ai_title_by_path.get(replacement, "") if replacement else ""
 
         self._get_ide_tab_indices(sessions, all_ps)
 

--- a/tests/detection/test_attention_status.py
+++ b/tests/detection/test_attention_status.py
@@ -81,6 +81,35 @@ class TestPendingToolDetection:
         assert result.has_pending is True
         assert "Bash" in result.one_line
 
+    def test_pending_tool_survives_trailing_bookkeeping_entries(self, tmp_path: str) -> None:
+        """mode/permission-mode/attachment spam after a pending tool_use must not
+        push it out of the scan window — that read as IDLE instead of ATTENTION."""
+        service, jsonl_path = _make_service(tmp_path)
+        entries: list[dict] = [
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}],
+                },
+            },
+        ]
+        bookkeeping = [
+            {"type": "mode", "mode": "normal"},
+            {"type": "permission-mode", "permissionMode": "default"},
+            {"type": "attachment"},
+            {"type": "queue-operation", "operation": "dequeue"},
+            {"type": "pr-link"},
+            {"type": "ai-title", "aiTitle": "Some task"},
+        ]
+        for _ in range(6):
+            entries.extend(bookkeeping)
+        _write_jsonl(jsonl_path, entries, stale=True)
+
+        result = service._check_jsonl_for_pending_tool(_read_tail(jsonl_path))
+        assert result.has_pending is True
+        assert "Bash" in result.one_line
+
     def test_no_pending_when_user_responded(self, tmp_path: str) -> None:
         service, jsonl_path = _make_service(tmp_path)
         _write_jsonl(

--- a/tests/detection/test_detect_integration.py
+++ b/tests/detection/test_detect_integration.py
@@ -576,6 +576,55 @@ class TestDetectSharedCwdAttention:
             for p in svc._test_patchers:
                 p.stop()
 
+    def test_blocked_fallback_reassigns_to_own_unclaimed_file(self, tmp_path):
+        """When the most-recent JSONL is claimed by a title-matched sibling, an
+        unmatched session reads the most-recent UNCLAIMED file — usually its own
+        — so a first permission prompt still reaches ATTENTION."""
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+        # Session A: most recent file, title-matched.
+        _write_jsonl(
+            os.path.join(proj_dir, "active.jsonl"),
+            [
+                {"type": "ai-title", "aiTitle": "Fix claudewatch bugs"},
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}},
+            ],
+            age_seconds=10,
+        )
+        # Session B: brand new (no aiTitle yet), waiting on its first permission.
+        _write_jsonl(
+            os.path.join(proj_dir, "fresh.jsonl"),
+            [
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}]},
+                },
+            ],
+            age_seconds=30,
+        )
+        svc = _build_service(
+            str(tmp_path),
+            [100, 200],
+            pid_info={
+                100: ProcessInfo(tty="ttys001", ppid=1, comm="claude"),
+                200: ProcessInfo(tty="ttys002", ppid=1, comm="claude"),
+            },
+            pid_cwds={100: cwd, 200: cwd},
+            terminal_titles={
+                "/dev/ttys001": ("myapp — ✳ Fix claudewatch bugs — node ◂ claude", 1),
+                "/dev/ttys002": ("myapp — ✳ Claude Code", 2),
+            },
+        )
+        try:
+            sessions = svc.detect()
+            by_pid = {s.pid: s for s in sessions}
+            assert by_pid[200].status == SessionStatus.ATTENTION
+            assert by_pid[200].session_id == "fresh"
+            assert by_pid[100].status == SessionStatus.IDLE
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
     def test_brand_new_session_no_ai_title_falls_back(self, tmp_path):
         """Session with no aiTitle in window title falls back to most-recent JSONL."""
         cwd = "/Users/dev/myapp"


### PR DESCRIPTION
## Summary

Sessions waiting for permission sometimes showed Idle (yellow) instead of Attention. Two causes: the pending-tool scan only looked at the last 20 lines, and current Claude Code writes enough trailing bookkeeping entries (mode, permission-mode, attachment, queue-operation) to push a pending tool_use past that window; and unmatched sessions whose fallback JSONL was claimed by a sibling got no JSONL at all, so they could never reach ATTENTION.

## Changes

- `_check_jsonl_for_pending_tool` scans the whole 10KB tail — the loop already stops at the first user/assistant/progress entry, so bookkeeping entries no longer eat the window
- a blocked fallback reassigns to the most-recent UNCLAIMED file in the CWD (usually the unmatched session's own brand-new log) instead of nothing — first permission prompts reach ATTENTION again

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] full suite: 876 passed
- [x] regression tests: pending tool_use behind 36 bookkeeping entries; fresh session's own file reclaimed for attention