### PR TITLE
fix: pair unmatched sessions with logs by process start vs file birth time

### DIFF
--- a/claudewatch/backend/core/process/procinfo.py
+++ b/claudewatch/backend/core/process/procinfo.py
@@ -34,10 +34,13 @@ _PTY_MAJOR = 16  # pseudo-terminal major device number
 
 # Struct offsets — verified empirically on macOS ARM64.
 # proc_pidinfo(PROC_PIDTASKALLINFO) returns 232 bytes.
-# Fields from proc_bsdinfo: ppid @ offset 16, tdev @ offset 108.
+# Fields from proc_bsdinfo: ppid @ offset 16, tdev @ offset 108,
+# pbi_start_tvsec @ 120 / pbi_start_tvusec @ 128 (both uint64).
 _TASKALLINFO_SIZE = 232
 _PBSD_PPID_OFFSET = 16
 _PBSD_TDEV_OFFSET = 108
+_PBSD_START_SEC_OFFSET = 120
+_PBSD_START_USEC_OFFSET = 128
 
 # proc_vnodepathinfo: the CWD vnode path starts at the vip_path field.
 # struct vnode_info_path = vnode_info (152 bytes) + path[MAXPATHLEN]
@@ -127,6 +130,18 @@ def _dev_to_tty(dev: int) -> str:
 
 
 # Public API
+
+
+def get_start_time(pid: int) -> float:
+    """Process start time as a Unix timestamp. Returns 0.0 on failure."""
+    info_buf = ctypes.create_string_buffer(_TASKALLINFO_SIZE)
+    ret = _libproc.proc_pidinfo(pid, PROC_PIDTASKALLINFO, 0, ctypes.byref(info_buf), _TASKALLINFO_SIZE)
+    if ret < _TASKALLINFO_SIZE:
+        return 0.0
+    raw = info_buf.raw
+    sec = int.from_bytes(raw[_PBSD_START_SEC_OFFSET : _PBSD_START_SEC_OFFSET + 8], "little")
+    usec = int.from_bytes(raw[_PBSD_START_USEC_OFFSET : _PBSD_START_USEC_OFFSET + 8], "little")
+    return sec + usec / 1_000_000
 
 
 def get_process_info(pids: list[int]) -> dict[int, ProcessInfo]:

--- a/claudewatch/backend/core/process/service.py
+++ b/claudewatch/backend/core/process/service.py
@@ -42,6 +42,10 @@ class ProcessService(BaseService):
         """Get the parent PID for a single process. Returns 0 on failure."""
         return procinfo.get_ppid(pid)
 
+    def get_start_time(self, pid: int) -> float:
+        """Process start time as a Unix timestamp. Returns 0.0 on failure."""
+        return procinfo.get_start_time(pid)
+
     def get_single_info(self, pid: int) -> ProcessInfo | None:
         """Get tty, ppid, and comm for a single PID. Returns None on failure."""
         return procinfo.get_single_process_info(pid)

--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -29,6 +29,7 @@ _TERMINAL_CACHE_TTL = 3  # seconds between AppleScript refreshes
 _AI_TITLE_CACHE_TTL = 3  # seconds between per-CWD ai-title scans
 _WORKTREE_CACHE_TTL = 30  # seconds between per-CWD worktree re-resolution
 _JSONL_STREAMING_THRESHOLD = 5  # JSONL modified within this → actively streaming
+_BIRTHTIME_SLACK = 5.0  # clock slack when comparing file birth to process start
 _JSONL_IDLE_THRESHOLD = 60  # JSONL not modified within this → definitely idle
 
 
@@ -406,15 +407,11 @@ class DetectionService(BaseService):
             if stale_cwd not in live_cwds:
                 del self._worktree_cache[stale_cwd]
 
-        # Per-CWD fallback (most-recent JSONL) when ai-title matching can't
-        # disambiguate a session. Built lazily.
-        cwd_fallback_jsonl: dict[str, str | None] = {}
         # Per-session JSONL path — keyed by PID. With shared-CWD setups the
         # most-recent file in the project dir often belongs to a sibling
-        # session, so we match on aiTitle from the window title instead.
+        # session, so we match on aiTitle from the window title first and
+        # pair the rest by process start time vs file birth time below.
         session_jsonl: dict[int, str | None] = {}
-        # pid → whether its JSONL was matched via aiTitle (vs the most-recent fallback)
-        matched_by_title: dict[int, bool] = {}
 
         sessions = []
         for pid in pids:
@@ -461,12 +458,8 @@ class DetectionService(BaseService):
 
             status = _determine_status(window_title)
 
-            if cwd not in cwd_fallback_jsonl:
-                cwd_fallback_jsonl[cwd] = self._session_log_service.find_most_recent(cwd)
-            fallback = cwd_fallback_jsonl[cwd]
-            jpath, title_matched = _match_jsonl_by_title(window_title, self._get_ai_title_map(cwd), fallback)
-            session_jsonl[pid] = jpath
-            matched_by_title[pid] = title_matched
+            jpath, title_matched = _match_jsonl_by_title(window_title, self._get_ai_title_map(cwd), None)
+            session_jsonl[pid] = jpath if title_matched else None
             worktree = self._get_worktree(cwd)
 
             sessions.append(
@@ -479,32 +472,36 @@ class DetectionService(BaseService):
                     window_title=window_title,
                     window_id=window_id,
                     status=status,
-                    session_id=self._get_session_id(cwd, jpath),
-                    ai_title=self._ai_title_by_path.get(jpath, "") if jpath else "",
+                    session_id=self._get_session_id(cwd, jpath) if title_matched and jpath else "",
+                    ai_title=self._ai_title_by_path.get(jpath, "") if title_matched and jpath else "",
                     worktree_repo=worktree.repo if worktree else "",
                     worktree_branch=worktree.branch if worktree else "",
                 )
             )
 
-        # A fallback JSONL that another session already claimed via title match
-        # belongs to that session. Dressing an unmatched session in it would
-        # mirror the sibling's title, status, and summary — show it plainly
-        # (no session id, title-only status) until its own aiTitle appears.
-        claimed_paths = {session_jsonl[s.pid] for s in sessions if matched_by_title.get(s.pid) and session_jsonl[s.pid]}
-        for s in sessions:
-            jpath = session_jsonl.get(s.pid)
-            if jpath and not matched_by_title.get(s.pid) and jpath in claimed_paths:
-                # The most-recent unclaimed file is usually the unmatched
-                # session's own brand-new log — reading it keeps ATTENTION
-                # detection working (e.g. a first permission prompt) instead
-                # of going dark until an aiTitle appears.
-                replacement = next(
-                    (p for p in self._session_log_service.list_in_cwd(s.cwd) if p not in claimed_paths),
-                    None,
-                )
-                session_jsonl[s.pid] = replacement
-                s.session_id = self._get_session_id(s.cwd, replacement) if replacement else ""
-                s.ai_title = self._ai_title_by_path.get(replacement, "") if replacement else ""
+        # Pair unmatched sessions with logs they could actually own. A session's
+        # JSONL is created when the session starts, so files born before the
+        # process belong to someone else — including dead sessions whose
+        # unresolved tool_use would otherwise read as phantom ATTENTION on
+        # every unmatched session. Each file is claimed at most once; newest
+        # sessions pick first so fresh sessions pair with fresh logs.
+        claimed_paths = {p for p in session_jsonl.values() if p}
+        unmatched = [s for s in sessions if not session_jsonl.get(s.pid)]
+        starts = {s.pid: self._process_service.get_start_time(s.pid) for s in unmatched}
+        for s in sorted(unmatched, key=lambda x: starts[x.pid], reverse=True):
+            candidate = None
+            for path in self._session_log_service.list_in_cwd(s.cwd):
+                if path in claimed_paths:
+                    continue
+                if starts[s.pid] and _file_birthtime(path) < starts[s.pid] - _BIRTHTIME_SLACK:
+                    continue
+                candidate = path
+                break
+            if candidate:
+                claimed_paths.add(candidate)
+                session_jsonl[s.pid] = candidate
+                s.session_id = self._get_session_id(s.cwd, candidate)
+                s.ai_title = self._ai_title_by_path.get(candidate, "")
 
         self._get_ide_tab_indices(sessions, all_ps)
 
@@ -553,6 +550,15 @@ class DetectionService(BaseService):
             # else: title confirms IDLE or WORKING — trust it
 
         return sessions
+
+
+def _file_birthtime(path: str) -> float:
+    """File creation time (mtime fallback). Returns 0.0 when unreadable."""
+    try:
+        st = os.stat(path)
+    except OSError:
+        return 0.0
+    return getattr(st, "st_birthtime", st.st_mtime)
 
 
 def _is_claude_cli(comm: str) -> bool:

--- a/tests/detection/test_detect_integration.py
+++ b/tests/detection/test_detect_integration.py
@@ -54,6 +54,7 @@ def _build_service(  # noqa: PLR0913
     process_service.get_cwds.return_value = pid_cwds or {}
     process_service.get_child_pids.return_value = child_pids or set()
     process_service.get_single_info.return_value = None
+    process_service.get_start_time.return_value = 0.0
     process_service.list_all.return_value = []
 
     session_log = SessionLogService()
@@ -621,6 +622,76 @@ class TestDetectSharedCwdAttention:
             assert by_pid[200].status == SessionStatus.ATTENTION
             assert by_pid[200].session_id == "fresh"
             assert by_pid[100].status == SessionStatus.IDLE
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
+    def test_dead_sessions_pending_file_is_not_a_magnet(self, tmp_path):
+        """A dead session's JSONL ending in an unresolved tool_use must not be
+        inherited by sessions started after it — that showed phantom ATTENTION
+        rows duplicating the dead session's title."""
+        import time as _time
+
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+        _write_jsonl(
+            os.path.join(proj_dir, "dead.jsonl"),
+            [
+                {"type": "ai-title", "aiTitle": "Set up Sentry CLI"},
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {"command": "source x"}}]},
+                },
+            ],
+            age_seconds=300,
+        )
+        svc = _build_service(
+            str(tmp_path),
+            [100],
+            pid_info={100: ProcessInfo(tty="ttys001", ppid=1, comm="claude")},
+            pid_cwds={100: cwd},
+            terminal_titles={"/dev/ttys001": ("myapp — ✳ Claude Code", 1)},
+        )
+        # This process started after the dead session's file was created.
+        svc._process_service.get_start_time.return_value = _time.time() + 60
+        try:
+            sessions = svc.detect()
+            assert sessions[0].status == SessionStatus.IDLE
+            assert sessions[0].session_id == ""
+            assert sessions[0].ai_title == ""
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
+    def test_two_unmatched_sessions_pair_with_distinct_files(self, tmp_path):
+        """Two sessions without title matches must not render as duplicates of
+        one file — each claims its own log."""
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+        for name in ("first.jsonl", "second.jsonl"):
+            _write_jsonl(
+                os.path.join(proj_dir, name),
+                [{"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}}],
+                age_seconds=120,
+            )
+        svc = _build_service(
+            str(tmp_path),
+            [100, 200],
+            pid_info={
+                100: ProcessInfo(tty="ttys001", ppid=1, comm="claude"),
+                200: ProcessInfo(tty="ttys002", ppid=1, comm="claude"),
+            },
+            pid_cwds={100: cwd, 200: cwd},
+            terminal_titles={
+                "/dev/ttys001": ("myapp — ✳ Claude Code", 1),
+                "/dev/ttys002": ("myapp — ✳ Claude Code", 2),
+            },
+        )
+        try:
+            sessions = svc.detect()
+            sids = [s.session_id for s in sessions]
+            assert all(sids)
+            assert len(set(sids)) == 2
         finally:
             for p in svc._test_patchers:
                 p.stop()


### PR DESCRIPTION
## Summary

Duplicate menu rows (same title, both ATTENTION) for one real session. Root cause: sessions without an aiTitle match — IDE sessions especially, since their window titles carry no task — all fell back to the CWD's most-recent JSONL. A dead session's log ending in an unresolved tool_use acts as a magnet: every unmatched session inherits its title and phantom ATTENTION.

## Changes

- `procinfo.get_start_time(pid)` — `pbi_start_tvsec/usec` from PROC_PIDTBSDINFO (offsets verified against `ps lstart` to the microsecond)
- unmatched sessions pair with the newest **unclaimed** file **born after the process started** (a session's log is created with it); each file claimed at most once, newest sessions pick first
- dead sessions' files pair with nobody; two unmatched sessions get distinct files or show plainly

## Test plan

- [x] `ruff check .` clean
- [x] `python3 scripts/audit_imports.py --check` clean
- [x] full suite: 882 passed
- [x] live: 14 sessions, zero duplicate ids, three PyCharm tabs distinct, dead Sentry-CLI log inherited by nobody