### PR TITLE
fix: detect permission dialogs from the Terminal screen, not just JSONL

### DIFF
--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 import subprocess
 import time
 
@@ -55,6 +56,8 @@ class DetectionService(BaseService):
         self._host_app_cache: dict[int, HostApp] = {}
         self._terminal_cache: dict[str, tuple[str, int]] | None = None
         self._terminal_cache_time: float = 0
+        # (requested ttys key, {tty: visible screen}, timestamp)
+        self._buffer_cache: tuple[str, dict[str, str], float] | None = None
         # cwd → ({ai_title: jsonl_path}, timestamp). Lets each session in a shared
         # CWD read its own JSONL instead of the most-recent one for the project.
         self._ai_title_cache: dict[str, tuple[dict[str, str], float]] = {}
@@ -115,6 +118,59 @@ class DetectionService(BaseService):
         self._terminal_cache = windows
         self._terminal_cache_time = now
         return windows
+
+    def _get_terminal_buffers(self, targets: list[tuple[str, int]]) -> dict[str, str]:
+        """Visible screen contents for (tty, window_id) Terminal.app tabs.
+
+        One AppleScript pass, cached for _TERMINAL_CACHE_TTL seconds. Only
+        inline reference chains are used — stored tab references fail to
+        dereference their properties — and addressing by window id skips
+        ghost windows entirely. TTY names are validated (ttysNNN only) and
+        window ids are ints, so the script receives no untrusted input.
+        """
+        now = time.time()
+        wanted = sorted(
+            {(t, int(w)) for t, w in targets if re.fullmatch(r"ttys[0-9]+", t or "")},
+        )
+        if not wanted:
+            return {}
+        cache_key = ",".join(f"{t}:{w}" for t, w in wanted)
+        if (
+            self._buffer_cache is not None
+            and self._buffer_cache[0] == cache_key
+            and now - self._buffer_cache[2] < _TERMINAL_CACHE_TTL
+        ):
+            return self._buffer_cache[1]
+
+        tty_list = ", ".join(f'"/dev/{t}"' for t, _ in wanted)
+        wid_list = ", ".join(str(w) for w in sorted({w for _, w in wanted}))
+        result = run_applescript(f"""
+        if application "Terminal" is running then
+            tell application "Terminal"
+                set wantedTtys to {{{tty_list}}}
+                set output to ""
+                repeat with wid in {{{wid_list}}}
+                    try
+                        set tabCount to count of tabs of window id wid
+                        repeat with i from 1 to tabCount
+                            if wantedTtys contains (tty of tab i of window id wid) then
+                                set output to output & "<<TTY:" & (tty of tab i of window id wid) & ">>" & (contents of tab i of window id wid)
+                            end if
+                        end repeat
+                    end try
+                end repeat
+                return output
+            end tell
+        end if
+        return ""
+        """)
+
+        buffers: dict[str, str] = {}
+        for chunk in result.split("<<TTY:/dev/")[1:]:
+            name, _, body = chunk.partition(">>")
+            buffers[name] = body
+        self._buffer_cache = (cache_key, buffers, now)
+        return buffers
 
     # -- Host app detection -------------------------------------------------
 
@@ -549,7 +605,48 @@ class DetectionService(BaseService):
                 s.status = jsonl_status
             # else: title confirms IDLE or WORKING — trust it
 
+        # Claude Code no longer writes the pending tool_use to the JSONL until
+        # the permission decision is made, so the JSONL alone can't see a
+        # waiting dialog. For Terminal sessions the dialog is on the visible
+        # screen — read it and upgrade to ATTENTION.
+        idle_terminal = [
+            s
+            for s in sessions
+            if s.host_app == HostApp.TERMINAL and s.status != SessionStatus.WORKING and s.tty and s.window_id
+        ]
+        if idle_terminal:
+            buffers = self._get_terminal_buffers([(s.tty, s.window_id) for s in idle_terminal])
+            for s in idle_terminal:
+                prompt = _buffer_prompt_line(buffers.get(s.tty, ""))
+                if prompt:
+                    s.status = SessionStatus.ATTENTION
+                    s.prompt_text = prompt
+
         return sessions
+
+
+_DIALOG_QUESTION_RE = re.compile(r"(?m)^\s*(.*Do you (?:want|trust).*?)\s*$")
+_DIALOG_OPTION_RE = re.compile(r"(?m)^\s*❯?\s*1\.\s")
+_DIALOG_TOOL_RE = re.compile(r"(?m)^\s*⏺\s*(\S.*?)\s*$")
+
+
+def _buffer_prompt_line(buffer_text: str) -> str:
+    """One-line description when the visible screen shows an input dialog.
+
+    Matches permission prompts, edit confirmations, trust prompts, and
+    numbered-choice dialogs. Returns "" when the screen shows no dialog.
+    """
+    if not buffer_text:
+        return ""
+    question = _DIALOG_QUESTION_RE.search(buffer_text)
+    has_choices = _DIALOG_OPTION_RE.search(buffer_text) and "2." in buffer_text and "sc to" in buffer_text
+    if not question and not has_choices:
+        return ""
+    tool_lines = _DIALOG_TOOL_RE.findall(buffer_text)
+    line = tool_lines[-1] if tool_lines else (question.group(1) if question else "Waiting for your input")
+    if len(line) > _TEXT_MAX_LEN:
+        line = line[: _TEXT_MAX_LEN - 3] + "..."
+    return line
 
 
 def _file_birthtime(path: str) -> float:

--- a/tests/detection/test_attention_status.py
+++ b/tests/detection/test_attention_status.py
@@ -12,7 +12,7 @@ import os
 import time
 
 from claudewatch.backend.core.models import SessionStatus
-from claudewatch.backend.detection.service import DetectionService, _match_jsonl_by_title
+from claudewatch.backend.detection.service import DetectionService, _buffer_prompt_line, _match_jsonl_by_title
 
 _STALE_AGE = 10  # seconds — old enough that the pending check runs
 
@@ -369,3 +369,27 @@ class TestMatchJsonlByTitle:
 
     def test_returns_fallback_when_fallback_is_none(self):
         assert _match_jsonl_by_title("x", {}, None) == (None, False)
+
+
+class TestBufferPromptLine:
+    """Dialog signatures on the visible Terminal screen."""
+
+    def test_permission_dialog_returns_tool_line(self):
+        screen = (
+            "⏺ Bash(touch probe.txt)\n  ⎿  Waiting…\n Bash command\n"
+            " Do you want to proceed?\n ❯ 1. Yes\n   2. No\n Esc to cancel\n"
+        )
+        assert "Bash(touch probe.txt)" in _buffer_prompt_line(screen)
+
+    def test_trust_prompt_detected(self):
+        screen = " Do you trust the files in this folder?\n ❯ 1. Yes, proceed\n   2. No, exit\n"
+        assert "Do you trust" in _buffer_prompt_line(screen)
+
+    def test_numbered_choices_with_esc_detected(self):
+        screen = "Which option?\n ❯ 1. First\n   2. Second\n Esc to skip\n"
+        assert _buffer_prompt_line(screen) == "Waiting for your input"
+
+    def test_plain_output_is_not_a_dialog(self):
+        assert _buffer_prompt_line("⏺ done\n❯ \n? for shortcuts") == ""
+        assert _buffer_prompt_line("1. first thing I did\n2. second thing\n") == ""
+        assert _buffer_prompt_line("") == ""

--- a/tests/detection/test_detect_integration.py
+++ b/tests/detection/test_detect_integration.py
@@ -60,8 +60,9 @@ def _build_service(  # noqa: PLR0913
     session_log = SessionLogService()
     service = DetectionService(process_service, session_log)
 
-    # Mock the terminal lookup to skip AppleScript entirely
+    # Mock the terminal lookups to skip AppleScript entirely
     service._get_terminal_windows = MagicMock(return_value=terminal_titles or {})  # type: ignore[method-assign]
+    service._get_terminal_buffers = MagicMock(return_value={})  # type: ignore[method-assign]
 
     # Patch CLAUDE_PROJECTS_DIR so find_most_recent / read_tail hit the tmp dir
     patcher = patch(
@@ -172,6 +173,98 @@ class TestDetectWorktreeSession:
             assert sessions[0].worktree_repo == "myrepo"
             assert sessions[0].worktree_branch == "feature-x"
             assert "myrepo [feature-x]" in sessions[0].menu_label
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
+
+class TestDetectBufferDialog:
+    """Permission dialogs are detected from the visible Terminal screen —
+    Claude Code no longer writes the pending tool_use to the JSONL first."""
+
+    DIALOG = (
+        "⏺ Bash(touch /private/tmp/cwtest/probe.txt)\n"
+        "  ⎿  Waiting…\n"
+        "────────────────\n"
+        " Bash command\n"
+        " touch /private/tmp/cwtest/probe.txt\n"
+        " Create empty probe.txt file\n"
+        "\n"
+        " Do you want to proceed?\n"
+        " ❯ 1. Yes\n"
+        "   2. Yes, and always allow access to cwtest/ from this project\n"
+        "   3. No\n"
+        " Esc to cancel · Tab to amend · ctrl+e to explain\n"
+    )
+
+    def test_idle_session_with_dialog_on_screen_is_attention(self, tmp_path):
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+        # JSONL shows nothing pending — the CLI hasn't written the tool_use yet.
+        _write_jsonl(
+            os.path.join(proj_dir, "s1.jsonl"),
+            [{"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}}],
+            age_seconds=120,
+        )
+        svc = _build_service(
+            str(tmp_path),
+            [100],
+            pid_info={100: ProcessInfo(tty="ttys001", ppid=1, comm="claude")},
+            pid_cwds={100: cwd},
+            terminal_titles={"/dev/ttys001": ("myapp — ✳ Claude Code", 1)},
+        )
+        svc._get_terminal_buffers = MagicMock(return_value={"ttys001": self.DIALOG})
+        try:
+            sessions = svc.detect()
+            assert sessions[0].status == SessionStatus.ATTENTION
+            assert "Bash(touch" in sessions[0].prompt_text
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
+    def test_plain_idle_screen_stays_idle(self, tmp_path):
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+        _write_jsonl(
+            os.path.join(proj_dir, "s1.jsonl"),
+            [{"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}}],
+            age_seconds=120,
+        )
+        svc = _build_service(
+            str(tmp_path),
+            [100],
+            pid_info={100: ProcessInfo(tty="ttys001", ppid=1, comm="claude")},
+            pid_cwds={100: cwd},
+            terminal_titles={"/dev/ttys001": ("myapp — ✳ Claude Code", 1)},
+        )
+        svc._get_terminal_buffers = MagicMock(return_value={"ttys001": "⏺ done\n❯ \n? for shortcuts"})
+        try:
+            sessions = svc.detect()
+            assert sessions[0].status == SessionStatus.IDLE
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
+    def test_working_session_skips_buffer_check(self, tmp_path):
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+        _write_jsonl(
+            os.path.join(proj_dir, "s1.jsonl"),
+            [{"type": "assistant", "message": {"content": [{"type": "text", "text": "..."}]}}],
+        )
+        svc = _build_service(
+            str(tmp_path),
+            [100],
+            pid_info={100: ProcessInfo(tty="ttys001", ppid=1, comm="claude")},
+            pid_cwds={100: cwd},
+            terminal_titles={"/dev/ttys001": ("myapp — ⠂ streaming", 1)},
+        )
+        buffers = MagicMock(return_value={"ttys001": self.DIALOG})
+        svc._get_terminal_buffers = buffers
+        try:
+            sessions = svc.detect()
+            assert sessions[0].status == SessionStatus.WORKING
+            buffers.assert_not_called()
         finally:
             for p in svc._test_patchers:
                 p.stop()


### PR DESCRIPTION
## Summary

ATTENTION never fired on current Claude Code. Proven by driving a real `claude` session into a permission prompt via a PTY: with the dialog on screen, the JSONL contains **no tool_use entry at all** — CLI 2.1.170 defers writing the assistant message until after the permission decision. The pending-tool_use heuristic (the app's core attention signal) is structurally dead against this CLI.

## Changes

- `_get_terminal_buffers`: one batched AppleScript per poll fetching visible screen contents for idle Terminal sessions, addressed inline by window id (stored tab references fail to dereference; window-id addressing also skips ghost windows). TTYs regex-validated, window ids are ints.
- `_buffer_prompt_line`: matches permission/edit/trust prompts and numbered-choice dialogs; extracts the `⏺ Tool(args)` line as the prompt text
- idle Terminal sessions with a dialog on screen upgrade to ATTENTION; JSONL heuristic retained (still fires for in-flight tools and older CLIs)
- known gap: IDE-hosted sessions have no readable screen, so their permission prompts stay invisible until the CLI writes something — noted for a future hook-based signal

## Test plan

- [x] `ruff check .` clean, import audit clean
- [x] full suite: 889 passed
- [x] fixture is the real captured dialog from the PTY probe
- [x] live: caught an actual permission dialog on a running session (`Bash(gh api …)`) as ATTENTION end-to-end