### PR TITLE
fix: unpaired sessions default to idle; resumed sessions pair via fresh mtime

### DIFF
--- a/claudewatch/backend/detection/service.py
+++ b/claudewatch/backend/detection/service.py
@@ -549,7 +549,11 @@ class DetectionService(BaseService):
             for path in self._session_log_service.list_in_cwd(s.cwd):
                 if path in claimed_paths:
                     continue
-                if starts[s.pid] and _file_birthtime(path) < starts[s.pid] - _BIRTHTIME_SLACK:
+                start = starts[s.pid]
+                if start and _file_birthtime(path) < start - _BIRTHTIME_SLACK and _file_mtime(path) < start:
+                    # Born before this process and untouched since it started —
+                    # someone else's log. (A resumed session appends to a file
+                    # born earlier, so a fresh mtime still qualifies it.)
                     continue
                 candidate = path
                 break
@@ -572,6 +576,13 @@ class DetectionService(BaseService):
                 continue
             jpath = session_jsonl.get(s.pid)
             cache_key = jpath or ""
+            if jpath is None:
+                # No log evidence at all (nothing pairable) — that's idle,
+                # not working. Title indicators still override below.
+                path_status_cache.setdefault(
+                    cache_key,
+                    (PendingToolResult(has_pending=False, one_line="", context=""), SessionStatus.IDLE),
+                )
             if cache_key not in path_status_cache:
                 tail, age = self._read_jsonl_tail(jpath)
                 if 0 <= age < _JSONL_STREAMING_THRESHOLD:
@@ -656,6 +667,14 @@ def _file_birthtime(path: str) -> float:
     except OSError:
         return 0.0
     return getattr(st, "st_birthtime", st.st_mtime)
+
+
+def _file_mtime(path: str) -> float:
+    """File modification time. Returns 0.0 when unreadable."""
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return 0.0
 
 
 def _is_claude_cli(comm: str) -> bool:

--- a/tests/detection/test_detect_integration.py
+++ b/tests/detection/test_detect_integration.py
@@ -756,6 +756,65 @@ class TestDetectSharedCwdAttention:
             for p in svc._test_patchers:
                 p.stop()
 
+    def test_unpaired_session_defaults_to_idle_not_working(self, tmp_path):
+        """A session with no pairable log must not show as actively working —
+        resumed IDE sessions sat green forever on the empty-tail bias."""
+        import time as _time
+
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+        _write_jsonl(
+            os.path.join(proj_dir, "old.jsonl"),
+            [{"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}}],
+            age_seconds=300,
+        )
+        svc = _build_service(
+            str(tmp_path),
+            [100],
+            pid_info={100: ProcessInfo(tty="ttys001", ppid=1, comm="claude")},
+            pid_cwds={100: cwd},
+            terminal_titles={"/dev/ttys001": ("myapp — no indicator", 1)},
+        )
+        svc._process_service.get_start_time.return_value = _time.time() + 60
+        try:
+            sessions = svc.detect()
+            assert sessions[0].session_id == ""
+            assert sessions[0].status == SessionStatus.IDLE
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
+    def test_resumed_session_pairs_via_fresh_mtime(self, tmp_path):
+        """A resumed session appends to a file born before the process —
+        a fresh mtime qualifies it for pairing."""
+        import time as _time
+
+        cwd = "/Users/dev/myapp"
+        proj_dir = _cwd_to_proj_dir(str(tmp_path), cwd)
+        _write_jsonl(
+            os.path.join(proj_dir, "resumed.jsonl"),
+            [{"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}}],
+            age_seconds=30,  # written after the process started
+        )
+        svc = _build_service(
+            str(tmp_path),
+            [100],
+            pid_info={100: ProcessInfo(tty="ttys001", ppid=1, comm="claude")},
+            pid_cwds={100: cwd},
+            terminal_titles={"/dev/ttys001": ("myapp — ✳ Claude Code", 1)},
+        )
+        svc._process_service.get_start_time.return_value = _time.time() - 3600
+        try:
+            with patch(
+                "claudewatch.backend.detection.service._file_birthtime",
+                return_value=_time.time() - 7200,  # born long before the process
+            ):
+                sessions = svc.detect()
+            assert sessions[0].session_id == "resumed"
+        finally:
+            for p in svc._test_patchers:
+                p.stop()
+
     def test_two_unmatched_sessions_pair_with_distinct_files(self, tmp_path):
         """Two sessions without title matches must not render as duplicates of
         one file — each claims its own log."""


### PR DESCRIPTION
## Summary

A resumed PyCharm session showed green (WORKING) while idle. Resumed sessions append to a JSONL born before the process, so the birthtime pairing rule excluded every candidate file — and unpaired sessions fell into an empty-tail 'assume working' bias with no title indicator to correct it.

## Changes

- pairing also accepts an unclaimed file whose **mtime is newer than the process start** — touched during this session's lifetime. Dead siblings' files stop updating before newer sessions start, so the phantom-attention magnet stays dead.
- sessions with nothing pairable default to IDLE — no log evidence is not evidence of work; title indicators still override

## Test plan

- [x] `ruff check .` clean, import audit clean
- [x] full suite: 892 passed
- [x] live: the offending resumed session now pairs with its real file and shows IDLE; both PyCharm tabs carry distinct correct titles