### PR TITLE
fix: key history by session id so multiple sessions per cwd are kept

### DIFF
--- a/claudewatch/backend/history/repository.py
+++ b/claudewatch/backend/history/repository.py
@@ -83,11 +83,14 @@ def _save(entries: list[_HistoryRecord]) -> None:
 
 
 def record_session(session_id: str, project: str, cwd: str, model: str, host_app: str) -> None:
-    """Record a session when it ends. Deduplicates by CWD (keeps latest)."""
+    """Record a session when it ends. Deduplicates by session id (CWD for legacy entries without one)."""
     with _LOCK:
         entries = _load()
         ts = datetime.now(tz=UTC).isoformat()
-        entries = [e for e in entries if e["cwd"] != cwd]
+        if session_id:
+            entries = [e for e in entries if e.get("session_id") != session_id]
+        else:
+            entries = [e for e in entries if e.get("session_id") or e["cwd"] != cwd]
         entries.append(
             _HistoryRecord(
                 session_id=session_id,
@@ -182,9 +185,12 @@ def _seed_from_jsonl() -> list[_HistoryRecord]:
     return entries
 
 
-def remove_history_entry(cwd: str) -> None:
-    """Remove a history entry by CWD."""
+def remove_history_entry(session_id: str, cwd: str = "") -> None:
+    """Remove a history entry by session id (CWD match for legacy entries without one)."""
     with _LOCK:
         entries = _load()
-        entries = [e for e in entries if e["cwd"] != cwd]
+        if session_id:
+            entries = [e for e in entries if e.get("session_id") != session_id]
+        else:
+            entries = [e for e in entries if e.get("session_id") or e["cwd"] != cwd]
         _save(entries)

--- a/claudewatch/backend/history/service.py
+++ b/claudewatch/backend/history/service.py
@@ -34,7 +34,7 @@ class HistoryService(BaseService):
         """Remove entries whose session logs no longer exist. Returns count removed."""
         stale = [e for e in self.get_all() if not self.logs_exist(e.cwd, e.session_id)]
         for entry in stale:
-            history_repo.remove_history_entry(entry.cwd)
+            history_repo.remove_history_entry(entry.session_id, entry.cwd)
         if stale:
             self._invalidate()
         return len(stale)
@@ -51,9 +51,9 @@ class HistoryService(BaseService):
                 self._cache = history_repo.get_history()
             return list(self._cache)
 
-    def remove(self, cwd: str) -> None:
-        """Remove a history entry by CWD."""
-        history_repo.remove_history_entry(cwd)
+    def remove(self, session_id: str, cwd: str = "") -> None:
+        """Remove a history entry by session id (CWD match for legacy entries without one)."""
+        history_repo.remove_history_entry(session_id, cwd)
         self._invalidate()
 
     def warm(self) -> None:

--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -253,7 +253,7 @@ class MenuBuilder:
                 actions = SessionActions(
                     activity=self._app._make_history_activity_handler(entry.project, entry.cwd),
                     resume=self._app._make_resume_handler(entry.session_id, entry.cwd) if entry.session_id else None,
-                    remove=self._app._make_remove_history_handler(entry.cwd),
+                    remove=self._app._make_remove_history_handler(entry.session_id, entry.cwd),
                     track_summary=lambda cwd=entry.cwd, sid=entry.session_id: self._app._summary_service.track_session(
                         cwd, session_id=sid or ""
                     ),

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -529,9 +529,9 @@ class ClaudeWatchApp:
 
         return handler
 
-    def _make_remove_history_handler(self, cwd: str) -> MenuCallback:
+    def _make_remove_history_handler(self, session_id: str, cwd: str = "") -> MenuCallback:
         def handler(_: NSMenuItem) -> None:
-            self._history_service.remove(cwd)
+            self._history_service.remove(session_id, cwd)
             self._last_menu_key = ""
             self.update_display()
 

--- a/claudewatch/ui/preferences/handlers/history.py
+++ b/claudewatch/ui/preferences/handlers/history.py
@@ -110,8 +110,9 @@ def handle_unbookmark(delegate: object, sender: object) -> None:
 
 
 def handle_delete(delegate: object, sender: object) -> None:
-    """Delete a history entry with confirmation."""
-    cwd = get_represented_object(sender)
+    """Delete a history entry with confirmation. Payload is 'session_id|cwd' (or bare cwd)."""
+    data = get_represented_object(sender)
+    sid, cwd = data.split("|", 1) if "|" in data else ("", data)
     NSApplication.sharedApplication().activateIgnoringOtherApps_(True)
     alert = NSAlert.alloc().init()
     alert.setMessageText_("Delete this session from history?")
@@ -119,7 +120,7 @@ def handle_delete(delegate: object, sender: object) -> None:
     alert.addButtonWithTitle_("Delete")
     alert.addButtonWithTitle_("Cancel")
     if alert.runModal() == NSAlertFirstButtonReturn:
-        get_history_service().remove(cwd)
+        get_history_service().remove(sid, cwd)
         from claudewatch.ui.preferences.panes.sessions import rebuild_rows
 
         rebuild_rows(delegate)

--- a/claudewatch/ui/preferences/panes/sessions.py
+++ b/claudewatch/ui/preferences/panes/sessions.py
@@ -242,7 +242,9 @@ def disambiguate_projects(entries: list[dict]) -> dict[str, str]:
         cwd = entry.get("cwd", "")
         if not cwd:
             continue
-        by_name.setdefault(name, []).append(cwd)
+        cwds = by_name.setdefault(name, [])
+        if cwd not in cwds:
+            cwds.append(cwd)
 
     labels: dict[str, str] = {}
     for name, cwds in by_name.items():
@@ -394,7 +396,7 @@ def _build_row_menu(  # noqa: PLR0913, ARG001
     _add_action("Copy Path", delegate.copyCwd_, cwd)
     _add_action("Open in Finder", delegate.revealInFinder_, cwd)
     menu.addItem_(NSMenuItem.separatorItem())
-    _add_action("Delete", delegate.deleteHistoryEntry_, cwd)
+    _add_action("Delete", delegate.deleteHistoryEntry_, f"{session_id}|{cwd}")
 
     return menu
 

--- a/claudewatch/ui/preferences/panes/usage.py
+++ b/claudewatch/ui/preferences/panes/usage.py
@@ -44,7 +44,12 @@ class UsagePane(BasePane):
         total = {"input": 0, "output": 0, "cache_create": 0, "cache_read": 0}
         cutoff = datetime.now(tz=UTC) - timedelta(days=30)
 
+        seen_cwds: set[str] = set()
         for entry in history:
+            # get_tokens is cwd-level; count each cwd once even with multiple sessions
+            if entry.cwd in seen_cwds:
+                continue
+            seen_cwds.add(entry.cwd)
             tokens = usage_svc.get_tokens(entry.cwd)
             t_in = tokens.input + tokens.cache_create + tokens.cache_read
             t_out = tokens.output

--- a/tests/history/test_history.py
+++ b/tests/history/test_history.py
@@ -24,16 +24,43 @@ class TestRecordSession:
         assert entries[0]["host_app"] == "Terminal"
         assert "ended_at" in entries[0]
 
-    def test_deduplicates_by_cwd(self, tmp_path):
+    def test_same_cwd_different_sessions_kept(self, tmp_path):
         fake_path = str(tmp_path / "history.json")
         with patch.object(history, "_PATH", fake_path):
             history.record_session("sess-1", "proj", "/cwd", "opus", "Terminal")
             history.record_session("sess-2", "proj", "/cwd", "sonnet", "Terminal")
             entries = history._load()
 
+        assert [e["session_id"] for e in entries] == ["sess-1", "sess-2"]
+
+    def test_rerecording_same_session_updates_in_place(self, tmp_path):
+        fake_path = str(tmp_path / "history.json")
+        with patch.object(history, "_PATH", fake_path):
+            history.record_session("sess-1", "proj", "/cwd", "opus", "Terminal")
+            history.record_session("sess-1", "proj", "/cwd", "sonnet", "Terminal")
+            entries = history._load()
+
         assert len(entries) == 1
-        assert entries[0]["session_id"] == "sess-2"
         assert entries[0]["model"] == "sonnet"
+
+    def test_legacy_entries_dedupe_by_cwd(self, tmp_path):
+        fake_path = str(tmp_path / "history.json")
+        with patch.object(history, "_PATH", fake_path):
+            history.record_session("", "proj", "/cwd", "opus", "Terminal")
+            history.record_session("", "proj", "/cwd", "sonnet", "Terminal")
+            entries = history._load()
+
+        assert len(entries) == 1
+        assert entries[0]["model"] == "sonnet"
+
+    def test_legacy_record_keeps_session_entries_for_same_cwd(self, tmp_path):
+        fake_path = str(tmp_path / "history.json")
+        with patch.object(history, "_PATH", fake_path):
+            history.record_session("sess-1", "proj", "/cwd", "opus", "Terminal")
+            history.record_session("", "proj", "/cwd", "sonnet", "Terminal")
+            entries = history._load()
+
+        assert len(entries) == 2
 
     def test_different_cwds_kept(self, tmp_path):
         fake_path = str(tmp_path / "history.json")
@@ -196,17 +223,37 @@ class TestRemoveHistoryEntry:
         with patch.object(history, "_PATH", fake_path):
             history.record_session("s1", "p1", "/a", "", "Terminal")
             history.record_session("s2", "p2", "/b", "", "Terminal")
-            history.remove_history_entry("/a")
+            history.remove_history_entry("s1")
             entries = history._load()
 
         assert len(entries) == 1
         assert entries[0]["cwd"] == "/b"
 
+    def test_removes_only_matching_session_in_shared_cwd(self, tmp_path):
+        fake_path = str(tmp_path / "history.json")
+        with patch.object(history, "_PATH", fake_path):
+            history.record_session("s1", "p", "/a", "", "Terminal")
+            history.record_session("s2", "p", "/a", "", "Terminal")
+            history.remove_history_entry("s1")
+            entries = history._load()
+
+        assert [e["session_id"] for e in entries] == ["s2"]
+
+    def test_legacy_removed_by_cwd(self, tmp_path):
+        fake_path = str(tmp_path / "history.json")
+        with patch.object(history, "_PATH", fake_path):
+            history.record_session("", "p", "/a", "", "Terminal")
+            history.record_session("s1", "p", "/a", "", "Terminal")
+            history.remove_history_entry("", "/a")
+            entries = history._load()
+
+        assert [e["session_id"] for e in entries] == ["s1"]
+
     def test_remove_nonexistent_is_noop(self, tmp_path):
         fake_path = str(tmp_path / "history.json")
         with patch.object(history, "_PATH", fake_path):
             history.record_session("s1", "p1", "/a", "", "Terminal")
-            history.remove_history_entry("/nonexistent")
+            history.remove_history_entry("s-nonexistent")
             entries = history._load()
 
         assert len(entries) == 1
@@ -427,3 +474,21 @@ class TestStaleEntries:
             remaining = svc.get_all()
         assert removed == 1
         assert [e.cwd for e in remaining] == ["/Users/dev/live"]
+
+    def test_remove_stale_per_session_in_shared_cwd(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-app"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "sid-live.jsonl").write_text("{}\n")
+        entries = [
+            {"session_id": "sid-live", "project": "app", "cwd": "/Users/dev/app", "ended_at": "2026-07-01"},
+            {"session_id": "sid-dead", "project": "app", "cwd": "/Users/dev/app", "ended_at": "2026-07-02"},
+        ]
+        svc, fake_path = self._service_with_entries(tmp_path, entries)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch.object(history, "_PATH", fake_path),
+        ):
+            removed = svc.remove_stale()
+            remaining = svc.get_all()
+        assert removed == 1
+        assert [e.session_id for e in remaining] == ["sid-live"]

--- a/tests/history/test_history_service.py
+++ b/tests/history/test_history_service.py
@@ -65,8 +65,8 @@ class TestHistoryService:
 
     @patch("claudewatch.backend.history.service.history_repo")
     def test_remove_delegates_to_repo(self, mock_repo):
-        self.svc.remove("/tmp/cwd")
-        mock_repo.remove_history_entry.assert_called_once_with("/tmp/cwd")
+        self.svc.remove("sid-1", "/tmp/cwd")
+        mock_repo.remove_history_entry.assert_called_once_with("sid-1", "/tmp/cwd")
 
     @patch("claudewatch.backend.history.service.history_repo")
     def test_get_all_caches_after_first_call(self, mock_repo):
@@ -88,7 +88,7 @@ class TestHistoryService:
     def test_remove_invalidates_cache(self, mock_repo):
         mock_repo.get_history.return_value = []
         self.svc.get_all()
-        self.svc.remove("/tmp/c")
+        self.svc.remove("sid-1", "/tmp/c")
         self.svc.get_all()
         assert mock_repo.get_history.call_count == 2
 

--- a/tests/ui/test_panes.py
+++ b/tests/ui/test_panes.py
@@ -250,6 +250,16 @@ class TestDisambiguateProjects:
         assert labels["/Users/dev/frontend/api"] == "frontend/api"
         assert labels["/Users/dev/webtools"] == "webtools"
 
+    def test_multiple_sessions_same_cwd_share_label(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import disambiguate_projects
+
+        entries = [
+            {"project": "api", "cwd": "/Users/dev/api"},
+            {"project": "api", "cwd": "/Users/dev/api"},
+        ]
+        labels = disambiguate_projects(entries)
+        assert labels == {"/Users/dev/api": "api"}
+
     def test_missing_cwd_is_skipped(self) -> None:
         from claudewatch.ui.preferences.panes.sessions import disambiguate_projects
 


### PR DESCRIPTION
## Summary

History dedupes by CWD — one entry per directory, every ended session overwriting the last. Shared-cwd users lose nearly all session history. Finding 1 of the pattern audit (identity keying).

## Changes

- `record_session` dedupes by session_id (updates in place); entries without one keep legacy cwd-dedupe among themselves
- `remove_history_entry(session_id, cwd="")` mirrors the bookmark pattern; `remove_stale` removes per entry
- delete payloads carry `session_id|cwd` with bare-cwd fallback; `disambiguate_projects` dedupes cwds so shared-cwd rows keep clean labels
- usage pane skips duplicate cwds when aggregating (interim guard until usage is session-keyed in the follow-up PR)

## Test plan

- [x] ruff + import audit clean
- [x] full suite: 899 passed (+7)