### PR TITLE
fix: key usage lookups by session, not cwd

### DIFF
--- a/claudewatch/backend/usage/service.py
+++ b/claudewatch/backend/usage/service.py
@@ -97,18 +97,19 @@ class UsageService(BaseService):
     def __init__(self, session_log_service: SessionLogService) -> None:
         super().__init__()
         self._session_log_service = session_log_service
-        # CWD -> (tokens_dto, jsonl_mtime)
+        # JSONL path -> (tokens_dto, jsonl_mtime)
         self._token_cache: dict[str, tuple[TokenUsageDTO, float]] = {}
 
-    def get_model(self, cwd: str) -> str:
-        """Get the raw model id for the most recent session at a CWD.
+    def get_model(self, cwd: str, session_id: str = "") -> str:
+        """Get the raw model id for a session at a CWD.
 
-        Reads the last assistant message from the JSONL to find the model.
+        With a session_id, reads that session's own JSONL (empty if gone —
+        never a sibling's); without one, falls back to the most recent.
         Returns the raw id (e.g. 'claude-opus-4-6') so callers store a stable
         identifier; display name mapping via model_display_name is done at
         render time. Returns empty string if unavailable or synthetic.
         """
-        path = self._session_log_service.find_most_recent(cwd)
+        path = self._session_log_service.resolve_jsonl(cwd, session_id)
         if not path:
             return ""
 
@@ -130,13 +131,15 @@ class UsageService(BaseService):
 
         return last_model
 
-    def get_tokens(self, cwd: str) -> TokenUsageDTO:
-        """Get token usage breakdown for the most recent session at a CWD.
+    def get_tokens(self, cwd: str, session_id: str = "") -> TokenUsageDTO:
+        """Get token usage breakdown for a session at a CWD.
 
+        With a session_id, reads that session's own JSONL (empty if gone —
+        never a sibling's); without one, falls back to the most recent.
         Returns TokenUsageDTO(input, output, cache_create, cache_read) summed across all messages.
         Cached by JSONL mtime — only re-reads when the file changes.
         """
-        path = self._session_log_service.find_most_recent(cwd)
+        path = self._session_log_service.resolve_jsonl(cwd, session_id)
         if not path:
             return _EMPTY_TOKENS
 
@@ -145,7 +148,7 @@ class UsageService(BaseService):
         except OSError:
             return _EMPTY_TOKENS
 
-        cached = self._token_cache.get(cwd)
+        cached = self._token_cache.get(path)
         if cached and cached[1] >= mtime:
             return cached[0]
 
@@ -180,5 +183,5 @@ class UsageService(BaseService):
             # Evict oldest entry by mtime
             oldest = min(self._token_cache, key=lambda k: self._token_cache[k][1])
             del self._token_cache[oldest]
-        self._token_cache[cwd] = (result, mtime)
+        self._token_cache[path] = (result, mtime)
         return result

--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -193,7 +193,7 @@ class MenuBuilder:
                     short_note = pin.note[:_max_note] + "…" if len(pin.note) > _max_note else pin.note
                     label += f" — {short_note}"
                 item = make_menu_item(label, self._app._make_resume_handler(pin.session_id, pin.cwd), d)
-                token_data = self._app._usage_service.get_tokens(pin.cwd)
+                token_data = self._app._usage_service.get_tokens(pin.cwd, pin.session_id)
                 actions = SessionActions(
                     activity=self._app._make_history_activity_handler(pin.project, pin.cwd),
                     resume=self._app._make_resume_handler(pin.session_id, pin.cwd),
@@ -249,7 +249,7 @@ class MenuBuilder:
                     label += f"  ({' · '.join(detail_parts)})"
                 click_action = self._app._make_resume_handler(entry.session_id, entry.cwd) if entry.session_id else noop
                 item = make_menu_item(label, click_action, d)
-                token_data = self._app._usage_service.get_tokens(entry.cwd)
+                token_data = self._app._usage_service.get_tokens(entry.cwd, entry.session_id)
                 actions = SessionActions(
                     activity=self._app._make_history_activity_handler(entry.project, entry.cwd),
                     resume=self._app._make_resume_handler(entry.session_id, entry.cwd) if entry.session_id else None,
@@ -330,7 +330,7 @@ class MenuBuilder:
             item.setImage_(icon)
         # Build submenu using shared session_submenu builder
         is_active = s.status in (SessionStatus.ATTENTION, SessionStatus.WORKING)
-        token_data = self._app._usage_service.get_tokens(s.cwd)
+        token_data = self._app._usage_service.get_tokens(s.cwd, s.session_id)
         actions = SessionActions(
             activity=self._app._make_activity_handler(s),
             bookmark=self._app._make_bookmark_handler(s) if not pinned and s.session_id else None,
@@ -353,7 +353,7 @@ class MenuBuilder:
         item.setSubmenu_(sub)
         self._menu.addItem_(item)
         # Detail line: model + summary (or status as fallback)
-        model = model_display_name(self._app._usage_service.get_model(s.cwd))
+        model = model_display_name(self._app._usage_service.get_model(s.cwd, s.session_id))
         cached = self._get_summary(s.cwd, s.session_id)
         _max_detail_total = 55
         oneliner = cached.replace("\n", " ").strip() if cached else s.detail_line

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -188,7 +188,7 @@ class ClaudeWatchApp:
         if self._prev_pids:  # not first poll
             for pid in new_pids:
                 s = session_map[pid]
-                model = self._usage_service.get_model(s.cwd)
+                model = self._usage_service.get_model(s.cwd, s.session_id)
                 log.info(
                     "session.started project=%s host=%s model=%s pid=%d",
                     s.project,
@@ -210,7 +210,7 @@ class ClaudeWatchApp:
                     session_id=prev.session_id,
                     project=prev.project,
                     cwd=prev.cwd,
-                    model=self._usage_service.get_model(prev.cwd),
+                    model=self._usage_service.get_model(prev.cwd, prev.session_id),
                     host_app=prev.host_app.value,
                 )
 

--- a/claudewatch/ui/preferences/panes/sessions.py
+++ b/claudewatch/ui/preferences/panes/sessions.py
@@ -258,7 +258,7 @@ def disambiguate_projects(entries: list[dict]) -> dict[str, str]:
     return labels
 
 
-def _resolve_model_label(model_raw: str, cwd: str, usage_svc: object) -> str:
+def _resolve_model_label(model_raw: str, cwd: str, usage_svc: object, session_id: str = "") -> str:
     """Map a raw model id to its display name, falling back to live JSONL lookup.
 
     History rows occasionally have an empty ``model`` field — sessions seeded
@@ -271,7 +271,7 @@ def _resolve_model_label(model_raw: str, cwd: str, usage_svc: object) -> str:
     if not cwd:
         return ""
     try:
-        fallback = usage_svc.get_model(cwd)  # type: ignore[attr-defined]
+        fallback = usage_svc.get_model(cwd, session_id)  # type: ignore[attr-defined]
     except (OSError, AttributeError):
         return ""
     return model_display_name(fallback)
@@ -299,7 +299,7 @@ def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001
     cwd = entry.get("cwd", "")
     session_id = entry.get("session_id", "")
     model_raw = entry.get("model", "")
-    model = _resolve_model_label(model_raw, cwd, usage_svc)
+    model = _resolve_model_label(model_raw, cwd, usage_svc, session_id)
     ended_at = entry.get("ended_at", "")
     is_pinned = bookmark_svc.is_bookmarked(session_id, cwd)  # type: ignore[attr-defined]
 
@@ -307,7 +307,7 @@ def _add_row(  # noqa: PLR0912, PLR0913, PLR0915, ARG001
     row_menu = _build_row_menu(delegate, entry, is_pinned, cwd, session_id, raw_project, summary_svc)
 
     # Gather display data
-    token_data = usage_svc.get_tokens(cwd)
+    token_data = usage_svc.get_tokens(cwd, session_id)
     token_compact = format_tokens_compact(token_data)
     cached_title = summary_svc.get_cached(cwd, session_id) if cwd else ""
 

--- a/claudewatch/ui/preferences/panes/usage.py
+++ b/claudewatch/ui/preferences/panes/usage.py
@@ -44,13 +44,8 @@ class UsagePane(BasePane):
         total = {"input": 0, "output": 0, "cache_create": 0, "cache_read": 0}
         cutoff = datetime.now(tz=UTC) - timedelta(days=30)
 
-        seen_cwds: set[str] = set()
         for entry in history:
-            # get_tokens is cwd-level; count each cwd once even with multiple sessions
-            if entry.cwd in seen_cwds:
-                continue
-            seen_cwds.add(entry.cwd)
-            tokens = usage_svc.get_tokens(entry.cwd)
+            tokens = usage_svc.get_tokens(entry.cwd, entry.session_id)
             t_in = tokens.input + tokens.cache_create + tokens.cache_read
             t_out = tokens.output
             if t_in + t_out == 0:

--- a/tests/ui/test_panes.py
+++ b/tests/ui/test_panes.py
@@ -297,7 +297,15 @@ class TestResolveModelLabel:
         svc = MagicMock()
         svc.get_model.return_value = "claude-sonnet-4-6"
         assert _resolve_model_label("", "/tmp/proj", svc) == "sonnet 4.6"
-        svc.get_model.assert_called_once_with("/tmp/proj")
+        svc.get_model.assert_called_once_with("/tmp/proj", "")
+
+    def test_fallback_passes_session_id(self) -> None:
+        from claudewatch.ui.preferences.panes.sessions import _resolve_model_label
+
+        svc = MagicMock()
+        svc.get_model.return_value = "claude-sonnet-4-6"
+        assert _resolve_model_label("", "/tmp/proj", svc, "sid-a") == "sonnet 4.6"
+        svc.get_model.assert_called_once_with("/tmp/proj", "sid-a")
 
     def test_fallback_service_id_derives_label(self) -> None:
         from claudewatch.ui.preferences.panes.sessions import _resolve_model_label

--- a/tests/usage/test_usage.py
+++ b/tests/usage/test_usage.py
@@ -1,19 +1,22 @@
 """Tests for claudewatch.backend.usage.service."""
 
 import json
-from unittest.mock import MagicMock
+import os
+import time
+from unittest.mock import MagicMock, patch
 
+from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.usage.service import UsageService, model_display_name
 
 
 def _make_service(
-    find_most_recent: str | None = None,
+    resolve_jsonl: str | None = None,
     read_tail: str = "",
     read_full: list[str] | None = None,
 ) -> UsageService:
     """Create a UsageService with a mocked SessionLogService."""
     mock_log = MagicMock()
-    mock_log.find_most_recent.return_value = find_most_recent
+    mock_log.resolve_jsonl.return_value = resolve_jsonl
     mock_log.read_tail.return_value = read_tail
     mock_log.read_full.return_value = read_full or []
     return UsageService(mock_log)
@@ -63,21 +66,21 @@ class TestUsageServiceGetModel:
     """Tests for UsageService.get_model — returns raw model ids."""
 
     def test_returns_empty_when_no_jsonl_found(self):
-        svc = _make_service(find_most_recent=None)
+        svc = _make_service(resolve_jsonl=None)
         assert svc.get_model("/Users/dev/myapp") == ""
 
     def test_returns_empty_when_tail_empty(self):
-        svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail="")
+        svc = _make_service(resolve_jsonl="/fake/path.jsonl", read_tail="")
         assert svc.get_model("/Users/dev/myapp") == ""
 
     def test_returns_raw_id_for_known_model(self):
         tail = json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}}) + "\n"
-        svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
+        svc = _make_service(resolve_jsonl="/fake/path.jsonl", read_tail=tail)
         assert svc.get_model("/Users/dev/myapp") == "claude-opus-4-6"
 
     def test_returns_raw_model_for_unknown(self):
         tail = json.dumps({"type": "assistant", "message": {"model": "claude-future-99"}}) + "\n"
-        svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
+        svc = _make_service(resolve_jsonl="/fake/path.jsonl", read_tail=tail)
         assert svc.get_model("/Users/dev/myapp") == "claude-future-99"
 
     def test_uses_last_model_in_file(self):
@@ -87,7 +90,7 @@ class TestUsageServiceGetModel:
             + json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}})
             + "\n"
         )
-        svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
+        svc = _make_service(resolve_jsonl="/fake/path.jsonl", read_tail=tail)
         assert svc.get_model("/Users/dev/myapp") == "claude-opus-4-6"
 
     def test_skips_synthetic_placeholder(self):
@@ -99,25 +102,78 @@ class TestUsageServiceGetModel:
             + json.dumps({"type": "assistant", "message": {"model": "<synthetic>"}})
             + "\n"
         )
-        svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
+        svc = _make_service(resolve_jsonl="/fake/path.jsonl", read_tail=tail)
         assert svc.get_model("/Users/dev/myapp") == "claude-opus-4-6"
 
     def test_returns_empty_when_only_synthetic(self):
         tail = json.dumps({"type": "assistant", "message": {"model": "<synthetic>"}}) + "\n"
-        svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
+        svc = _make_service(resolve_jsonl="/fake/path.jsonl", read_tail=tail)
         assert svc.get_model("/Users/dev/myapp") == ""
 
     def test_handles_invalid_json_lines(self):
         tail = "not json\n" + json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-6"}}) + "\n"
-        svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
+        svc = _make_service(resolve_jsonl="/fake/path.jsonl", read_tail=tail)
         assert svc.get_model("/Users/dev/myapp") == "claude-opus-4-6"
 
     def test_handles_non_dict_message(self):
         tail = json.dumps({"type": "assistant", "message": "string"}) + "\n"
-        svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
+        svc = _make_service(resolve_jsonl="/fake/path.jsonl", read_tail=tail)
         assert svc.get_model("/Users/dev/myapp") == ""
 
     def test_returns_empty_for_no_model_field(self):
         tail = json.dumps({"type": "user", "message": {"content": "hello"}}) + "\n"
-        svc = _make_service(find_most_recent="/fake/path.jsonl", read_tail=tail)
+        svc = _make_service(resolve_jsonl="/fake/path.jsonl", read_tail=tail)
         assert svc.get_model("/Users/dev/myapp") == ""
+
+    def test_no_session_id_resolves_most_recent(self):
+        svc = _make_service(resolve_jsonl="/fake/path.jsonl", read_tail="")
+        svc.get_model("/Users/dev/myapp")
+        svc._session_log_service.resolve_jsonl.assert_called_once_with("/Users/dev/myapp", "")
+
+    def test_session_id_passed_through(self):
+        svc = _make_service(resolve_jsonl="/fake/path.jsonl", read_tail="")
+        svc.get_model("/Users/dev/myapp", "sid-a")
+        svc._session_log_service.resolve_jsonl.assert_called_once_with("/Users/dev/myapp", "sid-a")
+
+
+def _write_session(path, model: str, input_tokens: int, output_tokens: int, mtime: float) -> None:
+    """Write a one-message session JSONL and pin its mtime."""
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {"model": model, "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens}},
+        }
+    )
+    path.write_text(line + "\n")
+    os.utime(path, (mtime, mtime))
+
+
+class TestUsageServiceSharedCwd:
+    """Two sessions sharing one cwd must not read each other's JSONL."""
+
+    def test_session_id_wins_over_newer_sibling(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        now = time.time()
+        _write_session(proj_dir / "sid-a.jsonl", "claude-opus-4-6", 100, 50, now - 100)
+        _write_session(proj_dir / "sid-b.jsonl", "claude-sonnet-4-6", 7, 3, now)
+
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            svc = UsageService(SessionLogService())
+            assert svc.get_model("/Users/dev/myapp", "sid-a") == "claude-opus-4-6"
+            tokens_a = svc.get_tokens("/Users/dev/myapp", "sid-a")
+            assert (tokens_a.input, tokens_a.output) == (100, 50)
+            # No session_id still falls back to the most recent file.
+            assert svc.get_model("/Users/dev/myapp") == "claude-sonnet-4-6"
+            tokens_recent = svc.get_tokens("/Users/dev/myapp")
+            assert (tokens_recent.input, tokens_recent.output) == (7, 3)
+
+    def test_gone_session_returns_empty_not_sibling(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_session(proj_dir / "sid-b.jsonl", "claude-sonnet-4-6", 7, 3, time.time())
+
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            svc = UsageService(SessionLogService())
+            assert svc.get_model("/Users/dev/myapp", "sid-gone") == ""
+            assert svc.get_tokens("/Users/dev/myapp", "sid-gone").total == 0

--- a/tests/usage/test_usage_tokens.py
+++ b/tests/usage/test_usage_tokens.py
@@ -13,12 +13,12 @@ from claudewatch.backend.usage.service import (
 
 
 def _make_service(
-    find_most_recent: str | None = None,
+    resolve_jsonl: str | None = None,
     read_full: list[str] | None = None,
 ) -> UsageService:
     """Create a UsageService with a mocked SessionLogService."""
     mock_log = MagicMock()
-    mock_log.find_most_recent.return_value = find_most_recent
+    mock_log.resolve_jsonl.return_value = resolve_jsonl
     mock_log.read_full.return_value = read_full or []
     return UsageService(mock_log)
 
@@ -68,13 +68,13 @@ class TestUsageServiceGetTokens:
     """Tests for UsageService.get_tokens."""
 
     def test_returns_empty_when_no_jsonl(self):
-        svc = _make_service(find_most_recent=None)
+        svc = _make_service(resolve_jsonl=None)
         result = svc.get_tokens("/Users/dev/myapp")
         assert isinstance(result, TokenUsageDTO)
         assert result.total == 0
 
     def test_returns_empty_when_file_gone(self, tmp_path):
-        svc = _make_service(find_most_recent=str(tmp_path / "gone.jsonl"))
+        svc = _make_service(resolve_jsonl=str(tmp_path / "gone.jsonl"))
         result = svc.get_tokens("/Users/dev/myapp")
         assert isinstance(result, TokenUsageDTO)
         assert result.total == 0
@@ -105,7 +105,7 @@ class TestUsageServiceGetTokens:
         ]
         jsonl_file.write_text("\n".join(lines) + "\n")
 
-        svc = _make_service(find_most_recent=str(jsonl_file), read_full=lines)
+        svc = _make_service(resolve_jsonl=str(jsonl_file), read_full=lines)
         result = svc.get_tokens("/Users/dev/myapp")
         assert result.input == 110
         assert result.output == 55
@@ -117,7 +117,7 @@ class TestUsageServiceGetTokens:
         line = json.dumps({"type": "assistant", "message": {"usage": {"input_tokens": 42, "output_tokens": 10}}})
         jsonl_file.write_text(line + "\n")
 
-        svc = _make_service(find_most_recent=str(jsonl_file), read_full=[line])
+        svc = _make_service(resolve_jsonl=str(jsonl_file), read_full=[line])
         r1 = svc.get_tokens("/Users/dev/myapp")
         r2 = svc.get_tokens("/Users/dev/myapp")
         assert r1 == r2
@@ -133,7 +133,7 @@ class TestUsageServiceGetTokens:
         ]
         jsonl_file.write_text("\n".join(lines) + "\n")
 
-        svc = _make_service(find_most_recent=str(jsonl_file), read_full=lines)
+        svc = _make_service(resolve_jsonl=str(jsonl_file), read_full=lines)
         result = svc.get_tokens("/Users/dev/myapp")
         assert result.input == 5
 
@@ -143,8 +143,8 @@ class TestUsageServiceGetTokens:
         line = json.dumps({"type": "assistant", "message": {"usage": {"input_tokens": 7, "output_tokens": 2}}})
         jsonl_file.write_text(line + "\n")
 
-        svc1 = _make_service(find_most_recent=str(jsonl_file), read_full=[line])
-        svc2 = _make_service(find_most_recent=str(jsonl_file), read_full=[line])
+        svc1 = _make_service(resolve_jsonl=str(jsonl_file), read_full=[line])
+        svc2 = _make_service(resolve_jsonl=str(jsonl_file), read_full=[line])
         svc1.get_tokens("/Users/dev/myapp")
         assert len(svc1._token_cache) == 1
         assert len(svc2._token_cache) == 0


### PR DESCRIPTION
## Summary

`get_model`/`get_tokens` read the CWD's most-recent JSONL, so per-session UI (menu detail lines, bookmark/recent token breakdowns, sessions pane rows, session-end history records) showed a sibling session's model and token counts in shared-cwd setups. Finding 2 of the pattern audit.

## Changes

- `get_model(cwd, session_id="")` / `get_tokens(cwd, session_id="")` resolve the session's own file via `resolve_jsonl`; no sibling fallback when the file is gone
- `_token_cache` keyed by resolved JSONL path instead of cwd
- session_id threaded from every call site (menu builder, menubar logging/recording, sessions + usage panes) — supersedes the interim `seen_cwds` guard from #237
- shared-cwd regression tests against a real SessionLogService

## Test plan

- [x] ruff + import audit clean
- [x] full suite: 904 passed