### PR TITLE
fix: key activity timelines by session id, not cwd

### DIFF
--- a/claudewatch/backend/activity/service.py
+++ b/claudewatch/backend/activity/service.py
@@ -18,12 +18,13 @@ class ActivityService(BaseService):
         super().__init__()
         self._session_log_service = session_log_service
 
-    def parse(self, cwd: str, max_entries: int = 100) -> list[ActivityEventDTO]:  # noqa: PLR0912
-        """Parse the most recent JSONL for a CWD into an activity timeline.
+    def parse(self, cwd: str, session_id: str = "", max_entries: int = 100) -> list[ActivityEventDTO]:  # noqa: PLR0912
+        """Parse a session's JSONL (or the CWD's most recent) into an activity timeline.
 
-        Returns newest-first list of ActivityEventDTO objects.
+        With a session_id, reads that session's own file — never a sibling's;
+        returns [] if it's gone. Returns newest-first list of ActivityEventDTO.
         """
-        path = self._session_log_service.find_most_recent(cwd)
+        path = self._session_log_service.resolve_jsonl(cwd, session_id)
         if not path:
             return []
 

--- a/claudewatch/ui/activity.py
+++ b/claudewatch/ui/activity.py
@@ -38,10 +38,11 @@ from claudewatch.ui.safety import objc_callback
 _W = 750
 _H = 500
 
+# All dicts keyed by "{cwd}::{session_id}" so sessions sharing a cwd get separate windows
 _windows: dict[str, NSWindow] = {}
 _delegates: dict[str, object] = {}  # prevent GC of delegate
 _text_views: dict[str, NSTextView] = {}
-_sort_state: dict[str, bool] = {}  # CWD → newest_first
+_sort_state: dict[str, bool] = {}  # key → newest_first
 
 # Styles per entry kind
 _KIND_CONFIG = {
@@ -66,13 +67,15 @@ class _ActivityDelegate(NSObject):
     """Handle window close, resume, and sort actions."""
 
     _cwd: str = ""
+    _session_id: str = ""
+    _key: str = ""
 
     @objc_callback
     def windowWillClose_(self, notification: objc.objc_object) -> None:
-        _windows.pop(self._cwd, None)
-        _delegates.pop(self._cwd, None)
-        _text_views.pop(self._cwd, None)
-        _sort_state.pop(self._cwd, None)
+        _windows.pop(self._key, None)
+        _delegates.pop(self._key, None)
+        _text_views.pop(self._key, None)
+        _sort_state.pop(self._key, None)
 
     @objc_callback
     def openInFinder_(self, sender: objc.objc_object) -> None:
@@ -81,7 +84,7 @@ class _ActivityDelegate(NSObject):
 
     @objc_callback
     def copyToClipboard_(self, sender: objc.objc_object) -> None:
-        tv = _text_views.get(self._cwd)
+        tv = _text_views.get(self._key)
         if tv:
             pb = NSPasteboard.generalPasteboard()
             pb.clearContents()
@@ -89,19 +92,19 @@ class _ActivityDelegate(NSObject):
 
     @objc_callback
     def openJsonlInFinder_(self, sender: objc.objc_object) -> None:
-        path = get_session_log_service().find_most_recent(self._cwd)
+        path = get_session_log_service().resolve_jsonl(self._cwd, self._session_id)
         if path:
             subprocess.run(["open", "-R", path], check=False)  # noqa: S603, S607
 
     @objc_callback
     def toggleSort_(self, sender: objc.objc_object) -> None:
-        newest_first = not _sort_state.get(self._cwd, False)
-        _sort_state[self._cwd] = newest_first
+        newest_first = not _sort_state.get(self._key, False)
+        _sort_state[self._key] = newest_first
         sender.setTitle_("↓ Newest first" if newest_first else "↑ Oldest first")
-        entries = get_activity_service().parse(self._cwd)
+        entries = get_activity_service().parse(self._cwd, self._session_id)
         if newest_first:
             entries = list(reversed(entries))
-        tv = _text_views.get(self._cwd)
+        tv = _text_views.get(self._key)
         if tv is not None:
             tv.textStorage().setAttributedString_(_render_timeline(entries))
             if newest_first:
@@ -111,14 +114,16 @@ class _ActivityDelegate(NSObject):
 
     @objc_callback
     def focusSession_(self, sender: objc.objc_object) -> None:  # noqa: N802
-        for s in get_detection_service().detect():
-            if s.cwd == self._cwd:
-                focus_session(s)
-                return
+        sessions = get_detection_service().detect()
+        match = next((s for s in sessions if self._session_id and s.session_id == self._session_id), None)
+        if match is None:
+            match = next((s for s in sessions if s.cwd == self._cwd), None)
+        if match is not None:
+            focus_session(match)
 
     @objc_callback
     def resumeSession_(self, sender: objc.objc_object) -> None:
-        sid = _get_session_id(self._cwd)
+        sid = self._session_id or _get_session_id(self._cwd)
         if not sid or not re.fullmatch(r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}", sid):
             return
         safe_cwd = escape_applescript(self._cwd)
@@ -184,10 +189,11 @@ def _render_timeline(entries: list[ActivityEventDTO]) -> NSMutableAttributedStri
     return result
 
 
-def show_activity(project: str, cwd: str, *, session_active: bool = False) -> None:  # noqa: PLR0915
+def show_activity(project: str, cwd: str, session_id: str = "", *, session_active: bool = False) -> None:  # noqa: PLR0915
     """Show (or bring to front) the activity window for a session."""
-    if cwd in _windows:
-        _windows[cwd].makeKeyAndOrderFront_(None)
+    key = f"{cwd}::{session_id}"
+    if key in _windows:
+        _windows[key].makeKeyAndOrderFront_(None)
         NSApplication.sharedApplication().activateIgnoringOtherApps_(True)
         return
 
@@ -195,6 +201,8 @@ def show_activity(project: str, cwd: str, *, session_active: bool = False) -> No
 
     delegate = _ActivityDelegate.alloc().init()
     delegate._cwd = cwd
+    delegate._session_id = session_id
+    delegate._key = key
 
     style = (
         NSWindowStyleMaskTitled
@@ -296,8 +304,8 @@ def show_activity(project: str, cwd: str, *, session_active: bool = False) -> No
     text_view.setAutoresizingMask_(18)
     text_view.setTextContainerInset_(NSMakeSize(16, 16))
 
-    _text_views[cwd] = text_view
-    entries = get_activity_service().parse(cwd)
+    _text_views[key] = text_view
+    entries = get_activity_service().parse(cwd, session_id)
     text_view.textStorage().setAttributedString_(_render_timeline(entries))
     text_view.scrollRangeToVisible_(NSRange(len(text_view.string()), 0))
 
@@ -306,8 +314,8 @@ def show_activity(project: str, cwd: str, *, session_active: bool = False) -> No
 
     window.setContentView_(root)
 
-    _delegates[cwd] = delegate
-    _windows[cwd] = window
+    _delegates[key] = delegate
+    _windows[key] = window
     window.center()
     window.makeKeyAndOrderFront_(None)
     NSApplication.sharedApplication().activateIgnoringOtherApps_(True)

--- a/claudewatch/ui/menu_builder.py
+++ b/claudewatch/ui/menu_builder.py
@@ -195,7 +195,7 @@ class MenuBuilder:
                 item = make_menu_item(label, self._app._make_resume_handler(pin.session_id, pin.cwd), d)
                 token_data = self._app._usage_service.get_tokens(pin.cwd, pin.session_id)
                 actions = SessionActions(
-                    activity=self._app._make_history_activity_handler(pin.project, pin.cwd),
+                    activity=self._app._make_history_activity_handler(pin.project, pin.cwd, pin.session_id or ""),
                     resume=self._app._make_resume_handler(pin.session_id, pin.cwd),
                     unbookmark=self._app._make_unbookmark_handler(pin.session_id, pin.cwd),
                     track_summary=lambda cwd=pin.cwd, sid=pin.session_id: self._app._summary_service.track_session(
@@ -251,7 +251,7 @@ class MenuBuilder:
                 item = make_menu_item(label, click_action, d)
                 token_data = self._app._usage_service.get_tokens(entry.cwd, entry.session_id)
                 actions = SessionActions(
-                    activity=self._app._make_history_activity_handler(entry.project, entry.cwd),
+                    activity=self._app._make_history_activity_handler(entry.project, entry.cwd, entry.session_id or ""),
                     resume=self._app._make_resume_handler(entry.session_id, entry.cwd) if entry.session_id else None,
                     remove=self._app._make_remove_history_handler(entry.session_id, entry.cwd),
                     track_summary=lambda cwd=entry.cwd, sid=entry.session_id: self._app._summary_service.track_session(

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -341,9 +341,10 @@ class ClaudeWatchApp:
     def _make_activity_handler(self, session: ClaudeSession) -> MenuCallback:
         project = session.project
         cwd = session.cwd
+        session_id = session.session_id
 
         def handler(_: NSMenuItem) -> None:
-            show_activity(project, cwd, session_active=True)
+            show_activity(project, cwd, session_id, session_active=True)
 
         return handler
 
@@ -523,9 +524,9 @@ class ClaudeWatchApp:
 
         return handler
 
-    def _make_history_activity_handler(self, project: str, cwd: str) -> MenuCallback:
+    def _make_history_activity_handler(self, project: str, cwd: str, session_id: str = "") -> MenuCallback:
         def handler(_: NSMenuItem) -> None:
-            show_activity(project, cwd)
+            show_activity(project, cwd, session_id)
 
         return handler
 

--- a/claudewatch/ui/preferences/handlers/actions.py
+++ b/claudewatch/ui/preferences/handlers/actions.py
@@ -47,12 +47,17 @@ def handle_resume(delegate: object, sender: object) -> None:  # noqa: ARG001
 
 
 def handle_view_activity(delegate: object, sender: object) -> None:  # noqa: ARG001
-    """Open the activity window for a session."""
+    """Open the activity window for a session.
+
+    Payload is "project|cwd|session_id"; legacy 2-part payloads omit session_id.
+    """
     data = get_represented_object(sender)
     if "|" not in data:
         return
-    project, cwd = data.split("|", 1)
-    show_activity(project, cwd)
+    parts = data.split("|", 2)
+    project, cwd = parts[0], parts[1]
+    session_id = parts[2] if len(parts) > 2 else ""
+    show_activity(project, cwd, session_id)
 
 
 def handle_copy_cwd(delegate: object, sender: object) -> None:  # noqa: ARG001

--- a/claudewatch/ui/preferences/panes/sessions.py
+++ b/claudewatch/ui/preferences/panes/sessions.py
@@ -385,7 +385,7 @@ def _build_row_menu(  # noqa: PLR0913, ARG001
 
     if session_id:
         _add_action("Resume", delegate.resumeSession_, f"{session_id}|{cwd}")
-    _add_action("Activity", delegate.viewActivity_, f"{project}|{cwd}")
+    _add_action("Activity", delegate.viewActivity_, f"{project}|{cwd}|{session_id}")
     menu.addItem_(NSMenuItem.separatorItem())
 
     if is_pinned:

--- a/tests/activity/test_activity.py
+++ b/tests/activity/test_activity.py
@@ -288,6 +288,52 @@ class TestParseActivity:
         assert len(result) == 1
         assert result[0].detail == "new msg"
 
+    def test_session_id_reads_that_sessions_file_not_newest_sibling(self, tmp_path):
+        """Two sessions share a cwd; parse(cwd, old_sid) must not read the newer sibling."""
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        sid_old = "11111111-1111-1111-1111-111111111111"
+        sid_new = "22222222-2222-2222-2222-222222222222"
+        old = proj_dir / f"{sid_old}.jsonl"
+        _write_jsonl(old, [{"type": "user", "message": {"content": "old msg"}, "timestamp": ""}])
+        os.utime(old, (1000, 1000))
+        new = proj_dir / f"{sid_new}.jsonl"
+        _write_jsonl(new, [{"type": "user", "message": {"content": "new msg"}, "timestamp": ""}])
+        os.utime(new, (2000, 2000))
+
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = ActivityService(SessionLogService()).parse("/Users/dev/myapp", sid_old)
+        assert len(result) == 1
+        assert result[0].detail == "old msg"
+
+    def test_session_id_missing_file_returns_empty_no_sibling_fallback(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        _write_jsonl(
+            proj_dir / "22222222-2222-2222-2222-222222222222.jsonl",
+            [{"type": "user", "message": {"content": "sibling msg"}, "timestamp": ""}],
+        )
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = ActivityService(SessionLogService()).parse(
+                "/Users/dev/myapp", "11111111-1111-1111-1111-111111111111"
+            )
+        assert result == []
+
+    def test_empty_session_id_falls_back_to_most_recent(self, tmp_path):
+        proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
+        proj_dir.mkdir(parents=True)
+        old = proj_dir / "old.jsonl"
+        _write_jsonl(old, [{"type": "user", "message": {"content": "old msg"}, "timestamp": ""}])
+        os.utime(old, (1000, 1000))
+        new = proj_dir / "new.jsonl"
+        _write_jsonl(new, [{"type": "user", "message": {"content": "new msg"}, "timestamp": ""}])
+        os.utime(new, (2000, 2000))
+
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            result = ActivityService(SessionLogService()).parse("/Users/dev/myapp", "")
+        assert len(result) == 1
+        assert result[0].detail == "new msg"
+
     def test_parses_recap_from_away_summary(self, tmp_path):
         proj_dir = tmp_path / "projects" / "-Users-dev-myapp"
         proj_dir.mkdir(parents=True)

--- a/tests/ui/test_actions.py
+++ b/tests/ui/test_actions.py
@@ -1,0 +1,36 @@
+"""Tests for preferences action handlers — activity payload parsing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from claudewatch.ui.preferences.handlers.actions import handle_view_activity
+
+
+def _sender(payload: str) -> MagicMock:
+    sender = MagicMock()
+    sender.representedObject.return_value = payload
+    return sender
+
+
+class TestHandleViewActivity:
+    def test_three_part_payload_passes_session_id(self) -> None:
+        sid = "11111111-1111-1111-1111-111111111111"
+        with patch("claudewatch.ui.preferences.handlers.actions.show_activity") as show:
+            handle_view_activity(None, _sender(f"myapp|/Users/dev/myapp|{sid}"))
+        show.assert_called_once_with("myapp", "/Users/dev/myapp", sid)
+
+    def test_legacy_two_part_payload_empty_session_id(self) -> None:
+        with patch("claudewatch.ui.preferences.handlers.actions.show_activity") as show:
+            handle_view_activity(None, _sender("myapp|/Users/dev/myapp"))
+        show.assert_called_once_with("myapp", "/Users/dev/myapp", "")
+
+    def test_three_part_payload_with_empty_session_id(self) -> None:
+        with patch("claudewatch.ui.preferences.handlers.actions.show_activity") as show:
+            handle_view_activity(None, _sender("myapp|/Users/dev/myapp|"))
+        show.assert_called_once_with("myapp", "/Users/dev/myapp", "")
+
+    def test_no_pipe_payload_ignored(self) -> None:
+        with patch("claudewatch.ui.preferences.handlers.actions.show_activity") as show:
+            handle_view_activity(None, _sender("garbage"))
+        show.assert_not_called()


### PR DESCRIPTION
## Summary

Activity windows parsed the CWD's most-recent JSONL — clicking Activity on any shared-cwd session showed the newest sibling's timeline. Finding 3 of the pattern audit.

## Changes

- `ActivityService.parse(cwd, session_id="")` resolves the session's own file; `[]` when it's gone, no sibling fallback
- `show_activity` carries session_id; activity windows keyed by `cwd::session_id` so two sessions in one cwd get separate windows; refresh/resume/reveal inside the window use the same session
- session_id threaded from all entry points (menubar handlers, menu builder, row menus, action payloads with legacy 2-part fallback)

## Test plan

- [x] ruff + import audit clean
- [x] full suite passing post-rebase
- [x] shared-cwd regression: parse(cwd, old_sid) reads the old session's file while a newer sibling exists