### PR TITLE
fix: validate the session's own jsonl on resume; single terminal-open helper

### DIFF
--- a/claudewatch/ui/activity.py
+++ b/claudewatch/ui/activity.py
@@ -28,12 +28,12 @@ from Foundation import NSMakeRect, NSMakeSize, NSObject, NSRange
 
 from claudewatch.backend.activity.dependencies import get_activity_service
 from claudewatch.backend.core.dto import ActivityEventDTO
-from claudewatch.backend.core.helpers import escape_applescript, run_applescript
 from claudewatch.backend.core.session_log.dependencies import get_session_log_service
 from claudewatch.backend.detection.dependencies import get_detection_service
 from claudewatch.ui.components.tokens import Font
 from claudewatch.ui.focus import focus_session
 from claudewatch.ui.safety import objc_callback
+from claudewatch.ui.session_actions import open_terminal_and_run
 
 _W = 750
 _H = 500
@@ -126,14 +126,7 @@ class _ActivityDelegate(NSObject):
         sid = self._session_id or _get_session_id(self._cwd)
         if not sid or not re.fullmatch(r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}", sid):
             return
-        safe_cwd = escape_applescript(self._cwd)
-        run_applescript(f'''
-            do shell script "open -a Terminal \\"{safe_cwd}\\""
-            delay 0.5
-            tell application "Terminal"
-                do script "claude -r {sid}" in front window
-            end tell
-        ''')
+        open_terminal_and_run(f"claude -r {sid}", self._cwd)
 
 
 def _append(attr_str: NSMutableAttributedString, text: str, font: NSFont, color: NSColor) -> None:

--- a/claudewatch/ui/menubar.py
+++ b/claudewatch/ui/menubar.py
@@ -31,7 +31,6 @@ from claudewatch.backend.bookmark.dependencies import get_bookmark_service
 from claudewatch.backend.bookmark.service import BookmarkService
 from claudewatch.backend.core import features
 from claudewatch.backend.core.features import FeatureKey
-from claudewatch.backend.core.helpers import escape_applescript, run_applescript
 from claudewatch.backend.core.login_item import refresh_login_item
 from claudewatch.backend.core.models import ClaudeSession
 from claudewatch.backend.core.paths import LOG_PATH, ensure_data_dir
@@ -60,7 +59,12 @@ from claudewatch.ui.focus import focus_session
 from claudewatch.ui.menu.core import AppDelegate, MenuCallback, make_menu_item
 from claudewatch.ui.menu_builder import MenuBuilder
 from claudewatch.ui.preferences import show_preferences
-from claudewatch.ui.session_actions import clean_exit_session, is_accessibility_trusted, notify_paused
+from claudewatch.ui.session_actions import (
+    clean_exit_session,
+    is_accessibility_trusted,
+    notify_paused,
+    open_terminal_and_run,
+)
 from claudewatch.ui.theme import theme
 from claudewatch.ui.welcome import should_show_welcome, show_welcome
 
@@ -498,28 +502,12 @@ class ClaudeWatchApp:
             if not re.fullmatch(r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}", session_id):
                 log.warning("invalid session ID: %s", session_id[:20])
                 return
-            # Verify the session JSONL still exists before trying to resume
-            path = get_session_log_service().find_most_recent(cwd) if cwd else None
+            # Verify the session's own JSONL still exists before trying to resume
+            path = get_session_log_service().resolve_jsonl(cwd, session_id) if cwd else None
             if not path:
                 log.warning("session JSONL not found for resume: %s", session_id[:8])
                 return
-            # Open a new Terminal tab, cd to the project dir, and resume
-            safe_cwd = escape_applescript(cwd) if cwd else ""
-            if safe_cwd:
-                run_applescript(f"""
-                    do shell script "open -a Terminal \\"{safe_cwd}\\""
-                    delay 0.5
-                    tell application "Terminal"
-                        do script "claude -r {session_id}" in front window
-                    end tell
-                """)
-            else:
-                run_applescript(f"""
-                    tell application "Terminal"
-                        activate
-                        do script "claude -r {session_id}"
-                    end tell
-                """)
+            open_terminal_and_run(f"claude -r {session_id}", cwd)
             log.info("session resumed: %s", session_id[:8])
 
         return handler

--- a/claudewatch/ui/preferences/handlers/actions.py
+++ b/claudewatch/ui/preferences/handlers/actions.py
@@ -18,12 +18,12 @@ from AppKit import (
 
 from claudewatch import __version__
 from claudewatch.backend.bookmark.dependencies import get_bookmark_service
-from claudewatch.backend.core.helpers import escape_applescript, run_applescript
 from claudewatch.backend.core.paths import LOG_PATH
 from claudewatch.backend.history.dependencies import get_history_service
 from claudewatch.backend.summary.dependencies import get_summary_service
 from claudewatch.ui.activity import show_activity
 from claudewatch.ui.safety import get_represented_object
+from claudewatch.ui.session_actions import open_terminal_and_run
 
 _DIAGNOSTIC_TAIL_BYTES = 50_000
 
@@ -36,14 +36,7 @@ def handle_resume(delegate: object, sender: object) -> None:  # noqa: ARG001
     sid, cwd = data.split("|", 1)
     if not re.fullmatch(r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}", sid):
         return
-    safe_cwd = escape_applescript(cwd)
-    run_applescript(f'''
-        do shell script "open -a Terminal \\"{safe_cwd}\\""
-        delay 0.5
-        tell application "Terminal"
-            do script "claude -r {sid}" in front window
-        end tell
-    ''')
+    open_terminal_and_run(f"claude -r {sid}", cwd)
 
 
 def handle_view_activity(delegate: object, sender: object) -> None:  # noqa: ARG001
@@ -117,13 +110,7 @@ def handle_open_claude_usage(delegate: object, sender: object) -> None:  # noqa:
         break
     if not cwd:
         cwd = os.path.expanduser("~")
-    safe_cwd = escape_applescript(cwd)
-    run_applescript(f'''
-        tell application "Terminal"
-            activate
-            do script "cd \\"{safe_cwd}\\" && claude /usage"
-        end tell
-    ''')
+    open_terminal_and_run("claude /usage", cwd)
 
 
 def handle_view_audit_log(delegate: object, sender: object) -> None:  # noqa: ARG001

--- a/claudewatch/ui/session_actions.py
+++ b/claudewatch/ui/session_actions.py
@@ -1,4 +1,4 @@
-"""Session lifecycle actions — exit, pause, accessibility check."""
+"""Session lifecycle actions — exit, pause, resume, accessibility check."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import signal
 import threading
 import time
 
-from claudewatch.backend.core.helpers import is_accessibility_trusted, run_applescript
+from claudewatch.backend.core.helpers import escape_applescript, is_accessibility_trusted, run_applescript
 from claudewatch.backend.notifications.dependencies import get_notification_service
 
 log = logging.getLogger("claudewatch")
@@ -54,4 +54,26 @@ def notify_paused(project: str) -> None:
     get_notification_service().send("Session paused", project, "Resume from the Pinned section")
 
 
-__all__ = ["clean_exit_session", "is_accessibility_trusted", "notify_paused"]
+def open_terminal_and_run(command: str, cwd: str = "") -> None:
+    """Run a shell command in a new Terminal window, cd'ing to cwd first if given.
+
+    A bare ``do script`` opens a new window — no positional window references,
+    which race the window opening. Callers build ``command`` from validated
+    parts (e.g. UUID-checked session IDs); everything interpolated here is
+    escaped via ``escape_applescript``.
+    """
+    safe_command = escape_applescript(command)
+    if cwd:
+        safe_cwd = escape_applescript(cwd)
+        shell = f'"cd " & quoted form of "{safe_cwd}" & " && {safe_command}"'
+    else:
+        shell = f'"{safe_command}"'
+    run_applescript(f"""
+        tell application "Terminal"
+            activate
+            do script {shell}
+        end tell
+    """)
+
+
+__all__ = ["clean_exit_session", "is_accessibility_trusted", "notify_paused", "open_terminal_and_run"]

--- a/tests/ui/test_resume_handler.py
+++ b/tests/ui/test_resume_handler.py
@@ -1,0 +1,43 @@
+"""Tests for the menubar resume handler's precondition validation."""
+
+from unittest.mock import MagicMock, patch
+
+_MOD = "claudewatch.ui.menubar"
+
+_SID = "12345678-1234-1234-1234-123456789abc"
+_CWD = "/Users/dev/myapp"
+
+
+def _invoke(session_id: str, cwd: str, log_service: MagicMock) -> MagicMock:
+    from claudewatch.ui.menubar import ClaudeWatchApp
+
+    handler = ClaudeWatchApp._make_resume_handler(MagicMock(), session_id, cwd)
+    with (
+        patch(f"{_MOD}.get_session_log_service", return_value=log_service),
+        patch(f"{_MOD}.open_terminal_and_run") as mock_open,
+    ):
+        handler(None)
+    return mock_open
+
+
+class TestResumePrecondition:
+    def test_aborts_when_sessions_own_jsonl_is_gone(self) -> None:
+        """A sibling session's file in the same cwd must not pass validation."""
+        svc = MagicMock()
+        svc.find_most_recent.return_value = "/fake/sibling-session.jsonl"
+        svc.resolve_jsonl.return_value = None
+        mock_open = _invoke(_SID, _CWD, svc)
+        svc.resolve_jsonl.assert_called_once_with(_CWD, _SID)
+        mock_open.assert_not_called()
+
+    def test_resumes_when_sessions_own_jsonl_exists(self) -> None:
+        svc = MagicMock()
+        svc.resolve_jsonl.return_value = f"/fake/{_SID}.jsonl"
+        mock_open = _invoke(_SID, _CWD, svc)
+        mock_open.assert_called_once_with(f"claude -r {_SID}", _CWD)
+
+    def test_rejects_non_uuid_session_id(self) -> None:
+        svc = MagicMock()
+        mock_open = _invoke("not-a-uuid; rm -rf ~", _CWD, svc)
+        svc.resolve_jsonl.assert_not_called()
+        mock_open.assert_not_called()

--- a/tests/ui/test_session_actions.py
+++ b/tests/ui/test_session_actions.py
@@ -1,0 +1,45 @@
+"""Tests for claudewatch.ui.session_actions.open_terminal_and_run."""
+
+from unittest.mock import patch
+
+_MOD = "claudewatch.ui.session_actions"
+
+_SID = "12345678-1234-1234-1234-123456789abc"
+
+
+def _run(command: str, cwd: str = "") -> str:
+    with patch(f"{_MOD}.run_applescript") as mock_run:
+        from claudewatch.ui.session_actions import open_terminal_and_run
+
+        open_terminal_and_run(command, cwd)
+    return mock_run.call_args.args[0]
+
+
+class TestOpenTerminalAndRun:
+    def test_no_positional_window_references(self) -> None:
+        """Stored/positional window refs race the window opening — banned."""
+        script = _run(f"claude -r {_SID}", "/Users/dev/myapp")
+        assert "front window" not in script
+        assert "open -a Terminal" not in script
+        assert "delay" not in script
+
+    def test_cwd_uses_quoted_form(self) -> None:
+        script = _run(f"claude -r {_SID}", "/Users/dev/myapp")
+        assert 'quoted form of "/Users/dev/myapp"' in script
+        assert f"claude -r {_SID}" in script
+        assert "activate" in script
+
+    def test_cwd_is_escaped(self) -> None:
+        script = _run("claude /usage", '/tmp/x"; do shell script "evil')
+        assert '/tmp/x\\"; do shell script \\"evil' in script
+        assert 'x";' not in script
+
+    def test_command_is_escaped(self) -> None:
+        script = _run('echo "hi"')
+        assert 'echo \\"hi\\"' in script
+
+    def test_no_cwd_runs_command_directly(self) -> None:
+        script = _run("claude /usage")
+        assert 'do script "claude /usage"' in script
+        assert "quoted form of" not in script
+        assert "activate" in script


### PR DESCRIPTION
## Summary

Resume checked that the CWD's most-recent JSONL exists — a sibling's file passed or failed the check regardless of the target session's state. And the open-Terminal-and-run AppleScript was copy-pasted five times using `do script … in front window`, the stored-window-reference pattern that races the window opening (same failure family as #234). Findings 4-5 of the pattern audit.

## Changes

- resume validates `resolve_jsonl(cwd, session_id)` — the session's own file
- one `open_terminal_and_run(command, cwd="")` helper in session_actions: `activate` + bare `do script` (opens a new window, no stored refs), cwd through `escape_applescript` + `quoted form of`; all five sites converted, UUID validation preserved at call sites
- menubar's no-cwd resume branch was dead code and is subsumed

## Test plan

- [x] ruff + import audit clean
- [x] full suite passing post-rebase
- [x] helper tests assert no `front window`/`open -a`/`delay`, escaping survives injection payloads; resume-validation tests cover sibling-file-present/own-file-gone