### PR TITLE
chore: encode session-identity and applescript invariants in rules + smoke checks

### DIFF
--- a/.claude/rules/macos.md
+++ b/.claude/rules/macos.md
@@ -18,3 +18,7 @@ paths:
 - Pair `NSImage.lockFocus()` with `unlockFocus()` in try/finally.
 - Thread-safety: use `threading.Event` or similar guards when background threads update UI objects that may be deallocated (e.g. modal text fields).
 - Check `AXIsProcessTrusted()` on launch and show a menu item if permission is missing.
+- **AppleScript: one action per script.** Never chain find/raise/activate steps in a single script — a thrown step silently kills everything after it. Activate first in its own call; treat window matching as best-effort.
+- **Iterating Terminal windows requires a per-window `try`** — ghost windows throw on any property access. Prefer addressing by `window id`, which skips ghosts entirely.
+- **Inline reference chains only** (`contents of tab i of window id W`). Reading properties off a stored tab/window variable fails to dereference.
+- **No positional or stored window refs** (`front window`, saved references) after opening a window. Use `ui/session_actions.open_terminal_and_run` for open-Terminal-and-run flows; it uses a bare `do script`, which opens its own window.

--- a/.claude/rules/sessions.md
+++ b/.claude/rules/sessions.md
@@ -1,0 +1,18 @@
+## Session Identity
+
+- Any data or UI surface describing a single session is keyed by `session_id`, never by `cwd` alone — many sessions share one cwd. Resolve a session's JSONL with `SessionLogService.resolve_jsonl(cwd, session_id)`: with a session_id it returns that exact file or None. Never substitute a sibling's file on None for a per-session surface.
+- `find_most_recent(cwd)` is only for genuinely per-project surfaces and for legacy entries with an empty session_id.
+- UI action payloads carry `session_id|cwd`; parse with a bare-cwd fallback for legacy rows. Stores dedupe and remove by session_id, matching entries without one by cwd (see the bookmark and history repositories for the pattern).
+
+## Session ↔ JSONL Pairing (detection)
+
+- Title match first: a session whose window title contains a known aiTitle owns that file.
+- Unmatched sessions pair with the newest UNCLAIMED file either created after the process started or modified after it (resumed sessions append to files born earlier). Each file pairs with at most one session per poll.
+- Unpaired sessions display plainly (no borrowed title or session_id) and default to IDLE.
+- Absence of evidence is idle: no heuristic may return WORKING or ATTENTION from missing, empty, or unreadable input. Title indicators override JSONL-derived status in both directions.
+
+## Claude Code CLI Contract
+
+- Claude Code (observed at 2.1.170) does not write the assistant tool_use entry to the JSONL until the permission decision is made. JSONL alone cannot detect a waiting permission dialog — Terminal sessions read the visible screen instead (`_get_terminal_buffers` + `_buffer_prompt_line`). IDE-hosted sessions have no readable screen; their prompts are undetectable until the CLI writes something.
+- `backend/core/session_log/schema.py` is the only place JSONL discriminator strings appear; all code uses its enums. Tests may write literal JSONL fixtures.
+- Run `uv run python scripts/live_smoke.py --pty` before tagging a release. The unit suite mocks every system boundary and cannot detect the outside world drifting; the smoke script fails on drift (dialog wording, tool_use deferral, ghost windows, buffer readability).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Path-scoped rules in `.claude/rules/` — only loaded when touching relevant fil
 | `architecture.md` | `backend/**`, `ui/**` | Import rules, DTOs, threading |
 | `testing.md` | `tests/**`, `backend/**` | Coverage, mocking, fixtures |
 | `macos.md` | `ui/**`, detection, notifications | AppKit patterns, PyObjC, window focus |
+| `sessions.md` | `backend/**`, `ui/**` | Session identity keying, JSONL pairing, CLI contract |
 | `packaging.md` | `pyproject.toml`, icons, release workflow | Briefcase builds, Homebrew tap |
 | `dependencies.md` | `pyproject.toml`, `uv.lock` | Dependency policy, ARM compat, `uv` usage |
 | `ci.md` | `.github/**`, `pyproject.toml` | Actions pinning, release process |

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -34,6 +34,7 @@ import claudewatch.backend.detection.service as detection_service
 from claudewatch.backend.core.process.service import ProcessService
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.detection.service import DetectionService
+from claudewatch.backend.history.service import HistoryService
 
 _PASS = 0
 _FAIL = 0
@@ -68,13 +69,24 @@ def _strip_ansi(text: str) -> str:
 def check_detection() -> list:
     """detect() against live processes: sessions found, identities distinct."""
     detection_service.run_applescript = _osascript
-    svc = DetectionService(ProcessService(), SessionLogService())
+    session_log = SessionLogService()
+    svc = DetectionService(ProcessService(), session_log)
     sessions = svc.detect()
 
     _report(len(sessions) > 0, "detection finds live sessions", f"{len(sessions)} found")
     sids = [s.session_id for s in sessions if s.session_id]
     dupes = len(sids) - len(set(sids))
     _report(dupes == 0, "session identities are distinct", f"{dupes} duplicated" if dupes else "")
+
+    mismatched = [
+        s.pid
+        for s in sessions
+        if s.session_id
+        and not (session_log.resolve_jsonl(s.cwd, s.session_id) or "").endswith(f"/{s.session_id}.jsonl")
+    ]
+    _report(
+        not mismatched, "session ids resolve to their own logs", f"mismatched pids: {mismatched}" if mismatched else ""
+    )
 
     terminal = [s for s in sessions if s.host_app.value == "Terminal"]
     titled = [s for s in terminal if s.window_id]
@@ -100,6 +112,24 @@ def check_detection() -> list:
     for s in attention:
         print(f"      note: ATTENTION on pid {s.pid}: {s.prompt_text[:60]}")
     return sessions
+
+
+def check_history() -> None:
+    """History integrity: per-session records with no duplicate session ids.
+
+    Judged only on entries whose logs still exist — legacy pre-migration rows
+    whose logs are gone are cleanup candidates (the pane's Clear-stale button),
+    not integrity failures.
+    """
+    history = HistoryService()
+    entries = history.get_all()
+    live = [e for e in entries if e.session_id and history.logs_exist(e.cwd, e.session_id)]
+    sids = [e.session_id for e in live]
+    dupes = len(sids) - len(set(sids))
+    stale = len(entries) - len(live)
+    _report(
+        dupes == 0, "history records are per-session", f"{len(entries)} entries ({stale} stale), {dupes} duplicate ids"
+    )
 
 
 def _jsonl_has_tool_use(proj_dir: str) -> bool:
@@ -212,6 +242,7 @@ def check_pty_probe() -> None:
 def main() -> int:
     print("== ClaudeWatch live smoke checks ==")
     check_detection()
+    check_history()
     if "--pty" in sys.argv:
         check_pty_probe()
     else:


### PR DESCRIPTION
## Summary

Phase 2 of the pattern audit: write the invariants the last two weeks taught us into the path-scoped rules (so they're enforced on every future change) and into the live smoke script (so drift fails loudly).

## Changes

- `.claude/rules/sessions.md` (new): session-identity keying, resolve_jsonl semantics, payload convention, JSONL pairing invariants, absence-of-evidence-is-idle, the CLI tool_use-deferral contract, schema.py as the only literal source, pre-release smoke requirement
- `.claude/rules/macos.md`: one-action-per-script, per-window try, inline reference chains, no stored/positional window refs
- `live_smoke.py`: sessions resolve to their own logs; history is per-session with no duplicate ids (judged on entries whose logs exist — legacy rows are noted as stale, not failed)

## Test plan

- [x] ruff clean; full suite 919 passed
- [x] live smoke 6/6 — the new history check caught (and correctly classified) a legacy April duplicate from the repo-move era