### PR TITLE
fix: bound summary skip cache and untrack gone sessions

### DIFF
--- a/claudewatch/backend/summary/service.py
+++ b/claudewatch/backend/summary/service.py
@@ -26,6 +26,7 @@ log = logging.getLogger("claudewatch")
 _REFRESH_INTERVAL = 60  # seconds between background refresh cycles
 _MAX_TITLE_LEN = 30
 _TAIL_BYTES = 200000
+_NO_RECAP_MAX = 512  # prune the no-recap skip cache past this size
 
 
 def _truncate_title(title: str) -> str:
@@ -96,6 +97,14 @@ class SummaryService(BaseService):
     @staticmethod
     def _cache_key(cwd: str, session_id: str = "") -> str:
         return SummaryRepository.cache_key(cwd, session_id)
+
+    @staticmethod
+    def _split_key(key: str) -> tuple[str, str]:
+        """Invert _cache_key: return (cwd, session_id)."""
+        if "::" in key:
+            cwd, sid = key.split("::", 1)
+            return cwd, sid
+        return key, ""
 
     # -- Cache access -------------------------------------------------------
 
@@ -190,6 +199,8 @@ class SummaryService(BaseService):
 
         path = self._session_log_service.resolve_jsonl(cwd, session_id)
         if not path:
+            # Session's JSONL is gone — stop the background loop rescanning it.
+            self._untrack_key(key)
             return ""
 
         # Skip if we already checked and found no recap, and the JSONL hasn't changed.
@@ -213,12 +224,29 @@ class SummaryService(BaseService):
                 return title
             with self._no_recap_lock:
                 self._no_recap_mtimes[key] = current_mtime
+                over_cap = len(self._no_recap_mtimes) > _NO_RECAP_MAX
+            if over_cap:
+                self._prune_no_recap_cache()
             return ""
 
         title = _truncate_title(self._extract_ai_title(path) or recap)
         self.cache_full(cwd, title, recap, session_id)
         log.debug("summarize: cached recap for %s", os.path.basename(cwd))
         return title
+
+    def _prune_no_recap_cache(self) -> None:
+        """Drop skip-cache entries whose JSONL is gone; clear all if still over cap.
+
+        Losing entries only costs a re-scan, never correctness.
+        """
+        with self._no_recap_lock:
+            keys = list(self._no_recap_mtimes)
+        dead = [key for key in keys if self._session_log_service.resolve_jsonl(*self._split_key(key)) is None]
+        with self._no_recap_lock:
+            for key in dead:
+                self._no_recap_mtimes.pop(key, None)
+            if len(self._no_recap_mtimes) > _NO_RECAP_MAX:
+                self._no_recap_mtimes.clear()
 
     # -- Background refresh -------------------------------------------------
 
@@ -242,10 +270,13 @@ class SummaryService(BaseService):
         with self._priority_lock:
             return len(self._priority_queue)
 
-    def untrack_session(self, cwd: str) -> None:
-        """Stop refreshing summaries for a CWD."""
+    def untrack_session(self, cwd: str, session_id: str = "") -> None:
+        """Stop refreshing summaries for a session."""
+        self._untrack_key(self._cache_key(cwd, session_id))
+
+    def _untrack_key(self, key: str) -> None:
         with self._tracked_lock:
-            self._tracked_cwds.discard(cwd)
+            self._tracked_cwds.discard(key)
 
     def _ensure_bg_thread(self) -> None:
         if self._bg_thread is not None and self._bg_thread.is_alive():
@@ -272,10 +303,7 @@ class SummaryService(BaseService):
                 with self._tracked_lock:
                     keys = list(self._tracked_cwds)
                 for key in keys:
-                    if "::" in key:
-                        cwd, sid = key.split("::", 1)
-                    else:
-                        cwd, sid = key, ""
+                    cwd, sid = self._split_key(key)
                     if self.get_cached(cwd, sid) is None:
                         log.debug("bg_refresh: re-extracting for %s", cwd)
                         self.generate_and_cache(cwd, sid)

--- a/tests/summary/test_summary_service.py
+++ b/tests/summary/test_summary_service.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from claudewatch.backend.core.session_log.service import SessionLogService
 from claudewatch.backend.summary.models import SummaryEntry
 from claudewatch.backend.summary.service import (
+    _NO_RECAP_MAX,
     SummaryService,
     _find_last_ai_title,
     _find_last_recap,
@@ -492,3 +493,81 @@ class TestInvalidateCache:
         svc._no_recap_mtimes["/test"] = 123.0
         svc.invalidate_cache("/test")
         assert "/test" not in svc._no_recap_mtimes
+
+
+def _write_no_recap_jsonl(tmp_path, dir_name: str) -> str:
+    """Create a projects/<dir_name>/s.jsonl with no recap or title; return its path."""
+    proj_dir = tmp_path / "projects" / dir_name
+    proj_dir.mkdir(parents=True)
+    path = proj_dir / "s.jsonl"
+    _write_jsonl(path, [{"type": "user", "message": {"content": "hi"}, "timestamp": ""}])
+    return str(path)
+
+
+class TestNoRecapBound:
+    def test_insert_past_cap_drops_dead_entries(self, tmp_path):
+        svc = _make_service(tmp_path)
+        _write_no_recap_jsonl(tmp_path, "-live")
+        half = _NO_RECAP_MAX // 2
+        svc._no_recap_mtimes = {f"/gone-{i}": 1.0 for i in range(half)}
+        svc._no_recap_mtimes.update({f"/gone-s{i}::sid-{i}": 1.0 for i in range(half)})
+
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            svc.generate_and_cache("/live")
+        assert svc._no_recap_mtimes.keys() == {"/live"}
+
+    def test_insert_past_cap_clears_all_when_still_over(self, tmp_path):
+        svc = _make_service(tmp_path)
+        path = _write_no_recap_jsonl(tmp_path, "-live")
+        svc._no_recap_mtimes = {f"/alive-{i}": 1.0 for i in range(_NO_RECAP_MAX)}
+
+        with patch.object(svc._session_log_service, "resolve_jsonl", return_value=path):
+            svc.generate_and_cache("/live")
+        assert svc._no_recap_mtimes == {}
+
+    def test_insert_under_cap_keeps_existing_entries(self, tmp_path):
+        svc = _make_service(tmp_path)
+        _write_no_recap_jsonl(tmp_path, "-live")
+        svc._no_recap_mtimes = {f"/gone-{i}": 1.0 for i in range(10)}
+
+        with patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")):
+            svc.generate_and_cache("/live")
+        assert len(svc._no_recap_mtimes) == 11
+
+
+class TestUntrackOnGoneFile:
+    def test_generate_and_cache_untracks_gone_session(self, tmp_path):
+        svc = _make_service(tmp_path)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch.object(svc, "_ensure_bg_thread"),
+        ):
+            svc.track_session("/gone", session_id="abc")
+            assert "/gone::abc" in svc._tracked_cwds
+            assert svc.generate_and_cache("/gone", "abc") == ""
+        assert "/gone::abc" not in svc._tracked_cwds
+
+    def test_generate_and_cache_untracks_gone_bare_cwd(self, tmp_path):
+        svc = _make_service(tmp_path)
+        with (
+            patch("claudewatch.backend.core.session_log.jsonl.CLAUDE_PROJECTS_DIR", str(tmp_path / "projects")),
+            patch.object(svc, "_ensure_bg_thread"),
+        ):
+            svc.track_session("/gone")
+            assert "/gone" in svc._tracked_cwds
+            assert svc.generate_and_cache("/gone") == ""
+        assert "/gone" not in svc._tracked_cwds
+
+
+class TestUntrackSession:
+    def test_untrack_with_session_id_removes_cache_key(self, tmp_path):
+        svc = _make_service(tmp_path)
+        svc._tracked_cwds = {"/cwd::sid", "/cwd"}
+        svc.untrack_session("/cwd", session_id="sid")
+        assert svc._tracked_cwds == {"/cwd"}
+
+    def test_untrack_without_session_id_removes_bare_key(self, tmp_path):
+        svc = _make_service(tmp_path)
+        svc._tracked_cwds = {"/cwd::sid", "/cwd"}
+        svc.untrack_session("/cwd")
+        assert svc._tracked_cwds == {"/cwd::sid"}


### PR DESCRIPTION
## Summary

Phase 3 of the pattern audit: two unbounded growths in the summary domain — `_no_recap_mtimes` grew forever, and the background refresh loop rescanned dead sessions every 60s indefinitely (the sessions pane now tracks historical entries).

## Changes

- `_no_recap_mtimes` bounded at 512: over-cap insert prunes entries whose JSONL is gone (file resolution outside the lock), clears entirely if still over — it's a skip-optimization, never correctness
- `generate_and_cache` untracks sessions whose file is gone; `untrack_session` fixed to discard the proper cache_key (with session_id) instead of raw cwd
- `_split_key` inverse helper, reused in the bg loop

## Test plan

- [x] ruff clean; 942 passed (7 new)