### PR TITLE
fix: skip ide tab switching cleanly when no window title matches the project

### DIFF
--- a/claudewatch/ui/focus.py
+++ b/claudewatch/ui/focus.py
@@ -17,6 +17,12 @@ from claudewatch.backend.core.models import ClaudeSession, HostApp
 
 log = logging.getLogger("claudewatch")
 
+# UI settle time between focus steps — load-bearing, do not remove.
+_UI_SETTLE_SECONDS = 0.3
+# Sentinel returned by tab-switching scripts when no window title matches the
+# project (diff viewers, detached editors) — expected, not an error.
+_NO_WINDOW = "no-window"
+
 
 def _click_at(x: float, y: float) -> None:
     """Click at screen coordinates using CGEvent (works for PyCharm tabs)."""
@@ -28,7 +34,12 @@ def _click_at(x: float, y: float) -> None:
 
 
 def _focus_ide_tab(process_name: str, project: str, tab_index: int | None) -> None:
-    """Focus an IDE window and switch to the right terminal tab."""
+    """Focus an IDE window and switch to the right terminal tab.
+
+    Contract: app activation is guaranteed; window raise and tab switch are
+    best-effort and silently skipped when window titles don't expose the
+    project (diff viewers, detached editors).
+    """
     if not is_accessibility_trusted():
         log.warning("focus: skipping System Events — Accessibility permission not granted")
         return
@@ -53,14 +64,18 @@ def _focus_ide_tab(process_name: str, project: str, tab_index: int | None) -> No
     ''')
     # Step 2: If we know the tab index, click the terminal tab via AX position
     if tab_index is not None:
-        time.sleep(0.3)
+        time.sleep(_UI_SETTLE_SECONDS)
         # Ensure terminal panel is open (Option+F12 for JetBrains, Ctrl+` for VS Code)
         if "pycharm" in process_name.lower() or "idea" in process_name.lower():
             # Check if terminal panel is already visible before toggling
             check = run_applescript(f'''
                 tell application "System Events"
                     tell process "{escape_applescript(process_name)}"
-                        set w to first window whose name contains "{escape_applescript(project)}"
+                        try
+                            set w to first window whose name contains "{escape_applescript(project)}"
+                        on error
+                            return "{_NO_WINDOW}"
+                        end try
                         set rootPane to first UI element of w whose role is "AXGroup"
                         set panels to every UI element of rootPane whose role is "AXGroup"
                         repeat with p in panels
@@ -75,20 +90,26 @@ def _focus_ide_tab(process_name: str, project: str, tab_index: int | None) -> No
                     end tell
                 end tell
             ''')
+            if check.strip() == _NO_WINDOW:
+                return
             if check.strip() == "hidden":
                 run_applescript("""
                     tell application "System Events"
                         key code 111 using {option down}
                     end tell
                 """)
-                time.sleep(0.3)
+                time.sleep(_UI_SETTLE_SECONDS)
         # Get terminal tab positions from AX tree
         # For JetBrains IDEs, the terminal tool window description is like "Local (N) Tool Window"
         # and contains AXStaticText tabs named "Terminal", "Local (2)", etc.
         result = run_applescript(f'''
             tell application "System Events"
                 tell process "{escape_applescript(process_name)}"
-                    set w to first window whose name contains "{escape_applescript(project)}"
+                    try
+                        set w to first window whose name contains "{escape_applescript(project)}"
+                    on error
+                        return "{_NO_WINDOW}"
+                    end try
                     set rootPane to first UI element of w whose role is "AXGroup"
                     set panels to every UI element of rootPane whose role is "AXGroup"
                     set output to ""
@@ -120,6 +141,8 @@ def _focus_ide_tab(process_name: str, project: str, tab_index: int | None) -> No
                 end tell
             end tell
         ''')
+        if result.strip() == _NO_WINDOW:
+            return
         if result:
             tabs = []
             _tab_fields = 4

--- a/tests/ui/test_focus.py
+++ b/tests/ui/test_focus.py
@@ -59,6 +59,57 @@ class TestFocusIdeTabAccessibilityGuard:
         assert any("AXRaise" in s and "try" in s for s in scripts[1:])
 
 
+class TestFocusIdeTabNoWindowSentinel:
+    """Tab switching skips cleanly when no window title exposes the project."""
+
+    def test_panel_check_sentinel_skips_tab_click_path(self) -> None:
+        """JetBrains path: sentinel from the panel check stops before the
+        panel toggle and the tab-position enumeration."""
+        with (
+            patch(f"{_MOD}.is_accessibility_trusted", return_value=True),
+            patch(f"{_MOD}.run_applescript", side_effect=["", "", "no-window"]) as mock_run,
+            patch(f"{_MOD}._click_at") as mock_click,
+            patch(f"{_MOD}.time"),
+        ):
+            from claudewatch.ui.focus import _focus_ide_tab
+
+            _focus_ide_tab("pycharm", "myproject", 0)
+        assert mock_run.call_count == 3  # activate, raise, panel check — nothing after
+        mock_click.assert_not_called()
+
+    def test_enumeration_sentinel_skips_tab_click(self) -> None:
+        """VS Code path (no panel check): sentinel from the tab-position
+        enumeration skips the click."""
+        with (
+            patch(f"{_MOD}.is_accessibility_trusted", return_value=True),
+            patch(f"{_MOD}.run_applescript", side_effect=["", "", "no-window"]) as mock_run,
+            patch(f"{_MOD}._click_at") as mock_click,
+            patch(f"{_MOD}.time"),
+        ):
+            from claudewatch.ui.focus import _focus_ide_tab
+
+            _focus_ide_tab("Code", "myproject", 0)
+        assert mock_run.call_count == 3  # activate, raise, tab enumeration
+        mock_click.assert_not_called()
+
+    def test_window_lookups_are_try_guarded_in_scripts(self) -> None:
+        """Both tab-switching scripts guard the whose-clause with a try that
+        returns the sentinel instead of throwing."""
+        with (
+            patch(f"{_MOD}.is_accessibility_trusted", return_value=True),
+            patch(f"{_MOD}.run_applescript", return_value="") as mock_run,
+            patch(f"{_MOD}._click_at"),
+            patch(f"{_MOD}.time"),
+        ):
+            from claudewatch.ui.focus import _focus_ide_tab
+
+            _focus_ide_tab("pycharm", "myproject", 0)
+        scripts = [c.args[0] for c in mock_run.call_args_list]
+        lookups = [s for s in scripts if "whose name contains" in s and "rootPane" in s]
+        assert len(lookups) == 2  # panel check + tab enumeration
+        assert all('return "no-window"' in s for s in lookups)
+
+
 class TestFindJetbrainsProcessAccessibilityGuard:
     """_find_jetbrains_process returns default when Accessibility is not trusted."""
 


### PR DESCRIPTION
## Summary

Phase 3 of the pattern audit (finding 6): the IDE tab-switching scripts throw when no window title contains the project name (diff viewers, detached editors) — an expected condition that spammed warning-level AppleScript errors.

## Changes

- both tab-switching scripts return a `no-window` sentinel via AppleScript try instead of erroring; Python skips tab switching cleanly
- `_focus_ide_tab` contract documented: activation guaranteed, raise/tab-switch best-effort
- settle-time magic numbers named (`_UI_SETTLE_SECONDS`)

## Test plan

- [x] ruff clean; 938 passed (3 new sentinel-path tests)